### PR TITLE
Remove initializer requirement.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # master
 
+* Remove initializer requirement from the component.
+
+    *Vasiliy Ermolovich*
+
 # v2.1.0
 
 * Support rendering collections (e.g., `render(MyComponent.with_collection(@items))`).

--- a/README.md
+++ b/README.md
@@ -496,7 +496,7 @@ Bug reports and pull requests are welcome on GitHub at https://github.com/github
 |<img src="https://avatars.githubusercontent.com/blakewilliams?s=256" alt="blakewilliams" width="128" />|<img src="https://avatars.githubusercontent.com/seanpdoyle?s=256" alt="seanpdoyle" width="128" />|<img src="https://avatars.githubusercontent.com/tclem?s=256" alt="tclem" width="128" />|<img src="https://avatars.githubusercontent.com/nashby?s=256" alt="nashby" width="128" />
 |:---:|:---:|:---:|
 |@blakewilliams|@seanpdoyle|@tclem|@nashby|
-|Boston, MA|New York, NY|San Francisco, CA|Minsk
+|Boston, MA|New York, NY|San Francisco, CA|Minsk|
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -494,7 +494,7 @@ Bug reports and pull requests are welcome on GitHub at https://github.com/github
 |Spring Hill, TN|Buenos Aires|São Paulo||Gambrills, MD|
 
 |<img src="https://avatars.githubusercontent.com/blakewilliams?s=256" alt="blakewilliams" width="128" />|<img src="https://avatars.githubusercontent.com/seanpdoyle?s=256" alt="seanpdoyle" width="128" />|<img src="https://avatars.githubusercontent.com/tclem?s=256" alt="tclem" width="128" />|<img src="https://avatars.githubusercontent.com/nashby?s=256" alt="nashby" width="128" />
-|:---:|:---:|:---:|
+|:---:|:---:|:---:|:---:|
 |@blakewilliams|@seanpdoyle|@tclem|@nashby|
 |Boston, MA|New York, NY|San Francisco, CA|Minsk|
 

--- a/README.md
+++ b/README.md
@@ -152,8 +152,6 @@ Which returns:
 <span title="my title">Hello, World!</span>
 ```
 
-`ViewComponent` requires the presence of an `initialize` method in each component.
-
 #### Content Areas
 
 A component can declare additional content areas to be rendered in the component. For example:
@@ -162,9 +160,6 @@ A component can declare additional content areas to be rendered in the component
 ```ruby
 class ModalComponent < ViewComponent::Base
   with_content_areas :header, :body
-
-  def initialize(*)
-  end
 end
 ```
 
@@ -498,10 +493,10 @@ Bug reports and pull requests are welcome on GitHub at https://github.com/github
 |@mellowfish|@horacio|@dukex|@dark-panda|@smashwilson|
 |Spring Hill, TN|Buenos Aires|São Paulo||Gambrills, MD|
 
-|<img src="https://avatars.githubusercontent.com/blakewilliams?s=256" alt="blakewilliams" width="128" />|<img src="https://avatars.githubusercontent.com/seanpdoyle?s=256" alt="seanpdoyle" width="128" />|<img src="https://avatars.githubusercontent.com/tclem?s=256" alt="tclem" width="128" />|
+|<img src="https://avatars.githubusercontent.com/blakewilliams?s=256" alt="blakewilliams" width="128" />|<img src="https://avatars.githubusercontent.com/seanpdoyle?s=256" alt="seanpdoyle" width="128" />|<img src="https://avatars.githubusercontent.com/tclem?s=256" alt="tclem" width="128" />|<img src="https://avatars.githubusercontent.com/nashby?s=256" alt="nashby" width="128" />
 |:---:|:---:|:---:|
-|@blakewilliams|@seanpdoyle|@tclem|
-|Boston, MA|New York, NY|San Francisco, CA|
+|@blakewilliams|@seanpdoyle|@tclem|@nashby|
+|Boston, MA|New York, NY|San Francisco, CA|Minsk
 
 ## License
 

--- a/lib/rails/generators/component/component_generator.rb
+++ b/lib/rails/generators/component/component_generator.rb
@@ -29,11 +29,9 @@ module Rails
       end
 
       def initialize_signature
-        if attributes.present?
-          attributes.map { |attr| "#{attr.name}:" }.join(", ")
-        else
-          "*"
-        end
+        return if attributes.blank?
+
+        attributes.map { |attr| "#{attr.name}:" }.join(", ")
       end
 
       def initialize_body

--- a/lib/rails/generators/component/templates/component.rb.tt
+++ b/lib/rails/generators/component/templates/component.rb.tt
@@ -1,5 +1,7 @@
 class <%= class_name %>Component < <%= parent_class %>
+<%- if initialize_signature -%>
   def initialize(<%= initialize_signature %>)
     <%= initialize_body %>
   end
+<%- end -%>
 end

--- a/test/app/components/another_component.rb
+++ b/test/app/components/another_component.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
 
 class AnotherComponent < ViewComponent::Base
-  def initialize(*); end
 end

--- a/test/app/components/asset_component.rb
+++ b/test/app/components/asset_component.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
 
 class AssetComponent < ViewComponent::Base
-  def initialize(*); end
 end

--- a/test/app/components/button_to_component.rb
+++ b/test/app/components/button_to_component.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
 
 class ButtonToComponent < ViewComponent::Base
-  def initialize(*); end
 end

--- a/test/app/components/content_for_component.rb
+++ b/test/app/components/content_for_component.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
 
 class ContentForComponent < ViewComponent::Base
-  def initialize(*); end
 end

--- a/test/app/components/css_sidecar_file_component.rb
+++ b/test/app/components/css_sidecar_file_component.rb
@@ -1,6 +1,4 @@
 # frozen_string_literal: true
 
 class CssSidecarFileComponent < ViewComponent::Base
-  def initialize(*)
-  end
 end

--- a/test/app/components/editorb_component.rb
+++ b/test/app/components/editorb_component.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
 
 class EditorbComponent < ViewComponent::Base
-  def initialize(*); end
 end

--- a/test/app/components/exception_in_template_component.rb
+++ b/test/app/components/exception_in_template_component.rb
@@ -1,6 +1,4 @@
 # frozen_string_literal: true
 
 class ExceptionInTemplateComponent < ViewComponent::Base
-  def initialize(*)
-  end
 end

--- a/test/app/components/helpers_proxy_component.rb
+++ b/test/app/components/helpers_proxy_component.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
 
 class HelpersProxyComponent < ViewComponent::Base
-  def initialize(*); end
 end

--- a/test/app/components/inline_component.rb
+++ b/test/app/components/inline_component.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class InlineComponent < ViewComponent::Base
-  def initialize(*); end
-
   def call
     text_field_tag :name
   end

--- a/test/app/components/missing_template_component.rb
+++ b/test/app/components/missing_template_component.rb
@@ -1,6 +1,4 @@
 # frozen_string_literal: true
 
 class MissingTemplateComponent < ViewComponent::Base
-  def initialize(*)
-  end
 end

--- a/test/app/components/my_component.rb
+++ b/test/app/components/my_component.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
 
 class MyComponent < ViewComponent::Base
-  def initialize(*); end
 end

--- a/test/app/components/no_format_component.rb
+++ b/test/app/components/no_format_component.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
 
 class NoFormatComponent < ViewComponent::Base
-  def initialize(*); end
 end

--- a/test/app/components/no_validations_component.rb
+++ b/test/app/components/no_validations_component.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class NoValidationsComponent < ViewComponent::Base
-  def initialize(*); end
-
   def before_render_check
     #noop
   end

--- a/test/app/components/partial_component.rb
+++ b/test/app/components/partial_component.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
 
 class PartialComponent < ViewComponent::Base
-  def initialize(*); end
 end

--- a/test/app/components/path_component.rb
+++ b/test/app/components/path_component.rb
@@ -1,6 +1,4 @@
 # frozen_string_literal: true
 
 class PathComponent < ViewComponent::Base
-  def initialize(*)
-  end
 end

--- a/test/app/components/path_container_component.rb
+++ b/test/app/components/path_container_component.rb
@@ -1,6 +1,4 @@
 # frozen_string_literal: true
 
 class PathContainerComponent < ViewComponent::Base
-  def initialize(*)
-  end
 end

--- a/test/app/components/render_check_component.rb
+++ b/test/app/components/render_check_component.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class RenderCheckComponent < ViewComponent::Base
-  def initialize(*); end
-
   def render?
     !view_context.cookies[:shown]
   end

--- a/test/app/components/request_component.rb
+++ b/test/app/components/request_component.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
 
 class RequestComponent < ViewComponent::Base
-  def initialize(*); end
 end

--- a/test/app/components/too_many_sidecar_files_component.rb
+++ b/test/app/components/too_many_sidecar_files_component.rb
@@ -1,6 +1,4 @@
 # frozen_string_literal: true
 
 class TooManySidecarFilesComponent < ViewComponent::Base
-  def initialize(*)
-  end
 end

--- a/test/app/components/too_many_sidecar_files_for_variant_component.rb
+++ b/test/app/components/too_many_sidecar_files_for_variant_component.rb
@@ -1,6 +1,4 @@
 # frozen_string_literal: true
 
 class TooManySidecarFilesForVariantComponent < ViewComponent::Base
-  def initialize(*)
-  end
 end

--- a/test/app/components/translations_component.rb
+++ b/test/app/components/translations_component.rb
@@ -1,6 +1,4 @@
 # frozen_string_literal: true
 
 class TranslationsComponent < ViewComponent::Base
-  def initialize(*)
-  end
 end

--- a/test/app/components/unreferenced_component.rb
+++ b/test/app/components/unreferenced_component.rb
@@ -1,6 +1,4 @@
 # frozen_string_literal: true
 
 class UnreferencedComponent < ViewComponent::Base
-  def initialize(*)
-  end
 end

--- a/test/app/components/url_component.rb
+++ b/test/app/components/url_component.rb
@@ -1,6 +1,4 @@
 # frozen_string_literal: true
 
 class UrlComponent < ViewComponent::Base
-  def initialize(*)
-  end
 end

--- a/test/app/components/validations_component.rb
+++ b/test/app/components/validations_component.rb
@@ -5,8 +5,6 @@ class ValidationsComponent < ViewComponent::Base
 
   validates :content, presence: true
 
-  def initialize(*); end
-
   def before_render_check
     validate!
   end

--- a/test/app/components/variants_component.rb
+++ b/test/app/components/variants_component.rb
@@ -1,6 +1,4 @@
 # frozen_string_literal: true
 
 class VariantsComponent < ViewComponent::Base
-  def initialize(*)
-  end
 end

--- a/test/app/components/wrapper_component.rb
+++ b/test/app/components/wrapper_component.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
 
 class WrapperComponent < ViewComponent::Base
-  def initialize(*); end
 end

--- a/test/generators/component_generator_test.rb
+++ b/test/generators/component_generator_test.rb
@@ -18,6 +18,16 @@ class ComponentGeneratorTest < Rails::Generators::TestCase
 
     assert_file "app/components/user_component.rb" do |component|
       assert_match(/class UserComponent < /, component)
+      assert_no_match(/def initialize/, component)
+    end
+  end
+
+  def test_component_with_arguments
+    run_generator %w[user name]
+
+    assert_file "app/components/user_component.rb" do |component|
+      assert_match(/class UserComponent < /, component)
+      assert_match(/def initialize\(name:\)/, component)
     end
   end
 

--- a/test/view_component/view_component_test.rb
+++ b/test/view_component/view_component_test.rb
@@ -337,16 +337,14 @@ class ViewComponentTest < ViewComponent::TestCase
     assert UnreferencedComponent.compiled?
   end
 
-  def test_does_not_compile_components_without_initializers
-    refute MissingInitializerComponent.compiled?
+  def test_compiles_components_without_initializers
+    assert MissingInitializerComponent.compiled?
   end
 
-  def test_raises_error_when_initializer_is_not_defined
-    exception = assert_raises ViewComponent::TemplateError do
-      render_inline(MissingInitializerComponent.new)
-    end
+  def test_renders_when_initializer_is_not_defined
+    render_inline(MissingInitializerComponent.new)
 
-    assert_includes exception.message, "must implement #initialize"
+    assert_selector("div", text: "Hello, world!")
   end
 
   def test_raises_error_when_sidecar_template_is_missing


### PR DESCRIPTION
Changes
- Use `Kernel#caller_locations` in `ViewComponent::Base::source_location` to get components location without requiring component to define `initialize` method.
- Remove initializer requirement from README