### PR TITLE
bypass monkey patch on Rails 6.1 builds.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # master
 
+* Bypass monkey patch on Rails 6.1 builds.
+
+    *Joel Hawksley*
+
 # v1.14.1
 
 * Fix bug where generator created invalid test code.

--- a/lib/view_component/render_monkey_patch.rb
+++ b/lib/view_component/render_monkey_patch.rb
@@ -3,7 +3,7 @@
 module ViewComponent
   module RenderMonkeyPatch # :nodoc:
     def render(options = {}, args = {}, &block)
-      if options.respond_to?(:render_in)
+      if options.respond_to?(:render_in) && Rails.version.to_f < 6.1
         options.render_in(self, &block)
       elsif options.is_a?(Class) && options < ActionView::Component::Base
         ActiveSupport::Deprecation.warn(

--- a/lib/view_component/rendering_monkey_patch.rb
+++ b/lib/view_component/rendering_monkey_patch.rb
@@ -3,7 +3,7 @@
 module ViewComponent
   module RenderingMonkeyPatch # :nodoc:
     def render(options = {}, args = {})
-      if options.respond_to?(:render_in)
+      if options.respond_to?(:render_in) && Rails.version.to_f < 6.1
         self.response_body = options.render_in(self.view_context)
       else
         super


### PR DESCRIPTION
This change disables the monkey patch when the Rails version
is at least 6.1.

This change confirms the compatibility of the library with Rails 6.1.