### PR TITLE
Annotations & Cleanups

### DIFF
--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -61,6 +61,7 @@ module ViewComponent
       old_current_template = @current_template
       @current_template = self
 
+      # Assign captured content passed to component as a block to @content
       @content = view_context.capture(self, &block) if block_given?
 
       before_render_check

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -191,8 +191,9 @@ module ViewComponent
       end
 
       # Compile templates to instance methods, assuming they haven't been compiled already.
-      # We could in theory do this on app boot, at least in production environments.
-      # Right now this just compiles the first time the component is rendered.
+      #
+      # Do as much work as possible in this step, as doing so reduces the amount
+      # of work done each time a component is rendered.
       def compile(raise_errors: false)
         return if compiled?
 

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -115,7 +115,8 @@ module ViewComponent
       []
     end
 
-    def format # :nodoc:
+    # For caching, such as #cache_if
+    def format
       @variant
     end
 

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -118,6 +118,7 @@ module ViewComponent
       @variant
     end
 
+    # Assign the provided content to the content area accessor
     def with(area, content = nil, &block)
       unless content_areas.include?(area)
         raise ArgumentError.new "Unknown content_area '#{area}' - expected one of '#{content_areas}'"

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -46,6 +46,9 @@ module ViewComponent
       @view_context = view_context
       @lookup_context ||= view_context.lookup_context
 
+      # required for path helpers in older Rails versions
+      @view_renderer ||= view_context.view_renderer
+
       # For content_for
       @view_flow ||= view_context.view_flow
 

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -110,6 +110,7 @@ module ViewComponent
       self.class.source_location.gsub(%r{(.*app/components)|(\.rb)}, "")
     end
 
+    # For caching, such as #cache_if
     def view_cache_dependencies
       []
     end

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -86,6 +86,8 @@ module ViewComponent
 
     def initialize(*); end
 
+    # If trying to render a partial or template inside a component,
+    # pass the render call to the parent view_context.
     def render(options = {}, args = {}, &block)
       if options.is_a?(String) || (options.is_a?(Hash) && options.has_key?(:partial))
         view_context.render(options, args, &block)

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -13,8 +13,8 @@ module ViewComponent
     # For CSRF authenticity tokens in forms
     delegate :form_authenticity_token, :protect_against_forgery?, to: :helpers
 
-    class_attribute :content_areas, default: []
-    self.content_areas = [] # default doesn't work until Rails 5.2
+    class_attribute :content_areas
+    self.content_areas = [] # class_attribute:default doesn't work until Rails 5.2
 
     # Render a component collection.
     def self.with_collection(*args)

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -49,7 +49,10 @@ module ViewComponent
       @view_context = view_context
       @view_renderer ||= view_context.view_renderer
       @lookup_context ||= view_context.lookup_context
+
+      # Expose @view_flow variable required to support content_for
       @view_flow ||= view_context.view_flow
+
       @virtual_path ||= virtual_path
       @variant = @lookup_context.variants.first
 

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -103,7 +103,7 @@ module ViewComponent
       @controller ||= view_context.controller
     end
 
-    # Provides a proxy to access helper methods through
+    # Provides a proxy to access helper methods
     def helpers
       @helpers ||= view_context
     end

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -16,11 +16,6 @@ module ViewComponent
     class_attribute :content_areas
     self.content_areas = [] # class_attribute:default doesn't work until Rails 5.2
 
-    # Render a component collection.
-    def self.with_collection(*args)
-      Collection.new(self, *args)
-    end
-
     # Entrypoint for rendering components.
     #
     # view_context: ActionView context from calling view
@@ -150,6 +145,11 @@ module ViewComponent
 
     class << self
       attr_accessor :source_location
+
+      # Render a component collection.
+      def with_collection(*args)
+        Collection.new(self, *args)
+      end
 
       def inherited(child)
         if defined?(Rails)

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -41,7 +41,8 @@ module ViewComponent
     # <span title="greeting">Hello, world!</span>
     #
     def render_in(view_context, &block)
-      self.class.compile!
+      self.class.compile(raise_errors: true)
+
       @view_context = view_context
       @lookup_context ||= view_context.lookup_context
 
@@ -184,10 +185,6 @@ module ViewComponent
 
       def compiled?
         @compiled && ActionView::Base.cache_template_loading
-      end
-
-      def compile!
-        compile(raise_errors: true)
       end
 
       # Compile templates to instance methods, assuming they haven't been compiled already.

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -160,6 +160,7 @@ module ViewComponent
       end
 
       def inherited(child)
+        # If we're in Rails, add application url_helpers to the component context
         if defined?(Rails)
           child.include Rails.application.routes.url_helpers unless child < Rails.application.routes.url_helpers
         end

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -47,7 +47,6 @@ module ViewComponent
     def render_in(view_context, &block)
       self.class.compile!
       @view_context = view_context
-      @view_renderer ||= view_context.view_renderer
       @lookup_context ||= view_context.lookup_context
 
       # Expose @view_flow variable required to support content_for

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -80,10 +80,6 @@ module ViewComponent
       true
     end
 
-    def self.short_identifier
-      @short_identifier ||= defined?(Rails.root) ? source_location.sub("#{Rails.root}/", "") : source_location
-    end
-
     def initialize(*); end
 
     # If trying to render a partial or template inside a component,
@@ -157,6 +153,11 @@ module ViewComponent
       # Render a component collection.
       def with_collection(*args)
         Collection.new(self, *args)
+      end
+
+      # Provide identifier for ActionView template annotations
+      def short_identifier
+        @short_identifier ||= defined?(Rails.root) ? source_location.sub("#{Rails.root}/", "") : source_location
       end
 
       def inherited(child)

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -135,6 +135,9 @@ module ViewComponent
 
     private
 
+    # Exposes the current request to the component.
+    # Use sparingly as doing so introduces coupling
+    # that inhibits encapsulation & reuse.
     def request
       @request ||= controller.request
     end

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -52,9 +52,10 @@ module ViewComponent
       # For content_for
       @view_flow ||= view_context.view_flow
 
-      # For i18n support
+      # For i18n
       @virtual_path ||= virtual_path
 
+      # For template variants (+phone, +desktop, etc.)
       @variant = @lookup_context.variants.first
 
       old_current_template = @current_template

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -49,10 +49,12 @@ module ViewComponent
       @view_context = view_context
       @lookup_context ||= view_context.lookup_context
 
-      # Expose @view_flow variable required to support content_for
+      # For content_for
       @view_flow ||= view_context.view_flow
 
+      # For i18n support
       @virtual_path ||= virtual_path
+
       @variant = @lookup_context.variants.first
 
       old_current_template = @current_template

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -10,6 +10,7 @@ module ViewComponent
     include ActiveSupport::Configurable
     include ViewComponent::Previewable
 
+    # For CSRF authenticity tokens in forms
     delegate :form_authenticity_token, :protect_against_forgery?, to: :helpers
 
     class_attribute :content_areas, default: []
@@ -58,6 +59,7 @@ module ViewComponent
       # For template variants (+phone, +desktop, etc.)
       @variant = @lookup_context.variants.first
 
+      # For caching, such as #cache_if
       old_current_template = @current_template
       @current_template = self
 

--- a/lib/view_component/collection.rb
+++ b/lib/view_component/collection.rb
@@ -5,7 +5,7 @@ module ViewComponent
     def render_in(view_context, &block)
       iterator = ActionView::PartialIteration.new(@collection.size)
 
-      @component.compile!
+      @component.compile(raise_errors: true)
       @component.validate_collection_parameter!(validate_default: true)
 
       @collection.map do |item|


### PR DESCRIPTION
### Summary

This PR is a preliminary pass at making our source code easier to understand for developers new to the project.

I:

- Added a healthy number of comments describing the function of specific lines/methods, often by deleting the code and seeing what tests failed 😱 
- Removed the `compile!` method, as it was only used twice. I think having the call sites use `compile(raise_errors: true)` is easier to understand.
- Moved a couple methods to be inside the `class << self` block.

This set of changes is non-breaking.