### PR TITLE
Add failing spec for preview with container element

### DIFF
--- a/test/test/components/previews/preview_component_preview.rb
+++ b/test/test/components/previews/preview_component_preview.rb
@@ -20,4 +20,10 @@ class PreviewComponentPreview < ViewComponent::Preview
   def with_params(cta: "Default CTA", title: "Default title")
     render(PreviewComponent.new(cta: cta, title: title))
   end
+
+  def wrapped_in_div
+    tag.div do
+      render(PreviewComponent.new(title: "Lorem Ipsum"))
+    end
+  end
 end

--- a/test/view_component/integration_test.rb
+++ b/test/view_component/integration_test.rb
@@ -209,6 +209,12 @@ class IntegrationTest < ActionDispatch::IntegrationTest
     refute_includes response.body, "Label from params"
   end
 
+  test "renders preview component wrapped in div" do
+    get "/rails/view_components/preview_component/wrapped_in_div"
+
+    assert_includes response.body, '<div><div class="preview-component">Lorem Ipsum</div></div>'
+  end
+
   test "renders badge component open preview" do
     get "/rails/view_components/issues/badge_component/open"
 


### PR DESCRIPTION
### Summary

This adds a failing test to cover a scenario [discussed](https://github.com/github/view_component/discussions/337) where a preview component may need (in the case of a table cell TD) or want (by the developer) to be wrapped in another parent element/container.  

eg (non-working)

```
class MyComponentPreview < ViewComponent::Preview
  def normal
    tag.table do 
      tag.tr do 
        render(MyTableCellComponent.new.....
      end
    end
  end
end
``` 

Currently previews only render the component itself or the component as a parent of content inside it.    

### Other Information

I'm happy to continue with this PR is someone could point me in the direction I should go.  I know that `tag.div` doesn't work in the context I'm using it but its a starting point.
