### PR TITLE
Making rails application layout the default for preview index views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # master
 
+* ViewComponent preview index views use Rails internal layout instead of application's layout
+
+    *Juan Manuel Ramallo*
+
 # v2.2.2
 
 * Add `Base.format` for better compatibility with `ActionView::Template`.

--- a/app/controllers/rails/view_components_controller.rb
+++ b/app/controllers/rails/view_components_controller.rb
@@ -4,7 +4,6 @@ require "rails/application_controller"
 
 class Rails::ViewComponentsController < Rails::ApplicationController # :nodoc:
   prepend_view_path File.expand_path("../../../lib/railties/lib/rails/templates/rails", __dir__)
-  prepend_view_path "#{Rails.root}/app/views/" if defined?(Rails.root)
 
   around_action :set_locale, only: :previews
   before_action :find_preview, only: :previews
@@ -18,7 +17,7 @@ class Rails::ViewComponentsController < Rails::ApplicationController # :nodoc:
     @previews = ViewComponent::Preview.all
     @page_title = "Component Previews"
     # rubocop:disable GitHub/RailsControllerRenderPathsExist
-    render "components/index"
+    render "components/index", layout: "application"
     # rubocop:enable GitHub/RailsControllerRenderPathsExist
   end
 
@@ -29,6 +28,7 @@ class Rails::ViewComponentsController < Rails::ApplicationController # :nodoc:
       render "components/previews"
       # rubocop:enable GitHub/RailsControllerRenderPathsExist
     else
+      prepend_application_view_paths
       @example_name = File.basename(params[:path])
       @render_args = @preview.render_args(@example_name)
       layout = @render_args[:layout]
@@ -61,5 +61,9 @@ class Rails::ViewComponentsController < Rails::ApplicationController # :nodoc:
     I18n.with_locale(params[:locale] || I18n.default_locale) do
       yield
     end
+  end
+
+  def prepend_application_view_paths
+    prepend_view_path Rails.root.join("app/views") if defined?(Rails.root)
   end
 end

--- a/app/controllers/rails/view_components_controller.rb
+++ b/app/controllers/rails/view_components_controller.rb
@@ -17,7 +17,7 @@ class Rails::ViewComponentsController < Rails::ApplicationController # :nodoc:
     @previews = ViewComponent::Preview.all
     @page_title = "Component Previews"
     # rubocop:disable GitHub/RailsControllerRenderPathsExist
-    render "components/index", layout: "application"
+    render "components/index"
     # rubocop:enable GitHub/RailsControllerRenderPathsExist
   end
 

--- a/test/view_component/integration_test.rb
+++ b/test/view_component/integration_test.rb
@@ -169,7 +169,6 @@ class IntegrationTest < ActionDispatch::IntegrationTest
   test "test preview renders" do
     get "/rails/view_components/preview_component/default"
 
-    assert_includes response.body, "ViewComponent - Test"
     assert_select(".preview-component .btn", "Click me!")
   end
 
@@ -184,6 +183,24 @@ class IntegrationTest < ActionDispatch::IntegrationTest
     get "/rails/view_components/no_layout/default"
 
     assert_select("div", "hello,world!")
+  end
+
+  test "test preview renders application's layout by default" do
+    get "/rails/view_components/preview_component/default"
+
+    assert_includes response.body, "<title>ViewComponent - Test</title>"
+  end
+
+  test "test preview index renders rails application layout by default" do
+    get "/rails/view_components"
+
+    assert_includes response.body, "<title>Component Previews</title>"
+  end
+
+  test "test preview index of a component renders rails application layout by default" do
+    get "/rails/view_components/preview_component"
+
+    assert_includes response.body, "<title>Component Previews for preview_component</title>"
   end
 
   test "renders collections" do

--- a/test/view_component/integration_test.rb
+++ b/test/view_component/integration_test.rb
@@ -203,7 +203,7 @@ class IntegrationTest < ActionDispatch::IntegrationTest
     assert_includes response.body, "<title>Component Previews for preview_component</title>"
   end
 
-  test "previews views are being rendered correctly" do
+  test "test preview related views are being rendered correctly" do
     get "/rails/view_components"
     assert_includes response.body, "<title>Component Previews</title>"
 

--- a/test/view_component/integration_test.rb
+++ b/test/view_component/integration_test.rb
@@ -188,30 +188,30 @@ class IntegrationTest < ActionDispatch::IntegrationTest
   test "test preview renders application's layout by default" do
     get "/rails/view_components/preview_component/default"
 
-    assert_includes response.body, "<title>ViewComponent - Test</title>"
+    assert_select "title", "ViewComponent - Test"
   end
 
   test "test preview index renders rails application layout by default" do
     get "/rails/view_components"
 
-    assert_includes response.body, "<title>Component Previews</title>"
+    assert_select "title", "Component Previews"
   end
 
   test "test preview index of a component renders rails application layout by default" do
     get "/rails/view_components/preview_component"
 
-    assert_includes response.body, "<title>Component Previews for preview_component</title>"
+    assert_select "title", "Component Previews for preview_component"
   end
 
   test "test preview related views are being rendered correctly" do
     get "/rails/view_components"
-    assert_includes response.body, "<title>Component Previews</title>"
+    assert_select "title", "Component Previews"
 
     get "/rails/view_components/preview_component/default"
-    assert_includes response.body, "<title>ViewComponent - Test</title>"
+    assert_select "title", "ViewComponent - Test"
 
     get "/rails/view_components/preview_component"
-    assert_includes response.body, "<title>Component Previews for preview_component</title>"
+    assert_select "title", "Component Previews for preview_component"
   end
 
   test "renders collections" do

--- a/test/view_component/integration_test.rb
+++ b/test/view_component/integration_test.rb
@@ -203,6 +203,17 @@ class IntegrationTest < ActionDispatch::IntegrationTest
     assert_includes response.body, "<title>Component Previews for preview_component</title>"
   end
 
+  test "previews views are being rendered correctly" do
+    get "/rails/view_components"
+    assert_includes response.body, "<title>Component Previews</title>"
+
+    get "/rails/view_components/preview_component/default"
+    assert_includes response.body, "<title>ViewComponent - Test</title>"
+
+    get "/rails/view_components/preview_component"
+    assert_includes response.body, "<title>Component Previews for preview_component</title>"
+  end
+
   test "renders collections" do
     get "/products"
 


### PR DESCRIPTION
Resolves #289 

<!-- See https://github.com/github/view_component/blob/master/CONTRIBUTING.md#submitting-a-pull-request  -->

### Summary

- Updated view_components_controller to only prepend application's view paths when rendering a given preview
- Preview index views will use rails' default application layout
- Added integration tests for this new behaviour

![image](https://user-images.githubusercontent.com/13257832/79054784-44999380-7c1e-11ea-87ca-b5727374c3be.png)

![image](https://user-images.githubusercontent.com/13257832/79054791-4b280b00-7c1e-11ea-905d-f7b8470208cd.png)

![image](https://user-images.githubusercontent.com/13257832/79054793-524f1900-7c1e-11ea-8270-a364d798d620.png)
