### PR TITLE
Add rendered_component method to ViewComponent::TestHelpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # master
 
+* Add `rendered_component` method to `ViewComponent::TestHelpers` which exposes the raw output of the rendered component.
+
+    *Richard Macklin*
+
 # 2.6.0
 
 * Add `config.view_component.preview_route` to set the endpoint for component previews. By default `/rails/view_components` is used.

--- a/README.md
+++ b/README.md
@@ -387,7 +387,7 @@ class MyComponentTest < ViewComponent::TestCase
 end
 ```
 
-In the absence of `capybara`, assertion against the return values of `render_inline`, which is an instance of `Nokogiri::HTML::DocumentFragment`:
+In the absence of `capybara`, assert against the return value of `render_inline`, which is an instance of `Nokogiri::HTML::DocumentFragment`:
 
 ```ruby
 test "render component" do

--- a/README.md
+++ b/README.md
@@ -397,6 +397,16 @@ test "render component" do
 end
 ```
 
+Alternatively, assert against the raw output of the component, which is exposed as `rendered_component`:
+
+```ruby
+test "render component" do
+  render_inline(TestComponent.new(title: "my title")) { "Hello, World!" }
+
+  assert_includes rendered_component, "Hello, World!"
+end
+```
+
 #### Action Pack Variants
 
 Use the `with_variant` helper to test specific variants:

--- a/lib/view_component/test_helpers.rb
+++ b/lib/view_component/test_helpers.rb
@@ -7,7 +7,7 @@ module ViewComponent
       include Capybara::Minitest::Assertions
 
       def page
-        Capybara::Node::Simple.new(@raw)
+        Capybara::Node::Simple.new(@rendered_component)
       end
 
       def refute_component_rendered
@@ -18,9 +18,9 @@ module ViewComponent
     end
 
     def render_inline(component, **args, &block)
-      @raw = controller.view_context.render(component, args, &block)
+      @rendered_component = controller.view_context.render(component, args, &block)
 
-      Nokogiri::HTML.fragment(@raw)
+      Nokogiri::HTML.fragment(@rendered_component)
     end
 
     def controller

--- a/lib/view_component/test_helpers.rb
+++ b/lib/view_component/test_helpers.rb
@@ -17,6 +17,8 @@ module ViewComponent
       warn "WARNING in `ViewComponent::TestHelpers`: You must add `capybara` to your Gemfile to use Capybara assertions."
     end
 
+    attr_reader :rendered_component
+
     def render_inline(component, **args, &block)
       @rendered_component = controller.view_context.render(component, args, &block)
 

--- a/test/view_component/view_component_test.rb
+++ b/test/view_component/view_component_test.rb
@@ -9,6 +9,10 @@ class ViewComponentTest < ViewComponent::TestCase
     assert_selector("div", text: "hello,world!")
   end
 
+  def test_render_inline_returns_nokogiri_fragment
+    assert_includes render_inline(MyComponent.new).css("div").to_html, "hello,world!"
+  end
+
   def test_child_component
     render_inline(ChildComponent.new)
 

--- a/test/view_component/view_component_test.rb
+++ b/test/view_component/view_component_test.rb
@@ -13,6 +13,12 @@ class ViewComponentTest < ViewComponent::TestCase
     assert_includes render_inline(MyComponent.new).css("div").to_html, "hello,world!"
   end
 
+  def test_render_inline_sets_rendered_component
+    render_inline(MyComponent.new)
+
+    assert_includes rendered_component, "hello,world!"
+  end
+
   def test_child_component
     render_inline(ChildComponent.new)
 


### PR DESCRIPTION
### Summary

As discussed in https://github.com/github/view_component/issues/304#issuecomment-629468829, this PR renames `@raw` to `@rendered_component` and exposes a `rendered_component` reader.

With this method, it becomes possible to write the following expectation in an rspec-rails view spec:
```rb
expect(rendered_component).to have_css("header h1", text: "Buy milk")
```
which mirrors the example code from Capybara's README:
https://github.com/teamcapybara/capybara/blame/3.32.1/README.md#L235

I also backfilled some test coverage for the return value of `render_inline`. This seemed appropriate given that we started documenting it in the README in https://github.com/github/view_component/commit/18d4569721457a34ae4c2096cb2b0a0c36570637. (I should've added this test when I was working on https://github.com/github/view_component/pull/298.)