### PR TITLE
Declare dependency on activesupport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # master
 
+* Declare explicit dependency on `activesupport`.
+
+    *Richard Macklin*
+
 * Remove `autoload`s of internal modules (`Previewable`, `RenderMonkeyPatch`, `RenderingMonkeyPatch`).
 
     *Richard Macklin*

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     view_component (2.3.0)
+      activesupport (>= 5.0.0, < 7.0)
 
 GEM
   remote: https://rubygems.org/

--- a/view_component.gemspec
+++ b/view_component.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.3.0"
 
+  spec.add_runtime_dependency     "activesupport", [">= 5.0.0", "< 7.0"]
   spec.add_development_dependency "bundler", "~> 1.14"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "minitest", "= 5.1.0"


### PR DESCRIPTION
### Summary

We're requiring activesupport in several places:
https://github.com/github/view_component/blob/060275c1927f4d7a5a5949866838a880ea896d2a/lib/view_component.rb#L3
https://github.com/github/view_component/blob/060275c1927f4d7a5a5949866838a880ea896d2a/lib/view_component/base.rb#L4
https://github.com/github/view_component/blob/060275c1927f4d7a5a5949866838a880ea896d2a/lib/view_component/preview.rb#L3
https://github.com/github/view_component/blob/060275c1927f4d7a5a5949866838a880ea896d2a/lib/view_component/previewable.rb#L3
https://github.com/github/view_component/blob/060275c1927f4d7a5a5949866838a880ea896d2a/lib/view_component/test_case.rb#L3

Thus, we should declare a formal dependency on it. Since we support Rails 5.0.0 through Rails 6.x, we've declared the dependency as `>= 5.0.0, < 7.0`. (Without the 7.0 upper bound, rubygems would print `WARNING:  open-ended dependency on activesupport (>= 5.0.0) is not recommended` when building the gem.)