### PR TITLE
Allow components to be rendered without a template file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # master
 
+# v1.16.0
+
+* Allow components to be rendered without a template file (aka inline component).
+
 # v1.15.0
 
 * Re-introduce ActionView::Component::TestHelpers.

--- a/README.md
+++ b/README.md
@@ -197,6 +197,24 @@ Which returns:
 </div>
 ```
 
+### Inline Component
+
+A component can be rendered without any template file as well.
+
+`app/components/inline_component.rb`:
+
+```ruby
+class InlineComponent < ViewComponent::Base
+  def call
+    if active?
+      link_to "Cancel integration", integration_path, method: :delete
+    else
+      link_to "Integrate now!", integration_path
+    end
+  end
+end
+```
+
 ### Conditional Rendering
 
 Components can implement a `#render?` method to determine if they should be rendered.

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -159,6 +159,10 @@ module ViewComponent
         @compiled && ActionView::Base.cache_template_loading
       end
 
+      def inlined?
+        instance_methods(false).grep(/^call/).present? && templates.empty?
+      end
+
       def compile!
         compile(raise_template_errors: true)
       end
@@ -167,7 +171,7 @@ module ViewComponent
       # We could in theory do this on app boot, at least in production environments.
       # Right now this just compiles the first time the component is rendered.
       def compile(raise_template_errors: false)
-        return if compiled?
+        return if compiled? || inlined?
 
         if template_errors.present?
           raise ViewComponent::TemplateError.new(template_errors) if raise_template_errors

--- a/test/app/components/inline_component.rb
+++ b/test/app/components/inline_component.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class InlineComponent < ViewComponent::Base
+  def initialize(*); end
+
+  def call
+    text_field_tag :name
+  end
+end

--- a/test/view_component/view_component_test.rb
+++ b/test/view_component/view_component_test.rb
@@ -17,6 +17,14 @@ class ViewComponentTest < ViewComponent::TestCase
     assert_selector("span", text: "content")
   end
 
+  def test_render_without_template
+    render_inline(InlineComponent.new)
+
+    assert_predicate InlineComponent, :inlined?
+    assert_not_predicate InlineComponent, :compiled?
+    assert_selector("input[type='text'][name='name']")
+  end
+
   def test_renders_slim_template
     render_inline(SlimComponent.new(message: "bar")) { "foo" }
 


### PR DESCRIPTION
### Summary

This is useful feature when it comes to create little widgets, toggle buttons, badges, and so on. It removes the need of an extra template file with one single line of code.
