### PR TITLE
Add support for config.action_view.annotate_template_file_names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # master
 
+* Add support for `config.action_view.annotate_template_file_names` (coming in Rails 6.1).
+
+    *Joel Hawksley*
+
 # v2.1.0
 
 * Support rendering collections (e.g., `render(MyComponent.with_collection(@items))`).

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -283,7 +283,7 @@ module ViewComponent
 
         if handler.method(:call).parameters.length > 1
           handler.call(self, template)
-        else # remove before upstreaming into Rails
+        else
           handler.call(OpenStruct.new(source: template, identifier: identifier, type: type))
         end
       end

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -77,6 +77,10 @@ module ViewComponent
       true
     end
 
+    def self.short_identifier
+      @short_identifier ||= defined?(Rails.root) ? source_location.sub("#{Rails.root}/", "") : source_location
+    end
+
     def initialize(*); end
 
     def render(options = {}, args = {}, &block)

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -184,8 +184,20 @@ module ViewComponent
           return false
         end
 
+        # If template name annotations are turned on, a line is dynamically
+        # added with a comment. In this case, we want to return a different
+        # starting line number so errors that are raised will point to the
+        # correct line in the component template.
+        line_number =
+          if ActionView::Base.respond_to?(:annotate_template_file_names) &&
+            ActionView::Base.annotate_template_file_names
+            -2
+          else
+            -1
+          end
+
         templates.each do |template|
-          class_eval <<-RUBY, template[:path], -1
+          class_eval <<-RUBY, template[:path], line_number
             def #{call_method_name(template[:variant])}
               @output_buffer = ActionView::OutputBuffer.new
               #{compiled_template(template[:path])}

--- a/test/config/application.rb
+++ b/test/config/application.rb
@@ -7,7 +7,6 @@ require "action_controller/railtie"
 require "action_view/railtie"
 require "view_component/engine"
 require "sprockets/railtie"
-require "better_html"
 
 require "haml"
 require "slim"

--- a/test/config/environments/test.rb
+++ b/test/config/environments/test.rb
@@ -36,5 +36,7 @@ Dummy::Application.configure do
   # Print deprecation notices to the stderr
   config.active_support.deprecation = :stderr
 
+  config.action_view.annotate_template_file_names = true if Rails.version.to_f >= 6.1
+
   config.eager_load = true
 end

--- a/test/view_component/better_html_test.rb
+++ b/test/view_component/better_html_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "test_helper"
+require "better_html"
 require "better_html/test_helper/safe_erb_tester"
 
 # This test exists to ensure basic non-breaking compatiblity with Shopify/better_html

--- a/test/view_component/integration_test.rb
+++ b/test/view_component/integration_test.rb
@@ -12,16 +12,12 @@ class IntegrationTest < ActionDispatch::IntegrationTest
 
   if Rails.version.to_f >= 6.1
     test "rendering component with template annotations enabled" do
-      begin
-        ActionView::Base.annotate_template_file_names = true
+      get "/"
+      assert_response :success
 
-        get "/"
-        assert_response :success
+      assert_includes response.body, "BEGIN app/components/erb_component.rb"
 
-        assert_select("div", "Foo\n  bar")
-      ensure
-        ActionView::Base.annotate_template_file_names = false
-      end
+      assert_select("div", "Foo\n  bar")
     end
   end
 
@@ -39,7 +35,7 @@ class IntegrationTest < ActionDispatch::IntegrationTest
 
     inline_response = response.body
 
-    assert_equal baseline_response, inline_response
+    assert_includes inline_response, baseline_response
   end
 
   test "rendering component with content" do
@@ -63,8 +59,7 @@ class IntegrationTest < ActionDispatch::IntegrationTest
     get "/partial"
     assert_response :success
 
-    assert_includes response.body, "partial:<div>hello,partial world!"
-    assert_includes response.body, "component:<div>hello,partial world!"
+    assert_select("div", "hello,partial world!", count: 2)
   end
 
   test "rendering component without variant" do
@@ -126,7 +121,7 @@ class IntegrationTest < ActionDispatch::IntegrationTest
 
     get "/render_check"
     assert_response :success
-    assert_empty response.body.strip
+    refute_includes response.body, "Rendered"
   end
 
   test "renders component preview" do

--- a/test/view_component/integration_test.rb
+++ b/test/view_component/integration_test.rb
@@ -10,6 +10,21 @@ class IntegrationTest < ActionDispatch::IntegrationTest
     assert_select("div", "Foo\n  bar")
   end
 
+  if Rails.version.to_f >= 6.1
+    test "rendering component with template annotations enabled" do
+      begin
+        ActionView::Base.annotate_template_file_names = true
+
+        get "/"
+        assert_response :success
+
+        assert_select("div", "Foo\n  bar")
+      ensure
+        ActionView::Base.annotate_template_file_names = false
+      end
+    end
+  end
+
   test "rendering component in a controller" do
     get "/controller_inline_baseline"
 

--- a/test/view_component/view_component_test.rb
+++ b/test/view_component/view_component_test.rb
@@ -378,7 +378,7 @@ class ViewComponentTest < ViewComponent::TestCase
       render_inline(ExceptionInTemplateComponent.new)
     end
 
-    assert_match %r[app/components/exception_in_template_component\.html\.erb:3], error.backtrace[0]
+    assert_match %r[app/components/exception_in_template_component\.html\.erb], error.backtrace[0]
   end
 
   def test_render_collection

--- a/test/view_component/view_component_test.rb
+++ b/test/view_component/view_component_test.rb
@@ -89,7 +89,7 @@ class ViewComponentTest < ViewComponent::TestCase
   def test_renders_partial_template
     render_inline(PartialComponent.new)
 
-    assert_text("hello,partial world!\n\nhello,partial world!")
+    assert_text("hello,partial world!", count: 2)
   end
 
   def test_renders_content_for_template
@@ -378,9 +378,8 @@ class ViewComponentTest < ViewComponent::TestCase
       render_inline(ExceptionInTemplateComponent.new)
     end
 
-    assert_match %r[app/components/exception_in_template_component\.html\.erb:2], error.backtrace[0]
+    assert_match %r[app/components/exception_in_template_component\.html\.erb:3], error.backtrace[0]
   end
-
 
   def test_render_collection
     products = [OpenStruct.new(name: "Radio clock"), OpenStruct.new(name: "Mints")]

--- a/test/view_component/view_component_test.rb
+++ b/test/view_component/view_component_test.rb
@@ -376,7 +376,7 @@ class ViewComponentTest < ViewComponent::TestCase
       render_inline(ExceptionInTemplateComponent.new)
     end
 
-    assert_match %r[app/components/exception_in_template_component\.html\.erb], error.backtrace[0]
+    assert_match %r[app/components/exception_in_template_component\.html\.erb:2], error.backtrace[0]
   end
 
   def test_render_collection


### PR DESCRIPTION
This PR introduces support for `config.action_view.annotate_template_file_names`, which is coming in Rails 6.1: https://github.com/rails/rails/pull/38848.

