### PR TITLE
[WIP] Use ActionView::ViewPaths to manage views with ViewComponent

### DIFF
--- a/lib/view_component.rb
+++ b/lib/view_component.rb
@@ -12,8 +12,9 @@ module ViewComponent
   autoload :TestHelpers
   autoload :TestCase
   autoload :RenderMonkeyPatch
+  autoload :Rendering
   autoload :RenderingMonkeyPatch
-  autoload :TemplateError
+  autoload :ViewPaths
 end
 
 module ActionView

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -151,7 +151,11 @@ module ViewComponent
             # Require `#initialize` to be defined so that we can use `method#source_location`
             # to look up the filename of the component.
             initialize_method = instance_method(:initialize)
-            initialize_method.source_location[0] if initialize_method.owner == self
+            if initialize_method.owner == self
+              initialize_method.source_location[0]
+            else
+              instance_methods(false).map { |m| instance_method(m).source_location[0] }.first
+            end
           end
       end
 

--- a/lib/view_component/rendering.rb
+++ b/lib/view_component/rendering.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module ViewComponent
+  module Rendering
+    extend ActiveSupport::Concern
+    include ViewComponent::ViewPaths
+  end
+end

--- a/lib/view_component/template_error.rb
+++ b/lib/view_component/template_error.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-module ViewComponent
-  class TemplateError < StandardError
-    def initialize(errors)
-      super(errors.join(", "))
-    end
-  end
-end

--- a/lib/view_component/view_paths.rb
+++ b/lib/view_component/view_paths.rb
@@ -1,0 +1,136 @@
+# frozen_string_literal: true
+
+# TODO: extend ActionView::ViewPaths to extend only necessary code.
+# And be sure we store our view_paths inside the same @all_view_paths
+# object.
+module ViewComponent
+  module ViewPaths
+    extend ActiveSupport::Concern
+
+    included do
+      ViewPaths.set_view_paths(self, ActionView::PathSet.new.freeze)
+    end
+
+    delegate :template_exists?, :any_templates?, :view_paths, :formats, :formats=,
+             :locale, :locale=, to: :lookup_context
+
+    module ClassMethods
+      def _view_paths
+        ViewPaths.get_view_paths(self)
+      end
+
+      def _view_paths=(paths)
+        ViewPaths.set_view_paths(self, paths)
+      end
+
+      def _prefixes # :nodoc:
+        @_prefixes ||= begin
+          return local_prefixes if superclass.abstract?
+
+          local_prefixes + superclass._prefixes
+        end
+      end
+
+      private
+
+        # Override this method in your controller if you want to change paths prefixes for finding views.
+        # Prefixes defined here will still be added to parents' <tt>._prefixes</tt>.
+        def local_prefixes
+          [component_path]
+        end
+    end
+
+    # :stopdoc:
+    @all_view_paths = {}
+
+    def self.get_view_paths(klass)
+      @all_view_paths[klass] || get_view_paths(klass.superclass)
+    end
+
+    def self.set_view_paths(klass, paths)
+      @all_view_paths[klass] = paths
+    end
+
+    def self.all_view_paths
+      @all_view_paths.values.uniq
+    end
+    # :startdoc:
+
+    def self.debug_all_view_paths
+      @all_view_paths
+    end
+
+    # The prefixes used in render "foo" shortcuts.
+    def _prefixes # :nodoc:
+      self.class._prefixes
+    end
+
+    # <tt>LookupContext</tt> is the object responsible for holding all
+    # information required for looking up templates, i.e. view paths and
+    # details. Check <tt>ActionView::LookupContext</tt> for more information.
+    def lookup_context
+      @_lookup_context ||=
+        ActionView::LookupContext.new(self.class._view_paths, details_for_lookup, _prefixes)
+    end
+
+    def details_for_lookup
+      {}
+    end
+
+    # Append a path to the list of view paths for the current <tt>LookupContext</tt>.
+    #
+    # ==== Parameters
+    # * <tt>path</tt> - If a String is provided, it gets converted into
+    #   the default view path. You may also provide a custom view path
+    #   (see ActionView::PathSet for more information)
+    def append_view_path(path)
+      lookup_context.view_paths.push(*path)
+    end
+
+    # Prepend a path to the list of view paths for the current <tt>LookupContext</tt>.
+    #
+    # ==== Parameters
+    # * <tt>path</tt> - If a String is provided, it gets converted into
+    #   the default view path. You may also provide a custom view path
+    #   (see ActionView::PathSet for more information)
+    def prepend_view_path(path)
+      lookup_context.view_paths.unshift(*path)
+    end
+
+    module ClassMethods
+      # Append a path to the list of view paths for this controller.
+      #
+      # ==== Parameters
+      # * <tt>path</tt> - If a String is provided, it gets converted into
+      #   the default view path. You may also provide a custom view path
+      #   (see ActionView::PathSet for more information)
+      def append_view_path(path)
+        self._view_paths = view_paths + Array(path)
+      end
+
+      # Prepend a path to the list of view paths for this controller.
+      #
+      # ==== Parameters
+      # * <tt>path</tt> - If a String is provided, it gets converted into
+      #   the default view path. You may also provide a custom view path
+      #   (see ActionView::PathSet for more information)
+      def prepend_view_path(path)
+        self._view_paths = ActionView::PathSet.new(Array(path) + view_paths)
+      end
+
+      # A list of all of the default view paths for this controller.
+      def view_paths
+        _view_paths
+      end
+
+      # Set the view paths.
+      #
+      # ==== Parameters
+      # * <tt>paths</tt> - If a PathSet is provided, use that;
+      #   otherwise, process the parameter into a PathSet.
+      def view_paths=(paths)
+        self._view_paths = ActionView::PathSet.new(Array(paths))
+      end
+    end
+  end
+end

--- a/test/app/components/action_view_component.rb
+++ b/test/app/components/action_view_component.rb
@@ -2,6 +2,4 @@
 
 class ActionViewComponent < ActionView::Component::Base
   validates :content, presence: true
-
-  def initialize(*); end
 end

--- a/test/app/components/another_component.rb
+++ b/test/app/components/another_component.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
 
 class AnotherComponent < ViewComponent::Base
-  def initialize(*); end
 end

--- a/test/app/components/asset_component.rb
+++ b/test/app/components/asset_component.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
 
 class AssetComponent < ViewComponent::Base
-  def initialize(*); end
 end

--- a/test/app/components/button_to_component.rb
+++ b/test/app/components/button_to_component.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
 
 class ButtonToComponent < ViewComponent::Base
-  def initialize(*); end
 end

--- a/test/app/components/content_for_component.rb
+++ b/test/app/components/content_for_component.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
 
 class ContentForComponent < ViewComponent::Base
-  def initialize(*); end
 end

--- a/test/app/components/editorb_component.rb
+++ b/test/app/components/editorb_component.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
 
 class EditorbComponent < ViewComponent::Base
-  def initialize(*); end
 end

--- a/test/app/components/helpers_proxy_component.rb
+++ b/test/app/components/helpers_proxy_component.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
 
 class HelpersProxyComponent < ViewComponent::Base
-  def initialize(*); end
 end

--- a/test/app/components/my_component.rb
+++ b/test/app/components/my_component.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
 
 class MyComponent < ViewComponent::Base
-  def initialize(*); end
 end

--- a/test/app/components/no_format_component.rb
+++ b/test/app/components/no_format_component.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
 
 class NoFormatComponent < ViewComponent::Base
-  def initialize(*); end
 end

--- a/test/app/components/no_validations_component.rb
+++ b/test/app/components/no_validations_component.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class NoValidationsComponent < ViewComponent::Base
-  def initialize(*); end
-
   def before_render_check
     #noop
   end

--- a/test/app/components/partial_component.rb
+++ b/test/app/components/partial_component.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
 
 class PartialComponent < ViewComponent::Base
-  def initialize(*); end
 end

--- a/test/app/components/render_check_component.rb
+++ b/test/app/components/render_check_component.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class RenderCheckComponent < ViewComponent::Base
-  def initialize(*); end
-
   def render?
     !view_context.cookies[:shown]
   end

--- a/test/app/components/request_component.rb
+++ b/test/app/components/request_component.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
 
 class RequestComponent < ViewComponent::Base
-  def initialize(*); end
 end

--- a/test/app/components/validations_component.rb
+++ b/test/app/components/validations_component.rb
@@ -2,6 +2,4 @@
 
 class ValidationsComponent < ActionView::Component::Base
   validates :content, presence: true
-
-  def initialize(*); end
 end

--- a/test/app/components/wrapper_component.rb
+++ b/test/app/components/wrapper_component.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
 
 class WrapperComponent < ViewComponent::Base
-  def initialize(*); end
 end

--- a/test/config/application.rb
+++ b/test/config/application.rb
@@ -15,6 +15,8 @@ require "slim"
 module Dummy
   class Application < Rails::Application
     config.action_controller.asset_host = "http://assets.example.com"
+
+    ViewComponent::Base.append_view_path Rails.root.join("app/lib")
   end
 end
 

--- a/test/view_component/base_test.rb
+++ b/test/view_component/base_test.rb
@@ -14,15 +14,5 @@ class ViewComponent::Base::UnitTest < Minitest::Test
       {variant: :desktop, handler: "slim"},
       {variant: nil, handler: "haml"}
     ]
-
-    ViewComponent::Base.stub(:matching_views_in_source_location, file_path) do
-      templates = ViewComponent::Base.send(:templates)
-
-      templates.each_with_index do |template, index|
-        assert_equal(template[:path], file_path[index])
-        assert_equal(template[:variant], expected[index][:variant])
-        assert_equal(template[:handler], expected[index][:handler])
-      end
-    end
   end
 end

--- a/test/view_component/integration_test.rb
+++ b/test/view_component/integration_test.rb
@@ -156,12 +156,4 @@ class IntegrationTest < ActionDispatch::IntegrationTest
 
     assert_includes response.body, "Closed"
   end
-
-  test "compiles unreferenced component" do
-    assert UnreferencedComponent.compiled?
-  end
-
-  test "does not compile components without initializers" do
-    assert !MissingInitializerComponent.compiled?
-  end
 end

--- a/test/view_component/invalid_components_test.rb
+++ b/test/view_component/invalid_components_test.rb
@@ -1,32 +1,26 @@
 # frozen_string_literal: true
 
 class ActionView::InvalidComponentTest < ViewComponent::TestCase
-  def test_raises_error_when_initializer_is_not_defined
-    exception = assert_raises ViewComponent::TemplateError do
-      render_inline(MissingInitializerComponent.new)
-    end
-
-    assert_includes exception.message, "must implement #initialize"
-  end
-
   def test_raises_error_when_sidecar_template_is_missing
-    exception = assert_raises ViewComponent::TemplateError do
+    exception = assert_raises ActionView::MissingTemplate do
       render_inline(MissingTemplateComponent.new)
     end
 
-    assert_includes exception.message, "Could not find a template file for MissingTemplateComponent"
+    assert_includes exception.message, "Missing template /missing_template_component"
   end
 
+  # FIXME: this is manage by ActionView now
   def test_raises_error_when_more_than_one_sidecar_template_is_present
-    error = assert_raises ViewComponent::TemplateError do
+    error = assert_raises ActionView::MissingTemplate do
       render_inline(TooManySidecarFilesComponent.new)
     end
 
     assert_includes error.message, "More than one template found for TooManySidecarFilesComponent."
   end
 
+  # FIXME: this is manage by ActionView now
   def test_raises_error_when_more_than_one_sidecar_template_for_a_variant_is_present
-    error = assert_raises ViewComponent::TemplateError do
+    error = assert_raises ActionView::MissingTemplate do
       render_inline(TooManySidecarFilesForVariantComponent.new)
     end
 
@@ -34,7 +28,7 @@ class ActionView::InvalidComponentTest < ViewComponent::TestCase
   end
 
   def test_backtrace_returns_correct_file_and_line_number
-    error = assert_raises NameError do
+    error = assert_raises ActionView::Template::Error do
       render_inline(ExceptionInTemplateComponent.new)
     end
 


### PR DESCRIPTION
### Summary

This is a work in progress. I only try locally on an existing project for now.

This change attempt to make `#initialize` method optional in components (as discuss in https://github.com/github/view_component/issues/236#issuecomment-594642108) by switching rendering system on `ActionView::ViewPaths`.

### Notes
* Should we have a custom class for `ActionView::MissingTemplate` exception?
* `ViewComponent::ViewPaths` has implemented the scoped view_paths by class on Rails 6.0.0.
