### PR TITLE
Update assert_selector API signature in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,7 +382,7 @@ class MyComponentTest < ViewComponent::TestCase
   test "render component" do
     render_inline(TestComponent.new(title: "my title")) { "Hello, World!" }
 
-    assert_selector("span[title='my title']", "Hello, World!")
+    assert_selector("span[title='my title']", text: "Hello, World!")
   end
 end
 ```
@@ -406,7 +406,7 @@ test "render component for tablet" do
   with_variant :tablet do
     render_inline(TestComponent.new(title: "my title")) { "Hello, tablets!" }
 
-    assert_selector("span[title='my title']", "Hello, tablets!")
+    assert_selector("span[title='my title']", text: "Hello, tablets!")
   end
 end
 ```


### PR DESCRIPTION
<!-- See https://github.com/github/view_component/blob/master/CONTRIBUTING.md#submitting-a-pull-request  -->

### Summary

The `assert_selector` API signature requires the `text:` keyword argument (https://www.rubydoc.info/github/teamcapybara/capybara/master/Capybara%2FNode%2FMatchers:assert_selector).

This simply updates the README to use it.