### PR TITLE
Support applying a layout to a block within a template

### DIFF
--- a/lib/action_view/component/base.rb
+++ b/lib/action_view/component/base.rb
@@ -69,7 +69,7 @@ module ActionView
       def initialize(*); end
 
       def render(options = {}, args = {}, &block)
-        if options.is_a?(String) || (options.is_a?(Hash) && options.has_key?(:partial))
+        if options.is_a?(String) || (options.is_a?(Hash) && (options.has_key?(:partial) || options.has_key?(:layout)))
           view_context.render(options, args, &block)
         else
           super

--- a/test/action_view/integration_test.rb
+++ b/test/action_view/integration_test.rb
@@ -71,6 +71,17 @@ class IntegrationTest < ActionDispatch::IntegrationTest
     HTML
   end
 
+  test "rendering component with a layout" do
+    get "/layout"
+    assert_response :success
+    assert_html_matches <<~HTML, response.body
+      layout:<div>hello,layout world!</div>
+
+      component:<div>hello,layout world!</div>
+      <div>hello,layout world!</div>
+    HTML
+  end
+
   test "rendering component with deprecated syntax" do
     get "/deprecated"
     assert_response :success

--- a/test/action_view/integration_test.rb
+++ b/test/action_view/integration_test.rb
@@ -75,10 +75,9 @@ class IntegrationTest < ActionDispatch::IntegrationTest
     get "/layout"
     assert_response :success
     assert_html_matches <<~HTML, response.body
-      layout:<div>hello,layout world!</div>
+      <div class="layout">hello from layout caller block</div>
 
-      component:<div>hello,layout world!</div>
-      <div>hello,layout world!</div>
+      <div class="layout">hello from layout caller block</div>
     HTML
   end
 

--- a/test/app/components/layout_component.html.erb
+++ b/test/app/components/layout_component.html.erb
@@ -1,0 +1,6 @@
+<%= render layout: "test_layout" do %>
+  <%= content %>
+<% end %>
+<%= render "test_layout" do %>
+  <%= content %>
+<% end %>

--- a/test/app/components/layout_component.rb
+++ b/test/app/components/layout_component.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class LayoutComponent < ActionView::Component::Base
+  def initialize(*); end
+end

--- a/test/app/views/integration_examples/_test_layout.html.erb
+++ b/test/app/views/integration_examples/_test_layout.html.erb
@@ -1,1 +1,1 @@
-<div>hello,layout world!</div>
+<div class="layout"><%= yield %></div>

--- a/test/app/views/integration_examples/_test_layout.html.erb
+++ b/test/app/views/integration_examples/_test_layout.html.erb
@@ -1,0 +1,1 @@
+<div>hello,layout world!</div>

--- a/test/app/views/integration_examples/layout.html.erb
+++ b/test/app/views/integration_examples/layout.html.erb
@@ -1,0 +1,2 @@
+layout:<%= render partial: "test_layout" %>
+component:<%= render LayoutComponent %>

--- a/test/app/views/integration_examples/layout.html.erb
+++ b/test/app/views/integration_examples/layout.html.erb
@@ -1,2 +1,3 @@
-layout:<%= render partial: "test_layout" %>
-component:<%= render LayoutComponent %>
+<%= render LayoutComponent do %>
+  <div>hello from layout caller block</div>
+<% end %>

--- a/test/config/routes.rb
+++ b/test/config/routes.rb
@@ -6,6 +6,7 @@ Dummy::Application.routes.draw do
   get :component, to: "integration_examples#component"
   get :content_areas, to: "integration_examples#content_areas"
   get :partial, to: "integration_examples#partial"
+  get :layout, to: "integration_examples#layout"
   get :content, to: "integration_examples#content"
   get :variants, to: "integration_examples#variants"
   get :cached, to: "integration_examples#cached"


### PR DESCRIPTION
`ActionView::PartialRenderer` supports applying a layout to a block within a template using syntax like:

```ruby
<%= render(layout: "administrator", locals: { user: chief }) do %>
  Title: <%= chief.title %>
<% end %>
```

This currently raises an exception when used in a component template, eg:

```
ActionView::Template::Error: undefined method `_app_views_integration_examples__test_layout_html_erb__2545028457847958506_70198999886460' for #<LayoutComponent:0x00007fb1057557e8>
    app/views/integration_examples/layout.html.erb:2
    test/action_view/integration_test.rb:75:in `block in <class:IntegrationTest>'

```

This change includes a failing test, and adds support for rendering partials with the `layout:` option.