### PR TITLE
ViewComponent generators should not have content validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # master
 
+* ViewComponent generators do not not prompt for content requirement.
+
+    *Joel Hawksley*
+
 # v1.16.0
 
 * Add `refute_component_rendered` test helper.

--- a/lib/rails/generators/component/component_generator.rb
+++ b/lib/rails/generators/component/component_generator.rb
@@ -8,8 +8,6 @@ module Rails
       argument :attributes, type: :array, default: [], banner: "attribute"
       check_class_collision suffix: "Component"
 
-      class_option :require_content, type: :boolean, default: false
-
       def create_component_file
         template "component.rb", File.join("app/components", class_path, "#{file_name}_component.rb")
       end
@@ -17,21 +15,13 @@ module Rails
       hook_for :test_framework
 
       hook_for :template_engine do |instance, template_engine|
-        instance.invoke template_engine, [instance.name], require_content: instance.send(:requires_content?)
+        instance.invoke template_engine, [instance.name]
       end
 
       private
 
       def file_name
         @_file_name ||= super.sub(/_component\z/i, "")
-      end
-
-      def requires_content?
-        return if behavior == :revoke
-        return @requires_content if @asked
-
-        @asked = true
-        @requires_content = ask("Would you like #{class_name} to require content? (Y/n)").downcase == "y"
       end
 
       def parent_class

--- a/lib/rails/generators/component/templates/component.rb.tt
+++ b/lib/rails/generators/component/templates/component.rb.tt
@@ -1,8 +1,4 @@
 class <%= class_name %>Component < <%= parent_class %>
-  <%- if requires_content? -%>
-  validates :content, presence: true
-  <%- end -%>
-
   def initialize(<%= initialize_signature %>)
     <%= initialize_body %>
   end

--- a/lib/rails/generators/erb/component_generator.rb
+++ b/lib/rails/generators/erb/component_generator.rb
@@ -7,17 +7,11 @@ module Erb
     class ComponentGenerator < Base
       source_root File.expand_path("templates", __dir__)
 
-      class_option :require_content, type: :boolean, default: false
-
       def copy_view_file
         template "component.html.erb", File.join("app/components", class_path, "#{file_name}_component.html.erb")
       end
 
       private
-
-      def requires_content?
-        options["require_content"]
-      end
 
       def file_name
         @_file_name ||= super.sub(/_component\z/i, "")

--- a/lib/rails/generators/erb/templates/component.html.erb.tt
+++ b/lib/rails/generators/erb/templates/component.html.erb.tt
@@ -1,5 +1,1 @@
-<%- if requires_content? -%>
-<%= "<%= content %%>" %>
-<%- else -%>
 <div>Add <%= class_name %> template here</div>
-<%- end -%>

--- a/lib/rails/generators/haml/component_generator.rb
+++ b/lib/rails/generators/haml/component_generator.rb
@@ -7,17 +7,11 @@ module Haml
     class ComponentGenerator < Erb::Generators::ComponentGenerator
       source_root File.expand_path("templates", __dir__)
 
-      class_option :require_content, type: :boolean, default: false
-
       def copy_view_file
         template "component.html.haml", File.join("app/components", class_path, "#{file_name}_component.html.haml")
       end
 
       private
-
-      def requires_content?
-        options["require_content"]
-      end
 
       def file_name
         @_file_name ||= super.sub(/_component\z/i, "")

--- a/lib/rails/generators/haml/templates/component.html.haml.tt
+++ b/lib/rails/generators/haml/templates/component.html.haml.tt
@@ -1,5 +1,1 @@
-<%- if requires_content? -%>
-<%= "= content" %>
-<%- else -%>
 %div Add <%= class_name %> template here
-<%- end -%>

--- a/lib/rails/generators/slim/component_generator.rb
+++ b/lib/rails/generators/slim/component_generator.rb
@@ -7,17 +7,11 @@ module Slim
     class ComponentGenerator < Erb::Generators::ComponentGenerator
       source_root File.expand_path("templates", __dir__)
 
-      class_option :require_content, type: :boolean, default: false
-
       def copy_view_file
         template "component.html.slim", File.join("app/components", class_path, "#{file_name}_component.html.slim")
       end
 
       private
-
-      def requires_content?
-        options["require_content"]
-      end
 
       def file_name
         @_file_name ||= super.sub(/_component\z/i, "")

--- a/lib/rails/generators/slim/templates/component.html.slim
+++ b/lib/rails/generators/slim/templates/component.html.slim
@@ -1,5 +1,0 @@
-<%- if requires_content? -%>
-= content
-<%- else -%>
-div Add <%= class_name %> template here
-<%- end -%>

--- a/lib/rails/generators/slim/templates/component.html.slim.tt
+++ b/lib/rails/generators/slim/templates/component.html.slim.tt
@@ -1,0 +1,1 @@
+div Add <%= class_name %> template here

--- a/lib/rails/generators/test_unit/templates/component_test.rb.tt
+++ b/lib/rails/generators/test_unit/templates/component_test.rb.tt
@@ -3,8 +3,8 @@ require "test_helper"
 class <%= class_name %>ComponentTest < ViewComponent::TestCase
   test "component renders something useful" do
     # assert_equal(
-    #   %(<span title="my title">Hello, components!</span>),
-    #   render_inline(<%= class_name %>Component.new(attr: "value")) { "Hello, components!" }.css("span").to_html
+    #   %(<span>Hello, components!</span>),
+    #   render_inline(<%= class_name %>Component.new(message: "Hello, components!")).css("span").to_html
     # )
   end
 end

--- a/test/generators/component_generator_test.rb
+++ b/test/generators/component_generator_test.rb
@@ -13,59 +13,35 @@ class ComponentGeneratorTest < Rails::Generators::TestCase
 
   arguments %w[user]
 
-  def test_component_with_required_content
-    with_required_content { run_generator }
+  def test_component
+    run_generator
 
     assert_file "app/components/user_component.rb" do |component|
       assert_match(/class UserComponent < /, component)
-      assert_match(/validates :content, presence: true/, component)
-    end
-  end
-
-  def test_component_without_required_content
-    without_required_content { run_generator }
-
-    assert_file "app/components/user_component.rb" do |component|
-      assert_match(/class UserComponent < /, component)
-      refute_match(/validates :content, presence: true/, component)
     end
   end
 
   def test_component_with_namespace
-    with_required_content { run_generator %w[admins/user] }
+    run_generator %w[admins/user]
 
     assert_file "app/components/admins/user_component.rb", /class Admins::UserComponent < /
   end
 
   def test_invoking_erb_template_engine
-    without_required_content { run_generator %w[user --template-engine erb] }
+    run_generator %w[user --template-engine erb]
 
     assert_file "app/components/user_component.html.erb"
   end
 
   def test_invoking_slim_template_engine
-    without_required_content { run_generator %w[user --template-engine slim] }
+    run_generator %w[user --template-engine slim]
 
     assert_file "app/components/user_component.html.slim"
   end
 
   def test_invoking_haml_template_engine
-    without_required_content { run_generator %w[user --template-engine haml] }
+    run_generator %w[user --template-engine haml]
 
     assert_file "app/components/user_component.html.haml"
-  end
-
-  private
-
-  def with_required_content
-    Thor::LineEditor.stub :readline, "Y" do
-      yield
-    end
-  end
-
-  def without_required_content
-    Thor::LineEditor.stub :readline, "n" do
-      yield
-    end
   end
 end

--- a/test/generators/erb_generator_test.rb
+++ b/test/generators/erb_generator_test.rb
@@ -13,15 +13,7 @@ class ErbGeneratorTest < Rails::Generators::TestCase
 
   arguments %w[user]
 
-  def test_component_with_required_content
-    run_generator %w[user --require-content]
-
-    assert_file "app/components/user_component.html.erb" do |view|
-      assert_match(/<%= content %>/, view)
-    end
-  end
-
-  def test_component_without_required_content
+  def test_component_generator
     run_generator
 
     assert_file "app/components/user_component.html.erb" do |view|

--- a/test/generators/haml_generator_test.rb
+++ b/test/generators/haml_generator_test.rb
@@ -13,15 +13,7 @@ class HamlGeneratorTest < Rails::Generators::TestCase
 
   arguments %w[user]
 
-  def test_component_with_required_content
-    run_generator %w[user --require-content]
-
-    assert_file "app/components/user_component.html.haml" do |view|
-      assert_match(/= content/, view)
-    end
-  end
-
-  def test_component_without_required_content
+  def test_component
     run_generator
 
     assert_file "app/components/user_component.html.haml" do |view|

--- a/test/generators/slim_generator_test.rb
+++ b/test/generators/slim_generator_test.rb
@@ -13,15 +13,7 @@ class SlimGeneratorTest < Rails::Generators::TestCase
 
   arguments %w[user]
 
-  def test_component_with_required_content
-    run_generator %w[user --require-content]
-
-    assert_file "app/components/user_component.html.slim" do |view|
-      assert_match(/= content/, view)
-    end
-  end
-
-  def test_component_without_required_content
+  def test_component
     run_generator
 
     assert_file "app/components/user_component.html.slim" do |view|

--- a/test/view_component/test_unit_generator_test.rb
+++ b/test/view_component/test_unit_generator_test.rb
@@ -17,7 +17,7 @@ class ViewComponent::TestUnitGeneratorTest < ::Rails::Generators::TestCase
 
   test "generates component" do
     assert_file "../tmp/test/components/dummy_component_test.rb" do |content|
-      assert_match(/render_inline\(DummyComponent.new\(attr: "value"\)\) { "Hello, components!" }.css\("span"\).to_html/, content)
+      assert_match(/render_inline\(DummyComponent.new\(message: "Hello, components!"\)\).css\("span"\).to_html/, content)
     end
   end
 end


### PR DESCRIPTION
This PR changes the component generators to not accept `requires_content`, as this option was creating components that use validations, something the library no longer supports out of the box.

cc @asgerb 