### PR TITLE
Make `TagHelper` available in Previews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # master
 
+* Make `ActionView::Helpers::TagHelper` available in Previews
+
+    def with_html_content
+      render(MyComponent.new) do
+        tag.div do
+          content_tag(:span, "Hello")
+        end
+      end
+    end
+
+    *Sean Doyle*
+
 # v1.14.1
 
 * Fix bug where generator created invalid test code.

--- a/README.md
+++ b/README.md
@@ -291,11 +291,28 @@ class TestComponentPreview < ViewComponent::Preview
   def with_long_title
     render(TestComponent.new(title: "This is a really long title to see how the component renders this"))
   end
+
+  def with_content_block
+    render(TestComponent.new(title: "This component accepts a block of content") do
+      tag.div do
+        content_tag(:span, "Hello")
+      end
+    end
+  end
 end
 ```
 
-Which generates <http://localhost:3000/rails/components/test_component/with_default_title>
-and <http://localhost:3000/rails/components/test_component/with_long_title>.
+Which generates <http://localhost:3000/rails/components/test_component/with_default_title>,
+<http://localhost:3000/rails/components/test_component/with_long_title>,
+and <http://localhost:3000/rails/components/test_component/with_content_block>.
+
+The `ViewComponent::Preview` base class includes
+[`ActionView::Helpers::TagHelper`][tag-helper], which provides the [`tag`][tag]
+and [`content_tag`][content_tag] view helper methods.
+
+[tag-helper]: https://api.rubyonrails.org/classes/ActionView/Helpers/TagHelper.html
+[tag]: https://api.rubyonrails.org/classes/ActionView/Helpers/TagHelper.html#method-i-tag
+[content_tag]: https://api.rubyonrails.org/classes/ActionView/Helpers/TagHelper.html#method-i-content_tag
 
 Previews default to the application layout, but can be overridden:
 
@@ -412,6 +429,11 @@ Bug reports and pull requests are welcome on GitHub at https://github.com/github
 |:---:|
 |@blakewilliams|
 |Boston, MA|
+
+|<img src="https://avatars.githubusercontent.com/seanpdoyle?s=256" alt="seanpdoyle" width="128" />|
+|:---:|
+|@seanpdoyle|
+|New York, NY|
 
 ## License
 

--- a/lib/view_component/preview.rb
+++ b/lib/view_component/preview.rb
@@ -4,6 +4,7 @@ require "active_support/descendants_tracker"
 
 module ViewComponent # :nodoc:
   class Preview
+    include ActionView::Helpers::TagHelper
     extend ActiveSupport::DescendantsTracker
 
     def render(component, **args, &block)

--- a/test/test/components/previews/preview_component_preview.rb
+++ b/test/test/components/previews/preview_component_preview.rb
@@ -12,4 +12,8 @@ class PreviewComponentPreview < ViewComponent::Preview
   def with_content
     render(PreviewComponent.new(title: "title")) { "some content" }
   end
+
+  def with_tag_helper_in_content
+    render(PreviewComponent.new(title: "title")) { content_tag(:span, "some content") }
+  end
 end

--- a/test/view_component/integration_test.rb
+++ b/test/view_component/integration_test.rb
@@ -145,6 +145,12 @@ class IntegrationTest < ActionDispatch::IntegrationTest
     assert_includes response.body, "some content"
   end
 
+  test "renders preview component with tag helper-generated content preview" do
+    get "/rails/components/preview_component/with_tag_helper_in_content"
+
+    assert_includes response.body, "<span>some content</span>"
+  end
+
   test "renders badge component open preview" do
     get "/rails/components/issues/badge_component/open"
 


### PR DESCRIPTION
Make `ActionView::Helpers::TagHelper` available in
`ViewComponent::Previews`:

```ruby
def with_html_content
  render(MyComponent.new) do
    tag.div do
      content_tag(:span, "Hello")
    end
  end
end
````

This commit includes [`ActionView::Helpers::TagHelper`][tag-helper] into
`ViewComponent::Preview` base class, which provides the [`tag`][tag] and
[`content_tag`][content_tag] view helper methods.

[tag-helper]: https://api.rubyonrails.org/classes/ActionView/Helpers/TagHelper.html
[tag]: https://api.rubyonrails.org/classes/ActionView/Helpers/TagHelper.html#method-i-tag
[content_tag]: https://api.rubyonrails.org/classes/ActionView/Helpers/TagHelper.html#method-i-content_tag

<!-- See https://github.com/github/view_component/blob/master/CONTRIBUTING.md#submitting-a-pull-request  -->

### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file. -->
