### PR TITLE
add post-install message about name change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
     *Joel Hawksley*
 
+* Add post-install message that gem has been renamed to `view_component`.
+
+    *Joel Hawksley*
+
 # v1.16.0
 
 * Add `refute_component_rendered` test helper.

--- a/actionview-component.gemspec
+++ b/actionview-component.gemspec
@@ -43,4 +43,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "better_html", "~> 1"
   spec.add_development_dependency "rubocop", "= 0.74"
   spec.add_development_dependency "rubocop-github", "~> 0.13.0"
+
+  spec.post_install_message = "actionview-component has been renamed to view_component, and will no longer be published in this namespace. Please update your Gemfile to use view_component."
 end


### PR DESCRIPTION
This PR sets in motion our migration to `view_component` 🎊 . I've already published `v1.16.0` under the new name. 

With this change, the next release will be the last to be made under `actionview-component`.