### PR TITLE
Allow arguments to be passed to content areas #285

### DIFF
--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -118,11 +118,11 @@ module ViewComponent
         raise ArgumentError.new "Unknown content_area '#{area}' - expected one of '#{content_areas}'"
       end
 
-      if block_given?
-        content = view_context.capture(&block)
+      define_singleton_method(area) do |*args|
+        block = ->() { content } unless block_given?
+        view_context.capture(*args, &block)
       end
 
-      instance_variable_set("@#{area}".to_sym, content)
       nil
     end
 
@@ -236,7 +236,7 @@ module ViewComponent
         if areas.include?(:content)
           raise ArgumentError.new ":content is a reserved content area name. Please use another name, such as ':body'"
         end
-        attr_reader *areas
+        attr_reader *areas # provide a default implementation for all areas. Will be redifined by calls to .with.
         self.content_areas = areas
       end
 

--- a/test/app/components/form_component.html.erb
+++ b/test/app/components/form_component.html.erb
@@ -1,5 +1,5 @@
 <div class="post_form">
-  <%= form_with model: post do |post_form| %>
+  <%= form_for post do |post_form| %>
     <div class="header">
       <%= header %>
     </div>

--- a/test/app/components/form_component.html.erb
+++ b/test/app/components/form_component.html.erb
@@ -1,0 +1,13 @@
+<div class="post_form">
+  <%= form_with model: post do |post_form| %>
+    <div class="header">
+      <%= header %>
+    </div>
+    <div class="body">
+      <%= body(post_form) %>
+    </div>
+    <div class="footer">
+      <%= footer(post_form) %>
+    </div>
+  <% end %>
+</div>

--- a/test/app/components/form_component.rb
+++ b/test/app/components/form_component.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class FormComponent < ViewComponent::Base
+  with_content_areas :header, :body, :footer
+
+  def post
+    @post ||= Post.new(title: "Check It Out")
+  end
+end

--- a/test/config/routes.rb
+++ b/test/config/routes.rb
@@ -12,4 +12,5 @@ Dummy::Application.routes.draw do
   get :controller_inline, to: "integration_examples#controller_inline"
   get :controller_inline_baseline, to: "integration_examples#controller_inline_baseline"
   get :controller_to_string, to: "integration_examples#controller_to_string"
+  resources :posts
 end

--- a/test/view_component/view_component_test.rb
+++ b/test/view_component/view_component_test.rb
@@ -176,17 +176,6 @@ class ViewComponentTest < ViewComponent::TestCase
     assert_selector(".footer", text: "Bye!")
   end
 
-  def test_renders_content_areas_template_can_wrap_render_arguments
-    render_inline(ContentAreasComponent.new(title: "Hello!", footer: "Bye!")) do |component|
-      component.with(:title) { "<strong>#{component.title}</strong>".html_safe }
-      component.with(:body) { "Have a nice day." }
-    end
-
-    assert_selector(".title strong", text: "Hello!")
-    assert_selector(".body", text: "Have a nice day.")
-    assert_selector(".footer", text: "Bye!")
-  end
-
   def test_renders_content_areas_template_raise_with_unknown_content_areas
     exception = assert_raises ArgumentError do
       render_inline(ContentAreasComponent.new(footer: "Bye!")) do |component|
@@ -502,6 +491,24 @@ class ViewComponentTest < ViewComponent::TestCase
     assert_selector("h1", text: "Product", count: 1)
     assert_selector("h2", text: "Mints")
     assert_selector("p", text: "On sale", count: 1)
+  end
+
+  def test_content_area_named_attributes
+    render_inline(FormComponent.new) do |component|
+      component.with(:header) do ||
+        "Form Header: #{component.post.title}"
+      end
+      component.with(:body) do |form|
+        form.text_field :title
+      end
+      component.with(:footer) do |form|
+        form.submit "Save"
+      end
+    end
+
+    assert_selector(".header", text: "Form Header: Check It Out")
+    assert_selector(".body input[name='post[title]'][value='Check It Out']")
+    assert_selector(".footer input[value='Save']")
   end
 
   private


### PR DESCRIPTION
### Summary

Alternative solution than #322  for passing arguments to content areas as requested in #285 

### Other Information

I'm not 100% convinced we need this complexity. I'd love more example use cases. But assuming an agreed need I think this is the way we'd do it