### PR TITLE
Make Capybara optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # master
 
+* Remove `capybara` dependency.
+
+    *Richard Macklin*
+
 # v2.3.0
 
 * Allow using inline render method(s) defined on a parent.

--- a/Gemfile
+++ b/Gemfile
@@ -5,4 +5,5 @@ gemspec
 
 rails_version = "#{ENV['RAILS_VERSION'] || '6.0.2.2'}"
 
+gem "capybara", "~> 3"
 gem "rails", rails_version == "master" ? { github: "rails/rails" } : rails_version

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -189,6 +189,7 @@ PLATFORMS
 DEPENDENCIES
   better_html (~> 1)
   bundler (~> 1.14)
+  capybara (~> 3)
   haml (~> 5)
   minitest (= 5.1.0)
   rails (= 6.0.2.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,6 @@ PATH
   remote: .
   specs:
     view_component (2.3.0)
-      capybara (~> 3)
 
 GEM
   remote: https://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -455,7 +455,7 @@ This will allow you to create files such as `app/components/widget_controller.js
 
 ### Testing
 
-Unit test components directly, using the `render_inline` test helper and Capybara matchers:
+Unit test components directly, using the `render_inline` test helper. If you have a `capybara` test dependency, Capybara matchers will be available in your tests:
 
 ```ruby
 require "view_component/test_case"
@@ -466,6 +466,16 @@ class MyComponentTest < ViewComponent::TestCase
 
     assert_selector("span[title='my title']", "Hello, World!")
   end
+end
+```
+
+In the absence of `capybara`, you can make assertions on the `render_inline` return value, which is an instance of `Nokogiri::HTML::DocumentFragment`:
+
+```ruby
+test "render component" do
+  result = render_inline(TestComponent.new(title: "my title")) { "Hello, World!" }
+
+  assert_includes result.css("span[title='my title']").to_html, "Hello, World!"
 end
 ```
 

--- a/lib/view_component/test_helpers.rb
+++ b/lib/view_component/test_helpers.rb
@@ -1,17 +1,20 @@
 # frozen_string_literal: true
 
-require "capybara/minitest"
-
 module ViewComponent
   module TestHelpers
-    include Capybara::Minitest::Assertions
+    begin
+      require "capybara/minitest"
+      include Capybara::Minitest::Assertions
 
-    def page
-      Capybara::Node::Simple.new(@raw)
-    end
+      def page
+        Capybara::Node::Simple.new(@raw)
+      end
 
-    def refute_component_rendered
-      assert_no_selector("body")
+      def refute_component_rendered
+        assert_no_selector("body")
+      end
+    rescue LoadError
+      warn "WARNING in `ViewComponent::TestHelpers`: You must add `capybara` to your Gemfile to use Capybara assertions."
     end
 
     def render_inline(component, **args, &block)

--- a/view_component.gemspec
+++ b/view_component.gemspec
@@ -29,7 +29,6 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.3.0"
 
-  spec.add_runtime_dependency     "capybara", "~> 3"
   spec.add_development_dependency "bundler", "~> 1.14"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "minitest", "= 5.1.0"


### PR DESCRIPTION
### Summary

This is a potential solution for the issue brought up in #292.

`ViewComponent::TestHelpers` was the only module that used `capybara`, and that module is for the test environment. Thus, requiring `capybara` in the production environment is unnecessary. Furthermore, since it's still possible to test components using the return value of `render_inline`, applications that don't already have their own `capybara` dependency could still use `view_component` and test their components without the `capybara` assertions. On the other hand, any rails app that already depends on capybara (including any app that uses [Rails System Tests](https://guides.rubyonrails.org/testing.html#system-testing)) will automatically be able to use capybara assertions in their component tests.