### PR TITLE
Fix rendering of components that utilize `capture` in a parent view context

### DIFF
--- a/lib/view_component/action_view_compatibility.rb
+++ b/lib/view_component/action_view_compatibility.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+module ViewComponent
+  module ActionViewCompatibility
+    extend ActiveSupport::Concern
+
+    def form_for(*args, **kwags, &block)
+      with_compatible_capture do
+        super
+      end
+    end
+
+    def form_with(*args, **kwargs, &block)
+      with_compatible_capture do
+        super
+      end
+    end
+
+    included do
+      alias_method :original_capture, :capture
+      alias_method :capture, :capture_with_compatibility
+    end
+
+    def with_compatible_capture(&block)
+      old_compatible_capture = defined?(@compatible_capture) ? @compatible_capture : false
+      @compatible_capture = true
+      yield
+    ensure
+      @compatible_capture = old_compatible_capture
+    end
+
+    def capture_with_compatibility(*args, &block)
+      if defined?(@compatible_capture) && @compatible_capture
+        receiver_aware_capture(*args, &block)
+      else
+        original_capture(*args, &block)
+      end
+    end
+
+    def receiver_aware_capture(*args, &block)
+      receiver = block.binding.receiver
+
+      if receiver != self && receiver.respond_to?(:output_buffer=)
+        if receiver.respond_to?(:original_capture)
+          receiver.original_capture(*args, &block)
+        else
+          receiver.capture(*args, &block)
+        end
+      else
+        original_capture(*args, &block)
+      end
+    end
+  end
+end

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -7,6 +7,7 @@ require "view_component/compile_cache"
 require "view_component/previewable"
 require "view_component/slotable"
 require "view_component/slotable_v2"
+require "view_component/action_view_compatibility"
 
 module ViewComponent
   class Base < ActionView::Base

--- a/test/app/components/form_for_component.html.erb
+++ b/test/app/components/form_for_component.html.erb
@@ -1,0 +1,3 @@
+<%= form_for Post.new, url: "/" do |form| %>
+  <%= render LabelComponent.new(form: form) %>
+<% end %>

--- a/test/app/components/form_for_component.rb
+++ b/test/app/components/form_for_component.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class FormForComponent < ViewComponent::Base
+  include ViewComponent::ActionViewCompatibility
+
+  def initialize
+  end
+end

--- a/test/app/components/form_with_component.html.erb
+++ b/test/app/components/form_with_component.html.erb
@@ -1,0 +1,3 @@
+<%= form_with Post.new, url: "/" do |form| %>
+  <%= render LabelComponent.new(form: form) %>
+<% end %>

--- a/test/app/components/form_with_component.rb
+++ b/test/app/components/form_with_component.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class FormWithComponent < ViewComponent::Base
+  include ViewComponent::ActionViewCompatibility
+
+  def initialize
+  end
+end

--- a/test/app/components/incompatible_form_component.html.erb
+++ b/test/app/components/incompatible_form_component.html.erb
@@ -1,0 +1,3 @@
+<%= form_for Post.new, url: "/" do |form| %>
+  <%= render LabelComponent.new(form: form) %>
+<% end %>

--- a/test/app/components/incompatible_form_component.rb
+++ b/test/app/components/incompatible_form_component.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class IncompatibleFormComponent < ViewComponent::Base
+  def initialize
+  end
+end

--- a/test/app/components/label_component.html.erb
+++ b/test/app/components/label_component.html.erb
@@ -1,0 +1,5 @@
+<div>
+  <%= form.label :published do %>
+    <%= form.check_box :published %>
+  <% end %>
+</div>

--- a/test/app/components/label_component.rb
+++ b/test/app/components/label_component.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+#
+class LabelComponent < ViewComponent::Base
+  def initialize(form:)
+    @form = form
+  end
+
+  private
+
+  attr_reader :form
+end

--- a/test/app/models/post.rb
+++ b/test/app/models/post.rb
@@ -3,5 +3,5 @@
 class Post
   include ActiveModel::Model
 
-  attr_accessor :title
+  attr_accessor :title, :published
 end

--- a/test/view_component/action_view_compatibility_test.rb
+++ b/test/view_component/action_view_compatibility_test.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ViewComponent::ActionViewCompatibilityTest < ViewComponent::TestCase
+  def test_renders_form_for_labels_with_block_correctly
+    render_inline(FormForComponent.new)
+
+    assert_selector("form > div > label > input")
+    refute_selector("form > div > input")
+  end
+
+  def test_renders_form_with_labels_with_block_correctly
+    render_inline(FormForComponent.new)
+
+    assert_selector("form > div > label > input")
+    refute_selector("form > div > input")
+  end
+
+  def test_form_without_compatability_does_not_raise
+    render_inline(IncompatibleFormComponent.new)
+
+    # Bad selector should be present, at least until fixed upstream or included by default
+    assert_selector("form > div > input")
+  end
+end

--- a/test/view_component/view_component_test.rb
+++ b/test/view_component/view_component_test.rb
@@ -423,7 +423,6 @@ class ViewComponentTest < ViewComponent::TestCase
     assert_equal "Validation failed: Content can't be blank", exception.message
   end
 
-  # TODO: Remove in v3.0.0
   def test_before_render_check
     exception = assert_raises ActiveModel::ValidationError do
       render_inline(OldValidationsComponent.new)


### PR DESCRIPTION
In Rails, when you create a form it saves a reference to the current
template object that is rendering the form. When you render a form
builder helper method, like `form.label` inside of a child component the
template object will be the original template object from where the form
builder was instantiated.

This means in cases where we pass a block to a form builder helper the
`@output_buffer` is the parent component's output buffer. So when that
buffer is overridden via `.capture` it's setting the parent component's
`@output_buffer` to a new, temporary buffer but it doesn't change the
child component that is actually rendering's `@output_buffer`. This
means the block is executed in the context of the child components
actual `@output_buffer` and immediately writes to the buffer. Since
`capture` had nothing written to the temporary buffer, it returns the
value of the block call and then inserts that into the parent
component's `@output_buffer`.

This adds a new module, ActionViewCompatibility which can be included in
a component to ensure that any `capture` calls coming from that
component will be called in the correct context. This is helpful when
using helper methods like `form_for`.