### PR TITLE
Compile component before rendering collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # master
 
+# 2.5.1
+
+* Compile component before rendering collection.
+
+    Rainer Borene
+
 # v2.5.0
 
 * Add counter variables when rendering collections.

--- a/lib/view_component/collection.rb
+++ b/lib/view_component/collection.rb
@@ -5,6 +5,7 @@ module ViewComponent
     def render_in(view_context, &block)
       iterator = ActionView::PartialIteration.new(@collection.size)
 
+      @component.compile!
       @collection.map do |item|
         content = @component.new(component_options(item, iterator)).render_in(view_context, &block)
         iterator.iterate!


### PR DESCRIPTION
After running our test suite today with the latest version of `view_component` I got the following message:

> ActionView::Template::Error: undefined method `counter_argument_present?' for Courses::Card:Class

This is an edge case. If you're running a test or development environment and never rendered that specific component individually, then you will face the same problem. So, this pull request fixes this problem. In other words, `Courses::Card` is only rendered through collections, and isn't compiled at this point yet.
