### PR TITLE
Check for Rails before invocation

### DIFF
--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -132,7 +132,9 @@ module ViewComponent
 
     class << self
       def inherited(child)
-        child.include Rails.application.routes.url_helpers unless child < Rails.application.routes.url_helpers
+        if defined?(Rails) && child >= Rails.application.routes.url_helpers
+          child.include Rails.application.routes.url_helpers
+        end
 
         super
       end

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -132,8 +132,8 @@ module ViewComponent
 
     class << self
       def inherited(child)
-        if defined?(Rails) && child >= Rails.application.routes.url_helpers
-          child.include Rails.application.routes.url_helpers
+        if defined?(Rails)
+          child.include Rails.application.routes.url_helpers unless child < Rails.application.routes.url_helpers
         end
 
         super


### PR DESCRIPTION
This line breaks when this library is a dependency of a ruby gem (such as the case of building a third party component library)

<!-- See https://github.com/github/view_component/blob/master/CONTRIBUTING.md#submitting-a-pull-request  -->

### Summary

Refs #231 Support for this library as a dependency of third-party component libraries
