### PR TITLE
ignore redefinitions of inherited when inspecting caller locations

### DIFF
--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -149,8 +149,8 @@ module ViewComponent
         end
 
         # Derive the source location of the component Ruby file from the call stack.
-        # We need to ignore `inherited` frames here as they indicated that this method
-        # has been re-defined by the consuming application.
+        # We need to ignore `inherited` frames here as they indicate that `inherited`
+        # has been re-defined by the consuming application, likely in ApplicationComponent.
         child.source_location = caller_locations(1,10).reject { |l| l.label == "inherited" }[0].absolute_path
 
         super

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -151,7 +151,7 @@ module ViewComponent
         # Derive the source location of the component Ruby file from the call stack.
         # We need to ignore `inherited` frames here as they indicate that `inherited`
         # has been re-defined by the consuming application, likely in ApplicationComponent.
-        child.source_location = caller_locations(1,10).reject { |l| l.label == "inherited" }[0].absolute_path
+        child.source_location = caller_locations(1, 10).reject { |l| l.label == "inherited" }[0].absolute_path
 
         super
       end

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -151,7 +151,7 @@ module ViewComponent
         # Derive the source location of the component Ruby file from the call stack.
         # We need to ignore `inherited` frames here as they indicated that this method
         # has been re-defined by the consuming application.
-        child.source_location = caller_locations.reject { |l| l.label == "inherited" }[0].absolute_path
+        child.source_location = caller_locations(1,10).reject { |l| l.label == "inherited" }[0].absolute_path
 
         super
       end

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -148,7 +148,10 @@ module ViewComponent
           child.include Rails.application.routes.url_helpers unless child < Rails.application.routes.url_helpers
         end
 
-        child.source_location = caller_locations(1, 1)[0].absolute_path
+        # Derive the source location of the component Ruby file from the call stack.
+        # We need to ignore `inherited` frames here as they indicated that this method
+        # has been re-defined by the consuming application.
+        child.source_location = caller_locations.reject { |l| l.label == "inherited" }[0].absolute_path
 
         super
       end

--- a/test/app/components/child_component.html.erb
+++ b/test/app/components/child_component.html.erb
@@ -1,0 +1,1 @@
+<div>hello,world!</div>

--- a/test/app/components/child_component.rb
+++ b/test/app/components/child_component.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 class ChildComponent < ParentComponent
 end

--- a/test/app/components/child_component.rb
+++ b/test/app/components/child_component.rb
@@ -1,0 +1,2 @@
+class ChildComponent < ParentComponent
+end

--- a/test/app/components/parent_component.rb
+++ b/test/app/components/parent_component.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ParentComponent < ViewComponent::Base
   def self.inherited(child)
     super

--- a/test/app/components/parent_component.rb
+++ b/test/app/components/parent_component.rb
@@ -1,0 +1,5 @@
+class ParentComponent < ViewComponent::Base
+  def self.inherited(child)
+    super
+  end
+end

--- a/test/view_component/view_component_test.rb
+++ b/test/view_component/view_component_test.rb
@@ -9,6 +9,12 @@ class ViewComponentTest < ViewComponent::TestCase
     assert_selector("div", text: "hello,world!")
   end
 
+  def test_child_component
+    render_inline(ChildComponent.new)
+
+    assert_selector("div", text: "hello,world!")
+  end
+
   def test_renders_content_from_block
     render_inline(WrapperComponent.new) do
       "content"


### PR DESCRIPTION
Given an ApplicationComponent that re-defines `inherited`,
we were failing to find the correct template for the child
component, as we were looking at the top frame in the
call stack.

This change ignores any definitions of `inherited` in
the call stack, avoiding the issue.

[Fixes: #280]