### PR TITLE
use new repo name

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -1,4 +1,4 @@
-<!-- See https://github.com/github/actionview-component/blob/master/CONTRIBUTING.md#submitting-a-pull-request  -->
+<!-- See https://github.com/github/view-component/blob/master/CONTRIBUTING.md#submitting-a-pull-request  -->
 
 ### Summary
 

--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -1,4 +1,4 @@
-<!-- See https://github.com/github/view-component/blob/master/CONTRIBUTING.md#submitting-a-pull-request  -->
+<!-- See https://github.com/github/view_component/blob/master/CONTRIBUTING.md#submitting-a-pull-request  -->
 
 ### Summary
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contributing
 
-[fork]: https://github.com/github/view-component/fork
-[pr]: https://github.com/github/view-component/compare
+[fork]: https://github.com/github/view_component/fork
+[pr]: https://github.com/github/view_component/compare
 [style]: https://github.com/styleguide/ruby
 [code-of-conduct]: CODE_OF_CONDUCT.md
 
@@ -38,9 +38,9 @@ If you are the current maintainer of this gem:
 1. Add version heading/entries to `CHANGELOG.md`.
 1. Make sure your local dependencies are up to date: `bundle`
 1. Ensure that tests are green: `bundle exec rake`
-1. Make a PR to github/view-component.
+1. Make a PR to github/view_component.
 1. Build a local gem: `gem build actionview-component.gemspec`
-1. Merge github/view-component PR
+1. Merge github/view_component PR
 1. Tag and push: `git tag vx.xx.xx; git push --tags`
-1. Create a GitHub release with the pushed tag (https://github.com/github/view-component/releases/new) and populate it with a list of the commits from `git log --pretty=format:"- %s" --reverse refs/tags/[OLD TAG]...refs/tags/[NEW TAG]`
+1. Create a GitHub release with the pushed tag (https://github.com/github/view_component/releases/new) and populate it with a list of the commits from `git log --pretty=format:"- %s" --reverse refs/tags/[OLD TAG]...refs/tags/[NEW TAG]`
 1. Push to rubygems.org -- `gem push actionview-component-VERSION.gem`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contributing
 
-[fork]: https://github.com/github/actionview-component/fork
-[pr]: https://github.com/github/actionview-component/compare
+[fork]: https://github.com/github/view-component/fork
+[pr]: https://github.com/github/view-component/compare
 [style]: https://github.com/styleguide/ruby
 [code-of-conduct]: CODE_OF_CONDUCT.md
 
@@ -38,9 +38,9 @@ If you are the current maintainer of this gem:
 1. Add version heading/entries to `CHANGELOG.md`.
 1. Make sure your local dependencies are up to date: `bundle`
 1. Ensure that tests are green: `bundle exec rake`
-1. Make a PR to github/actionview-component.
+1. Make a PR to github/view-component.
 1. Build a local gem: `gem build actionview-component.gemspec`
-1. Merge github/actionview-component PR
+1. Merge github/view-component PR
 1. Tag and push: `git tag vx.xx.xx; git push --tags`
-1. Create a GitHub release with the pushed tag (https://github.com/github/actionview-component/releases/new) and populate it with a list of the commits from `git log --pretty=format:"- %s" --reverse refs/tags/[OLD TAG]...refs/tags/[NEW TAG]`
+1. Create a GitHub release with the pushed tag (https://github.com/github/view-component/releases/new) and populate it with a list of the commits from `git log --pretty=format:"- %s" --reverse refs/tags/[OLD TAG]...refs/tags/[NEW TAG]`
 1. Push to rubygems.org -- `gem push actionview-component-VERSION.gem`

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # ViewComponent
 A view component framework for Rails.
 
-**Current Status**: Used in production at GitHub. Because of this, all changes will be thoroughly vetted, which could slow down the process of contributing. We will do our best to actively communicate status of pull requests with any contributors. If you have any substantial changes that you would like to make, it would be great to first [open an issue](http://github.com/github/view-component/issues/new) to discuss them with us.
+**Current Status**: Used in production at GitHub. Because of this, all changes will be thoroughly vetted, which could slow down the process of contributing. We will do our best to actively communicate status of pull requests with any contributors. If you have any substantial changes that you would like to make, it would be great to first [open an issue](http://github.com/github/view_component/issues/new) to discuss them with us.
 
 ## Migration in progress
 
-This gem is in the process of a name / API change from `ActionView::Component` to `ViewComponent`, see https://github.com/github/view-component/issues/206.
+This gem is in the process of a name / API change from `ActionView::Component` to `ViewComponent`, see https://github.com/github/view_component/issues/206.
 
 ### What's changing in the migration
 
@@ -527,7 +527,7 @@ Inline templates have been removed (for now) due to concerns raised by [@soutaro
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/github/view-component. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct. We recommend reading the [contributing guide](./CONTRIBUTING.md) as well.
+Bug reports and pull requests are welcome on GitHub at https://github.com/github/view_component. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct. We recommend reading the [contributing guide](./CONTRIBUTING.md) as well.
 
 ## Contributors
 

--- a/actionview-component.gemspec
+++ b/actionview-component.gemspec
@@ -9,11 +9,11 @@ Gem::Specification.new do |spec|
   spec.name          = "actionview-component"
   spec.version       = ViewComponent::VERSION::STRING
   spec.authors       = ["GitHub Open Source"]
-  spec.email         = ["opensource+actionview-component@github.com"]
+  spec.email         = ["opensource+view-component@github.com"]
 
   spec.summary       = %q{View components for Rails}
-  spec.description   = %q{View components for Rails, intended for upstreaming in Rails 6.1}
-  spec.homepage      = "https://github.com/github/actionview-component"
+  spec.description   = %q{View components for Rails}
+  spec.homepage      = "https://github.com/github/view-component"
   spec.license       = "MIT"
 
   # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'

--- a/actionview-component.gemspec
+++ b/actionview-component.gemspec
@@ -9,11 +9,11 @@ Gem::Specification.new do |spec|
   spec.name          = "actionview-component"
   spec.version       = ViewComponent::VERSION::STRING
   spec.authors       = ["GitHub Open Source"]
-  spec.email         = ["opensource+view-component@github.com"]
+  spec.email         = ["opensource+view_component@github.com"]
 
   spec.summary       = %q{View components for Rails}
   spec.description   = %q{View components for Rails}
-  spec.homepage      = "https://github.com/github/view-component"
+  spec.homepage      = "https://github.com/github/view_component"
   spec.license       = "MIT"
 
   # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'


### PR DESCRIPTION
This PR updates some comments to reference our new repository name, `github/view-component` 🎊 