### PR TITLE
261 no render

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,13 @@
 
     *Joel Hawksley*
 
+* Check for Rails before invocation.
+
+    *Dave Paola*
+
 * Allow components to be rendered without a template file (aka inline component).
+
+    *Rainer Borene*
 
 # v1.15.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 # v1.16.0
 
+* Add `refute_component_rendered` test helper.
+
+    *Joel Hawksley*
+
 * Allow components to be rendered without a template file (aka inline component).
 
 # v1.15.0

--- a/README.md
+++ b/README.md
@@ -266,6 +266,8 @@ end
 <%= render(ConfirmEmailComponent.new(user: current_user)) %>
 ```
 
+To assert that a component has not been rendered, use `refute_component_rendered` from `ViewComponent::TestHelpers`.
+
 ### Testing
 
 Unit test components directly, using the `render_inline` test helper and Capybara matchers:

--- a/lib/view_component/test_helpers.rb
+++ b/lib/view_component/test_helpers.rb
@@ -11,7 +11,7 @@ module ViewComponent
     end
 
     def refute_component_rendered
-      assert_no_selector('body')
+      assert_no_selector("body")
     end
 
     def render_inline(component, **args, &block)

--- a/lib/view_component/test_helpers.rb
+++ b/lib/view_component/test_helpers.rb
@@ -10,6 +10,10 @@ module ViewComponent
       Capybara::Node::Simple.new(@raw)
     end
 
+    def refute_component_rendered
+      assert_no_selector('body')
+    end
+
     def render_inline(component, **args, &block)
       @raw = controller.view_context.render(component, args, &block)
 

--- a/test/view_component/view_component_test.rb
+++ b/test/view_component/view_component_test.rb
@@ -315,6 +315,7 @@ class ViewComponentTest < ViewComponent::TestCase
     render_inline(RenderCheckComponent.new)
 
     assert_no_text("Rendered")
+    refute_component_rendered
   end
 
   def test_assert_select


### PR DESCRIPTION
This PR introduces the `refute_component_rendered` test helper.

[Finishes: #261]
