### PR TITLE
re-introduce ActionView::Component::TestHelpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # master
 
+* Re-introduce ActionView::Component::TestHelpers
+
+    *Joel Hawksley*
+
 * Make `ActionView::Helpers::TagHelper` available in Previews
 
     def with_html_content

--- a/lib/action_view/component/test_case.rb
+++ b/lib/action_view/component/test_case.rb
@@ -2,7 +2,8 @@
 
 module ActionView
   module Component
-    class TestCase < ViewComponent::TestCase
+    class TestCase
+      include ActionView::Component::TestHelpers
     end
   end
 end

--- a/lib/action_view/component/test_helpers.rb
+++ b/lib/action_view/component/test_helpers.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module ActionView
+  module Component
+    module TestHelpers
+      include ViewComponent::TestHelpers
+
+      def render_component(component, **args, &block)
+        ActiveSupport::Deprecation.warn(
+          "`render_component` has been deprecated in favor of `render_inline`, and will be removed in v2.0.0."
+        )
+
+        render_inline(component, args, &block)
+      end
+    end
+  end
+end

--- a/lib/view_component.rb
+++ b/lib/view_component.rb
@@ -23,6 +23,7 @@ module ActionView
     autoload :Base
     autoload :Preview
     autoload :TestCase
+    autoload :TestHelpers
   end
 end
 

--- a/lib/view_component/test_helpers.rb
+++ b/lib/view_component/test_helpers.rb
@@ -24,14 +24,6 @@ module ViewComponent
       @request ||= ActionDispatch::TestRequest.create
     end
 
-    def render_component(component, **args, &block)
-      ActiveSupport::Deprecation.warn(
-        "`render_component` has been deprecated in favor of `render_inline`, and will be removed in v2.0.0."
-      )
-
-      render_inline(component, args, &block)
-    end
-
     def with_variant(variant)
       old_variants = controller.view_context.lookup_context.variants
 

--- a/test/view_component/action_view_component_test.rb
+++ b/test/view_component/action_view_component_test.rb
@@ -37,4 +37,10 @@ class ActionView::ComponentTest < ActionView::Component::TestCase
 
     assert_selector("span", text: "The Awesome post component!")
   end
+
+  def test_render_inline_with_old_helper
+    render_component(ActionViewComponent.new)
+
+    assert_selector("div", text: "hello,world!")
+  end
 end

--- a/test/view_component/view_component_test.rb
+++ b/test/view_component/view_component_test.rb
@@ -9,12 +9,6 @@ class ViewComponentTest < ViewComponent::TestCase
     assert_selector("div", text: "hello,world!")
   end
 
-  def test_render_inline_with_old_helper
-    render_component(MyComponent.new)
-
-    assert_selector("div", text: "hello,world!")
-  end
-
   def test_renders_content_from_block
     render_inline(WrapperComponent.new) do
       "content"


### PR DESCRIPTION
This module should not have been removed in #239, as doing so
was a breaking change.

This change re-introduces the module and moves render_component,
which will be removed in v2.0.0, to the module.

Thanks to @jcoyne for the report!

[fixes: #254]