### PR TITLE
All ViewComponents have an :html format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # master
 
+* Add `Base.format` for better compatibility with `ActionView::Template`.
+
+    *Joel Hawksley*
+
 # v2.2.1
 
 * Fix bug where template could not be found if `inherited` was redefined.

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -220,6 +220,10 @@ module ViewComponent
         "text/html"
       end
 
+      def format
+        :html
+      end
+
       def identifier
         source_location
       end


### PR DESCRIPTION
For now, we need to set the format of ViewComponents to :html,
as there are other latent assumptions in the library that we
will only use it to build HTML.

This change unblocks better support for template annotations
in Rails.

cc @github/view-component-reviewers 