### PR TITLE
Updating gemspec files attribute

### DIFF
--- a/view_component.gemspec
+++ b/view_component.gemspec
@@ -24,9 +24,7 @@ Gem::Specification.new do |spec|
       "public gem pushes."
   end
 
-  spec.files         = `git ls-files -z`.split("\x0").reject do |f|
-    f.match(%r{^(test|spec|features)/})
-  end
+  spec.files         = Dir["CHANGELOG.md", "LICENSE.txt", "README.md", "app/**/*", "lib/**/*"]
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]

--- a/view_component.gemspec
+++ b/view_component.gemspec
@@ -25,8 +25,6 @@ Gem::Specification.new do |spec|
   end
 
   spec.files         = Dir["CHANGELOG.md", "LICENSE.txt", "README.md", "app/**/*", "lib/**/*"]
-  spec.bindir        = "exe"
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
   spec.required_ruby_version = ">= 2.3.0"


### PR DESCRIPTION
<!-- See https://github.com/github/view_component/blob/master/CONTRIBUTING.md#submitting-a-pull-request  -->

### Summary

The view_component gem is currently bundling more files than actually needed/used by the applications where it's installed. 

Using version 2.0.0, after running `ls /Users/{whoami}/.gem/ruby/2.6.3/gems/view_component-2.0.0`, we get:
```
CHANGELOG.md           
CONTRIBUTING.md        
Gemfile.lock           
README.md              
app                    
lib                    
view_component.gemspec
CODE_OF_CONDUCT.md     
Gemfile                
LICENSE.txt            
Rakefile               
docs                   
script
```

After this change, we'll get:
```
CHANGELOG.md 
LICENSE.txt  
README.md    
app          
lib
```

Why only those files? Well they are the ones the final user would actually care about, and those are files being used in other gems: [ActionText](https://github.com/rails/rails/blob/master/actiontext/actiontext.gemspec#L20), [ActiveSupport](https://github.com/rails/rails/blob/master/activesupport/activesupport.gemspec#L20), ...
### Other Information

Given this gem does not provide any executable I also removed the `bindir` and `executables` configuration from the gemspec.

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file. -->
