### PR TITLE
Only autoload public API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # master
 
+* Remove `autoload`s of internal modules (`Previewable`, `RenderMonkeyPatch`, `RenderingMonkeyPatch`).
+
+    *Richard Macklin*
+
 * Remove `capybara` dependency.
 
     *Richard Macklin*

--- a/lib/view_component.rb
+++ b/lib/view_component.rb
@@ -9,7 +9,5 @@ module ViewComponent
   autoload :Preview
   autoload :TestHelpers
   autoload :TestCase
-  autoload :RenderMonkeyPatch
-  autoload :RenderingMonkeyPatch
   autoload :TemplateError
 end

--- a/lib/view_component.rb
+++ b/lib/view_component.rb
@@ -7,7 +7,6 @@ module ViewComponent
 
   autoload :Base
   autoload :Preview
-  autoload :Previewable
   autoload :TestHelpers
   autoload :TestCase
   autoload :RenderMonkeyPatch

--- a/lib/view_component/engine.rb
+++ b/lib/view_component/engine.rb
@@ -43,11 +43,17 @@ module ViewComponent
 
     initializer "view_component.monkey_patch_render" do
       ActiveSupport.on_load(:action_view) do
-        ActionView::Base.prepend ViewComponent::RenderMonkeyPatch if Rails.version.to_f < 6.1
+        if Rails.version.to_f < 6.1
+          require "view_component/render_monkey_patch"
+          ActionView::Base.prepend ViewComponent::RenderMonkeyPatch
+        end
       end
 
       ActiveSupport.on_load(:action_controller) do
-        ActionController::Base.prepend ViewComponent::RenderingMonkeyPatch if Rails.version.to_f < 6.1
+        if Rails.version.to_f < 6.1
+          require "view_component/rendering_monkey_patch"
+          ActionController::Base.prepend ViewComponent::RenderingMonkeyPatch
+        end
       end
     end
 


### PR DESCRIPTION
## Summary

Some of the modules we were `autoload`ing are internal modules. Unlike `Base`, `Preview`, `TestCase`, and `TemplateError`, we don't intend for users to directly use the `Previewable`, `TestHelpers`, `RenderMonkeyPatch`, or `RenderingMonkeyPatch` modules (AFAIK). So I've removed those modules from the gem's `autoload`s.