### PR TITLE
Removed validation on should_render test

### DIFF
--- a/test/app/components/conditional_render_component.rb
+++ b/test/app/components/conditional_render_component.rb
@@ -5,13 +5,7 @@ class ConditionalRenderComponent < ViewComponent::Base
     @should_render = should_render
   end
 
-  attr_reader :should_render
-
   def render?
-    unless [true, false].include?(should_render)
-      raise RuntimeError.new("should_render wasn't validated!")
-    end
-
-    should_render
+    @should_render
   end
 end

--- a/test/view_component/view_component_test.rb
+++ b/test/view_component/view_component_test.rb
@@ -298,11 +298,6 @@ class ViewComponentTest < ViewComponent::TestCase
     render_inline(ConditionalRenderComponent.new(should_render: false))
 
     assert_no_text("component was rendered")
-
-    exception = assert_raises RuntimeError do
-      render_inline(ConditionalRenderComponent.new(should_render: nil))
-    end
-    assert_equal exception.message, "should_render wasn't validated!"
   end
 
   def test_render_check


### PR DESCRIPTION
### Summary

This is a small PR that removes a component validation for at test since we are moving away from those. It also replaces the use of `attr_reader` in favor of the instance variable. 🎉 

