### PR TITLE
Allow to access params in preview examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # master
 
+* Add the ability to access params from preview examples.
+
+    *Fabio Cantoni*
+
 # v2.4.0
 
 * Add `#render_to_string` support.

--- a/README.md
+++ b/README.md
@@ -521,6 +521,19 @@ Which generates <http://localhost:3000/rails/view_components/test_component/with
 <http://localhost:3000/rails/view_components/test_component/with_long_title>,
 and <http://localhost:3000/rails/view_components/test_component/with_content_block>.
 
+It's also possible to set dynamic values from the params by setting them as arguments:
+
+`test/components/previews/test_component_preview.rb`
+```ruby
+class TestComponentPreview < ViewComponent::Preview
+  def with_dynamic_title(title: "Test component default")
+    render(TestComponent.new(title: title))
+  end
+end
+```
+
+You'll then be able to pass down a value with <http://localhost:3000/rails/components/test_component/with_dynamic_title?title=Custom+title>.
+
 The `ViewComponent::Preview` base class includes
 [`ActionView::Helpers::TagHelper`][tag-helper], which provides the [`tag`][tag]
 and [`content_tag`][content_tag] view helper methods.
@@ -648,10 +661,10 @@ Bug reports and pull requests are welcome on GitHub at https://github.com/github
 |@blakewilliams|@seanpdoyle|@tclem|@nashby|@jaredcwhite|
 |Boston, MA|New York, NY|San Francisco, CA|Minsk|Portland, OR|
 
-|<img src="https://avatars.githubusercontent.com/simonrand?s=256" alt="simonrand" width="128" />|<img src="https://avatars.githubusercontent.com/fugufish?s=256" alt="fugufish" width="128" />|
-|:---:|:---:|
-|@simonrand|@fugufish|
-|Dublin, Ireland|Salt Lake City, Utah|
+|<img src="https://avatars.githubusercontent.com/simonrand?s=256" alt="simonrand" width="128" />|<img src="https://avatars.githubusercontent.com/fugufish?s=256" alt="fugufish" width="128" />|<img src="https://avatars.githubusercontent.com/cover?s=256" alt="cover" width="128" />|
+|:---:|:---:|:---:|
+|@simonrand|@fugufish|@cover|
+|Dublin, Ireland|Salt Lake City, Utah|Barcelona|
 
 ## License
 

--- a/app/controllers/rails/view_components_controller.rb
+++ b/app/controllers/rails/view_components_controller.rb
@@ -30,7 +30,7 @@ class Rails::ViewComponentsController < Rails::ApplicationController # :nodoc:
     else
       prepend_application_view_paths
       @example_name = File.basename(params[:path])
-      @render_args = @preview.render_args(@example_name)
+      @render_args = @preview.render_args(@example_name, params: params.permit!)
       layout = @render_args[:layout]
       opts = layout.nil? ? {} : { layout: layout }
       # rubocop:disable GitHub/RailsControllerRenderPathsExist

--- a/lib/view_component/preview.rb
+++ b/lib/view_component/preview.rb
@@ -19,8 +19,11 @@ module ViewComponent # :nodoc:
       end
 
       # Returns the arguments for rendering of the component in its layout
-      def render_args(example)
-        new.public_send(example).merge(layout: @layout)
+      def render_args(example, params: {})
+        example_params_names = instance_method(example).parameters.map(&:last)
+        provided_params = params.slice(*example_params_names).to_h.symbolize_keys
+        result = provided_params.empty? ? new.public_send(example) : new.public_send(example, **provided_params)
+        result.merge(layout: @layout)
       end
 
       # Returns the component object class associated to the preview.

--- a/test/test/components/previews/preview_component_preview.rb
+++ b/test/test/components/previews/preview_component_preview.rb
@@ -16,4 +16,8 @@ class PreviewComponentPreview < ViewComponent::Preview
   def with_tag_helper_in_content
     render(PreviewComponent.new(title: "title")) { content_tag(:span, "some content") }
   end
+
+  def with_params(cta: "Default CTA", title: "Default title")
+    render(PreviewComponent.new(cta: cta, title: title))
+  end
 end

--- a/test/view_component/integration_test.rb
+++ b/test/view_component/integration_test.rb
@@ -153,6 +153,14 @@ class IntegrationTest < ActionDispatch::IntegrationTest
     assert_includes response.body, "Click me!"
   end
 
+  test "renders preview component default preview ignoring params" do
+    get "/rails/view_components/preview_component/default?cta=CTA+from+params"
+
+    assert_includes response.body, "Click me!"
+
+    refute_includes response.body, "CTA from params"
+  end
+
   test "renders preview component with_cta preview" do
     get "/rails/view_components/preview_component/without_cta"
 
@@ -169,6 +177,36 @@ class IntegrationTest < ActionDispatch::IntegrationTest
     get "/rails/view_components/preview_component/with_tag_helper_in_content"
 
     assert_includes response.body, "<span>some content</span>"
+  end
+
+  test "renders preview component with params preview with default values" do
+    get "/rails/view_components/preview_component/with_params"
+
+    assert_includes response.body, "Default CTA"
+    assert_includes response.body, "Default title"
+  end
+
+  test "renders preview component with params preview with one param" do
+    get "/rails/view_components/preview_component/with_params?cta=CTA+from+params"
+
+    assert_includes response.body, "CTA from params"
+    assert_includes response.body, "Default title"
+  end
+
+  test "renders preview component with params preview with multiple params" do
+    get "/rails/view_components/preview_component/with_params?cta=CTA+from+params&title=Title+from+params"
+
+    assert_includes response.body, "CTA from params"
+    assert_includes response.body, "Title from params"
+  end
+
+  test "renders preview component with params preview ignoring unsupported params" do
+    get "/rails/view_components/preview_component/with_params?cta=CTA+from+params&label=Label+from+params"
+
+    assert_includes response.body, "CTA from params"
+    assert_includes response.body, "Default title"
+
+    refute_includes response.body, "Label from params"
   end
 
   test "renders badge component open preview" do


### PR DESCRIPTION
### Summary

This is helpful when you want to show dynamic values on the component preview.

One use case is integrating [Storybook](https://storybook.js.org/) and the [Knobs addon](https://github.com/storybookjs/storybook/tree/master/addons/knobs), which allows to tweak the values directly from the component's page.

We can take those values and pass them down as params to the Rails preview page, which will then be used to set the values on the component.

### Other Information

I've been briefly playing with the repo from #159 and adding this would allow us to have something like:

![Screenshot_20200228_115618](https://user-images.githubusercontent.com/76693/75543293-c0020580-5a21-11ea-868e-d266743a4503.png)