### PR TITLE
Support Ruby 2.4 in CI

### DIFF
--- a/.github/workflows/ruby_on_rails.yml
+++ b/.github/workflows/ruby_on_rails.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         rails_version: [5.0.0, 5.2.3, 6.0.0, master]
-        ruby_version: [2.5.x, 2.6.x, 2.7.x]
+        ruby_version: [2.4.x, 2.5.x, 2.6.x, 2.7.x]
         exclude:
           - rails_version: master
             ruby_version: 2.4.x
@@ -20,6 +20,10 @@ jobs:
       uses: actions/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby_version }}
+    - name: Update rubygems when testing with Ruby 2.4.x
+      if: startsWith(matrix.ruby_version, '2.4')
+      run: |
+        gem update --system --no-document
     - name: Build and test with Rake
       run: |
         gem install bundler:1.17.3

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ This library is designed to integrate as seamlessly as possible with Rails, with
 
 ## Compatibility
 
-`actionview-component` is tested for compatibility with combinations of Ruby `2.5`/`2.6`/`2.7` and Rails `5.0.0`/`5.2.3`/`6.0.0`/`master`.
+`actionview-component` is tested for compatibility with combinations of Ruby `2.4`/`2.5`/`2.6`/`2.7` and Rails `5.0.0`/`5.2.3`/`6.0.0`/`master`.
 
 ## Installation
 


### PR DESCRIPTION
<!-- See https://github.com/github/view_component/blob/master/CONTRIBUTING.md#submitting-a-pull-request  -->

### Summary

Fixes #209 

Update the `ruby_on_rails` action to re-add testing against Ruby 2.4.
To accomplish this, we need to run `gem update --system`, but we don't
want to do this on any version except `2.4.x` to save build time.

This commit uses the context and expression syntax for GitHub actions to
check if the Ruby versions starts with `2.4`, and update the system gems
in the event that we have a match. 