### PR TITLE
Add default layout option in order to use app/views/layouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # master
 
+* Add `default_preview_layout` configuration option to load custom app/views/layouts.
+
+    *Jared White, Juan Manuel Ramallo*
+
 # 2.17.0
 
 * Slots return stripped HTML, removing leading and trailing whitespace.

--- a/README.md
+++ b/README.md
@@ -674,6 +674,14 @@ class TestComponentPreview < ViewComponent::Preview
 end
 ```
 
+You can also set a custom layout to be used by default for previews as well as the preview index pages via the `default_preview_layout` configuration option:
+
+`config/application.rb`
+```ruby
+# Set the default layout to app/views/layouts/component_preview.html.erb
+config.default_preview_layout = "component_preview"
+```
+
 Preview classes live in `test/components/previews`, which can be configured using the `preview_paths` option:
 
 `config/application.rb`

--- a/app/controllers/view_components_controller.rb
+++ b/app/controllers/view_components_controller.rb
@@ -28,11 +28,11 @@ class ViewComponentsController < Rails::ApplicationController # :nodoc:
       prepend_preview_examples_view_path
       @example_name = File.basename(params[:path])
       @render_args = @preview.render_args(@example_name, params: params.permit!)
-      layout = determine_layout(@render_args[:layout])[:layout]
+      layout = determine_layout(@render_args[:layout], prepend_views: false)[:layout]
       template = @render_args[:template]
       locals = @render_args[:locals]
       opts = {}
-      opts[:layout] = layout if layout.present?
+      opts[:layout] = layout if layout.present? || layout == false
       opts[:locals] = locals if locals.present?
       render template, opts # rubocop:disable GitHub/RailsControllerRenderLiteral
     end
@@ -67,7 +67,7 @@ class ViewComponentsController < Rails::ApplicationController # :nodoc:
   end
 
   # Returns either {} or {layout: value} depending on configuration
-  def determine_layout(layout_override = nil)
+  def determine_layout(layout_override = nil, prepend_views: true)
     return {} unless defined?(Rails.root)
 
     layout_declaration = {}
@@ -78,6 +78,8 @@ class ViewComponentsController < Rails::ApplicationController # :nodoc:
     elsif default_preview_layout.present?
       layout_declaration[:layout] = default_preview_layout
     end
+
+    prepend_application_view_paths if layout_declaration[:layout].present? && prepend_views
 
     layout_declaration
   end

--- a/coverage/coverage.txt
+++ b/coverage/coverage.txt
@@ -2,10 +2,10 @@
 Incomplete test coverage
 --------------------------------------------------------------------------------
 
-/app/controllers/view_components_controller.rb: 97.67% (missed: 54)
+/app/controllers/view_components_controller.rb: 98.18% (missed: 59)
 /lib/view_component/base.rb: 97.86% (missed: 178,265,293,356)
 /lib/view_component/engine.rb: 94.64% (missed: 22,25,38)
 /lib/view_component/preview.rb: 94.0% (missed: 47,57,107)
 /lib/view_component/render_to_string_monkey_patch.rb: 83.33% (missed: 9)
 /lib/view_component/test_helpers.rb: 91.67% (missed: 17,25)
-/test/view_component/integration_test.rb: 96.73% (missed: 14,15,16,18,20,370,371,372,374)
+/test/view_component/integration_test.rb: 96.74% (missed: 14,15,16,18,20,371,372,373,375)

--- a/lib/view_component/previewable.rb
+++ b/lib/view_component/previewable.rb
@@ -7,6 +7,14 @@ module ViewComponent # :nodoc:
     extend ActiveSupport::Concern
 
     included do
+      # Set a custom default preview layout through app configuration:
+      #
+      #     config.view_component.default_preview_layout = "component_preview"
+      #
+      # This affects preview index pages as well as individual component previews
+      #
+      mattr_accessor :default_preview_layout, instance_writer: false
+
       # Set the location of component previews through app configuration:
       #
       #     config.view_component.preview_paths << "#{Rails.root}/lib/component_previews"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -41,3 +41,10 @@ def modify_file(file, content)
     File.open(filename, "wb+") { |f| f.write(old_content) }
   end
 end
+
+def with_default_preview_layout(layout)
+  old_value = ViewComponent::Base.default_preview_layout
+  ViewComponent::Base.default_preview_layout = layout
+  yield
+  ViewComponent::Base.default_preview_layout = old_value
+end

--- a/test/view_component/default_preview_layout_integration_test.rb
+++ b/test/view_component/default_preview_layout_integration_test.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class DefaultPreviewLayoutIntegrationTest < ActionDispatch::IntegrationTest
+  test "preview index renders custom application layout if configured" do
+    with_default_preview_layout("admin") do
+      get "/rails/view_components"
+      assert_select "title", "ViewComponent - Admin - Test"
+    end
+  end
+
+  test "preview index of a component renders custom application layout if configured" do
+    with_default_preview_layout("admin") do
+      get "/rails/view_components/preview_component"
+      assert_select "title", "ViewComponent - Admin - Test"
+    end
+  end
+
+  test "component preview renders custom application layout if configured" do
+    with_default_preview_layout("admin") do
+      get "/rails/view_components/preview_component/default"
+      assert_select "title", "ViewComponent - Admin - Test"
+      assert_select ".preview-component .btn", "Click me!"
+    end
+  end
+
+  test "component preview renders standard Rails layout if configured false" do
+    with_default_preview_layout(false) do
+      get "/rails/view_components/preview_component/default"
+
+      assert_select "title", "ViewComponent - Test"
+      assert_select ".preview-component .btn", "Click me!"
+    end
+  end
+
+  test "preview renders without layout even if default layout is configured" do
+    with_default_preview_layout("admin") do
+      get "/rails/view_components/no_layout/default"
+      assert_select("div", "hello,world!")
+      refute_includes response.body, "ViewComponent - Admin - Test"
+    end
+  end
+end

--- a/test/view_component/integration_test.rb
+++ b/test/view_component/integration_test.rb
@@ -281,6 +281,7 @@ class IntegrationTest < ActionDispatch::IntegrationTest
     get "/rails/view_components/no_layout/default"
 
     assert_select("div", "hello,world!")
+    refute_includes response.body, "ViewComponent - Test"
   end
 
   test "test preview renders application's layout by default" do


### PR DESCRIPTION
### Summary

I was digging a ton into component previews on a new project today, and I found myself wanting to use a custom layout (in my case `component_preview`) for all of the index pages as well as component preview pages. I started by monkey patching Rails::ApplicationController, but then realized I should simply adjust what's going on in ViewComponentsController, which gave me the idea for a configuration option and hence this PR.

### Other Information

This makes no behavioral change at all out-of-the-box. Everything will work as before. The only difference is if that `default_preview_layout` config option is set, the preview indices and components will pull that in rather than use the Rails internal app layout. Of course individual previews can still override the layout, including setting it to nil. (I also ended up fixing an existing test that would always pass even if a layout _was_ rendered.)

Let me know what you think! Thanks.