### PR TITLE
[338] Previewing examples with contextual HTML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # master
 
-* Add support for templates as preview examples
+* Add support for templates as ViewComponent::Preview examples.
 
     *Juan Manuel Ramallo
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # master
 
-* Add support to use templates as preview examples
+* Add support for templates as preview examples
 
     *Juan Manuel Ramallo
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # master
 
+* Add support to use templates as preview examples
+
+    *Juan Manuel Ramallo
+
 # 2.14.1
 
 * Allow using `render_inline` in test when the render monkey patch is disabled with `config.view_component.render_monkey_patch_enabled = false` in versions of Rails < 6.1.

--- a/README.md
+++ b/README.md
@@ -681,6 +681,7 @@ config.view_component.preview_route = "/previews"
 This example will make the previews available from <http://localhost:3000/previews>.
 
 #### Adding contextual HTML for previews
+
 Given the preview component lives in `test/components/previews/cell_component_preview.rb`, template files can be defined at `test/components/previews/cell_component_preview/`.
 
 `test/components/previews/cell_component_preview.rb`

--- a/README.md
+++ b/README.md
@@ -704,7 +704,7 @@ end
 </div>
 ```
 
-If you'd rather use a different location for your custom preview templates, you can pass a path in the `template` argument
+To use a different location for preview templates, pass the `template` argument:
 (the path should be relative to your `config.view_component.preview_path`):
 
 `test/components/previews/cell_component_preview.rb`

--- a/README.md
+++ b/README.md
@@ -687,6 +687,7 @@ Given the preview component lives in `test/components/previews/cell_component_pr
 ```ruby
 class CellComponentPreview < ViewComponent::Preview
   def default
+    render_with_template
   end
 end
 ```
@@ -701,6 +702,34 @@ end
   </tbody>
 </div>
 ```
+
+If you'd rather use a different location for your custom preview templates, you can pass a path in the `template` argument
+(the path should be relative to your `config.view_component.preview_path`):
+
+`test/components/previews/cell_component_preview.rb`
+```ruby
+class CellComponentPreview < ViewComponent::Preview
+  def default
+    render_with_template(template: 'custom_cell_component_preview/my_preview_template')
+  end
+end
+```
+
+To use dynamic values from the params you can use the `locals` argument:
+
+`test/components/previews/cell_component_preview.rb`
+```ruby
+class CellComponentPreview < ViewComponent::Preview
+  def default(title: "Default title", subtitle: "A subtitle")
+    render_with_template(locals: {
+      title: title,
+      subtitle: subtitle
+    })
+  end
+end
+```
+
+Which enables passing in a value with <http://localhost:3000/rails/components/cell_component/default?title=Custom+title&subtitle=Another+subtitle>.
 
 #### Configuring TestController
 

--- a/README.md
+++ b/README.md
@@ -682,7 +682,7 @@ This example will make the previews available from <http://localhost:3000/previe
 
 #### Adding contextual HTML for previews
 
-Given the preview component lives in `test/components/previews/cell_component_preview.rb`, template files can be defined at `test/components/previews/cell_component_preview/`.
+Given a preview component`test/components/previews/cell_component_preview.rb`, template files can be defined at `test/components/previews/cell_component_preview/`:
 
 `test/components/previews/cell_component_preview.rb`
 ```ruby

--- a/README.md
+++ b/README.md
@@ -688,7 +688,6 @@ Given a preview component`test/components/previews/cell_component_preview.rb`, t
 ```ruby
 class CellComponentPreview < ViewComponent::Preview
   def default
-    render_with_template
   end
 end
 ```

--- a/README.md
+++ b/README.md
@@ -680,9 +680,9 @@ config.view_component.preview_route = "/previews"
 
 This example will make the previews available from <http://localhost:3000/previews>.
 
-#### Adding contextual HTML for previews
+#### Preview templates
 
-Given a preview component`test/components/previews/cell_component_preview.rb`, template files can be defined at `test/components/previews/cell_component_preview/`:
+Given a preview `test/components/previews/cell_component_preview.rb`, template files can be defined at `test/components/previews/cell_component_preview/`:
 
 `test/components/previews/cell_component_preview.rb`
 ```ruby

--- a/README.md
+++ b/README.md
@@ -680,6 +680,28 @@ config.view_component.preview_route = "/previews"
 
 This example will make the previews available from <http://localhost:3000/previews>.
 
+#### Adding contextual HTML for previews
+Given the preview component lives in `test/components/previews/cell_component_preview.rb`, template files can be defined at `test/components/previews/cell_component_preview/`.
+
+`test/components/previews/cell_component_preview.rb`
+```ruby
+class CellComponentPreview < ViewComponent::Preview
+  def default
+  end
+end
+```
+
+`test/components/previews/cell_component_preview/default.html.erb`
+```erb
+<table class="table">
+  <tbody>
+    <tr>
+      <%= render CellComponent.new %>
+    </tr>
+  </tbody>
+</div>
+```
+
 #### Configuring TestController
 
 Component tests and previews assume the existence of an `ApplicationController` class, which be can be configured using the `test_controller` option:

--- a/README.md
+++ b/README.md
@@ -716,7 +716,7 @@ class CellComponentPreview < ViewComponent::Preview
 end
 ```
 
-To use dynamic values from the params you can use the `locals` argument:
+Values from `params` can be accessed through `locals`:
 
 `test/components/previews/cell_component_preview.rb`
 ```ruby

--- a/README.md
+++ b/README.md
@@ -705,7 +705,7 @@ end
 ```
 
 To use a different location for preview templates, pass the `template` argument:
-(the path should be relative to your `config.view_component.preview_path`):
+(the path should be relative to `config.view_component.preview_path`):
 
 `test/components/previews/cell_component_preview.rb`
 ```ruby

--- a/app/controllers/view_components_controller.rb
+++ b/app/controllers/view_components_controller.rb
@@ -30,8 +30,9 @@ class ViewComponentsController < Rails::ApplicationController # :nodoc:
       layout = @render_args[:layout]
       template = @render_args[:template]
       locals = @render_args[:locals]
-      opts = layout.nil? ? {} : { layout: layout }
-      opts[:locals] = locals
+      opts = {}
+      opts[:layout] = layout if layout.present?
+      opts[:locals] = locals if locals.present?
       render template, opts # rubocop:disable GitHub/RailsControllerRenderLiteral
     end
   end

--- a/app/controllers/view_components_controller.rb
+++ b/app/controllers/view_components_controller.rb
@@ -28,7 +28,7 @@ class ViewComponentsController < Rails::ApplicationController # :nodoc:
       @render_args = @preview.render_args(@example_name, params: params.permit!)
       layout = @render_args[:layout]
       opts = layout.nil? ? {} : { layout: layout }
-      render "view_components/preview", opts
+      render template_path, opts # rubocop:disable GitHub/RailsControllerRenderLiteral
     end
   end
 
@@ -56,7 +56,20 @@ class ViewComponentsController < Rails::ApplicationController # :nodoc:
     end
   end
 
+  def template_path
+    if @preview.preview_example_template?(@example_name)
+      prepend_preview_examples_view_path
+      @preview.preview_example_template_path(@example_name)
+    else
+      "view_components/preview"
+    end
+  end
+
   def prepend_application_view_paths
     prepend_view_path Rails.root.join("app/views") if defined?(Rails.root)
+  end
+
+  def prepend_preview_examples_view_path
+    prepend_view_path(ViewComponent::Base.preview_path)
   end
 end

--- a/app/controllers/view_components_controller.rb
+++ b/app/controllers/view_components_controller.rb
@@ -57,9 +57,9 @@ class ViewComponentsController < Rails::ApplicationController # :nodoc:
   end
 
   def template_path
-    if @preview.preview_example_template?(@example_name)
+    if (path = @preview.preview_example_template_path(@example_name))
       prepend_preview_examples_view_path
-      @preview.preview_example_template_path(@example_name)
+      path
     else
       "view_components/preview"
     end

--- a/app/controllers/view_components_controller.rb
+++ b/app/controllers/view_components_controller.rb
@@ -57,7 +57,8 @@ class ViewComponentsController < Rails::ApplicationController # :nodoc:
   end
 
   def template_path
-    if (path = @preview.preview_example_template_path(@example_name))
+    path = @preview.preview_example_template_path(@example_name)
+    if path.present?
       prepend_preview_examples_view_path
       path
     else

--- a/app/controllers/view_components_controller.rb
+++ b/app/controllers/view_components_controller.rb
@@ -24,11 +24,15 @@ class ViewComponentsController < Rails::ApplicationController # :nodoc:
       render "view_components/previews"
     else
       prepend_application_view_paths
+      prepend_preview_examples_view_path
       @example_name = File.basename(params[:path])
       @render_args = @preview.render_args(@example_name, params: params.permit!)
       layout = @render_args[:layout]
+      template = @render_args[:template]
+      locals = @render_args[:locals]
       opts = layout.nil? ? {} : { layout: layout }
-      render template_path, opts # rubocop:disable GitHub/RailsControllerRenderLiteral
+      opts[:locals] = locals
+      render template, opts # rubocop:disable GitHub/RailsControllerRenderLiteral
     end
   end
 
@@ -53,16 +57,6 @@ class ViewComponentsController < Rails::ApplicationController # :nodoc:
   def set_locale
     I18n.with_locale(params[:locale] || I18n.default_locale) do
       yield
-    end
-  end
-
-  def template_path
-    path = @preview.preview_example_template_path(@example_name)
-    if path.present?
-      prepend_preview_examples_view_path
-      path
-    else
-      "view_components/preview"
     end
   end
 

--- a/app/controllers/view_components_controller.rb
+++ b/app/controllers/view_components_controller.rb
@@ -66,6 +66,6 @@ class ViewComponentsController < Rails::ApplicationController # :nodoc:
   end
 
   def prepend_preview_examples_view_path
-    prepend_view_path(ViewComponent::Base.preview_path)
+    prepend_view_path(ViewComponent::Base.preview_paths)
   end
 end

--- a/coverage/coverage.txt
+++ b/coverage/coverage.txt
@@ -2,10 +2,10 @@
 Incomplete test coverage
 --------------------------------------------------------------------------------
 
-/app/controllers/view_components_controller.rb: 97.22% (missed: 49)
+/app/controllers/view_components_controller.rb: 97.67% (missed: 54)
 /lib/view_component/base.rb: 97.86% (missed: 178,265,293,356)
 /lib/view_component/engine.rb: 94.64% (missed: 22,25,38)
-/lib/view_component/preview.rb: 92.31% (missed: 32,42,78)
+/lib/view_component/preview.rb: 94.0% (missed: 47,57,107)
 /lib/view_component/render_to_string_monkey_patch.rb: 83.33% (missed: 9)
-/lib/view_component/test_helpers.rb: 95.45% (missed: 17)
-/test/view_component/integration_test.rb: 96.12% (missed: 14,15,16,18,20,365,366,367,369)
+/lib/view_component/test_helpers.rb: 91.67% (missed: 17,25)
+/test/view_component/integration_test.rb: 96.69% (missed: 14,15,16,18,20,365,366,367,369)

--- a/lib/view_component.rb
+++ b/lib/view_component.rb
@@ -7,6 +7,7 @@ module ViewComponent
 
   autoload :Base
   autoload :Preview
+  autoload :PreviewTemplateError
   autoload :TestHelpers
   autoload :TestCase
   autoload :TemplateError

--- a/lib/view_component/preview.rb
+++ b/lib/view_component/preview.rb
@@ -24,7 +24,7 @@ module ViewComponent # :nodoc:
         provided_params = params.slice(*example_params_names).to_h.symbolize_keys
         result = provided_params.empty? ? new.public_send(example) : new.public_send(example, **provided_params)
         @layout = nil unless defined?(@layout)
-        result.merge(layout: @layout)
+        { layout: @layout }.tap { |args| args.merge!(result) if result }
       end
 
       # Returns the component object class associated to the preview.
@@ -60,6 +60,21 @@ module ViewComponent # :nodoc:
       # Setter for layout name.
       def layout(layout_name)
         @layout = layout_name
+      end
+
+      # Returns +true+ if the preview example has a template
+      def preview_example_template?(example)
+        return false unless example_exists?(example)
+
+        preview_example_template_path(example).present?
+      end
+
+      # Returns the relative path (from preview_path) to the preview example template if any
+      def preview_example_template_path(example)
+        path = Dir["#{preview_path}/#{preview_name}_preview/#{example}.html.erb"].first
+        return nil unless path
+
+        Pathname.new(path).relative_path_from(preview_path).to_s
       end
 
       private

--- a/lib/view_component/preview.rb
+++ b/lib/view_component/preview.rb
@@ -70,7 +70,7 @@ module ViewComponent # :nodoc:
         path = Dir["#{preview_path}/#{preview_name}_preview/#{example}.html.erb"].first
         return nil unless path
 
-        Pathname.new(path).relative_path_from(preview_path).to_s
+        Pathname.new(path).relative_path_from(Pathname.new(preview_path)).to_s
       end
 
       private

--- a/lib/view_component/preview.rb
+++ b/lib/view_component/preview.rb
@@ -8,7 +8,20 @@ module ViewComponent # :nodoc:
     extend ActiveSupport::DescendantsTracker
 
     def render(component, **args, &block)
-      { component: component, args: args, block: block }
+      {
+        args: args,
+        block: block,
+        component: component,
+        locals: {},
+        template: "view_components/preview",
+      }
+    end
+
+    def render_with_template(template: nil, locals: {})
+      {
+        template: template,
+        locals: locals
+      }
     end
 
     class << self
@@ -23,8 +36,8 @@ module ViewComponent # :nodoc:
         example_params_names = instance_method(example).parameters.map(&:last)
         provided_params = params.slice(*example_params_names).to_h.symbolize_keys
         result = provided_params.empty? ? new.public_send(example) : new.public_send(example, **provided_params)
+        result[:template] = preview_example_template_path(example) if result[:template].nil?
         @layout = nil unless defined?(@layout)
-        result ||= {}
         result.merge(layout: @layout)
       end
 
@@ -63,12 +76,10 @@ module ViewComponent # :nodoc:
         @layout = layout_name
       end
 
-      # Returns the relative path (from preview_path) to the preview example template if the example and template exists
+      # Returns the relative path (from preview_path) to the preview example template if the template exists
       def preview_example_template_path(example)
-        return nil unless example_exists?(example)
-
-        path = Dir["#{preview_path}/#{preview_name}_preview/#{example}.html.erb"].first
-        return nil unless path
+        path = Dir["#{preview_path}/#{preview_name}_preview/#{example}.html.*"].first
+        raise PreviewTemplateError, "preview template for example #{example} does not exist" unless path
 
         Pathname.new(path).relative_path_from(Pathname.new(preview_path)).to_s
       end

--- a/lib/view_component/preview.rb
+++ b/lib/view_component/preview.rb
@@ -36,6 +36,7 @@ module ViewComponent # :nodoc:
         example_params_names = instance_method(example).parameters.map(&:last)
         provided_params = params.slice(*example_params_names).to_h.symbolize_keys
         result = provided_params.empty? ? new.public_send(example) : new.public_send(example, **provided_params)
+        result ||= {}
         result[:template] = preview_example_template_path(example) if result[:template].nil?
         @layout = nil unless defined?(@layout)
         result.merge(layout: @layout)

--- a/lib/view_component/preview.rb
+++ b/lib/view_component/preview.rb
@@ -24,7 +24,8 @@ module ViewComponent # :nodoc:
         provided_params = params.slice(*example_params_names).to_h.symbolize_keys
         result = provided_params.empty? ? new.public_send(example) : new.public_send(example, **provided_params)
         @layout = nil unless defined?(@layout)
-        { layout: @layout }.tap { |args| args.merge!(result) if result }
+        result ||= {}
+        result.merge(layout: @layout)
       end
 
       # Returns the component object class associated to the preview.

--- a/lib/view_component/preview.rb
+++ b/lib/view_component/preview.rb
@@ -62,15 +62,10 @@ module ViewComponent # :nodoc:
         @layout = layout_name
       end
 
-      # Returns +true+ if the preview example has a template
-      def preview_example_template?(example)
-        return false unless example_exists?(example)
-
-        preview_example_template_path(example).present?
-      end
-
-      # Returns the relative path (from preview_path) to the preview example template if any
+      # Returns the relative path (from preview_path) to the preview example template if the example and template exists
       def preview_example_template_path(example)
+        return nil unless example_exists?(example)
+
         path = Dir["#{preview_path}/#{preview_name}_preview/#{example}.html.erb"].first
         return nil unless path
 

--- a/lib/view_component/preview.rb
+++ b/lib/view_component/preview.rb
@@ -79,9 +79,15 @@ module ViewComponent # :nodoc:
 
       # Returns the relative path (from preview_path) to the preview example template if the template exists
       def preview_example_template_path(example)
-        path = Dir["#{preview_path}/#{preview_name}_preview/#{example}.html.*"].first
-        raise PreviewTemplateError, "preview template for example #{example} does not exist" unless path
+        preview_path = Array(preview_paths).detect do |preview_path|
+          Dir["#{preview_path}/#{preview_name}_preview/#{example}.html.*"].first
+        end
 
+        if preview_path.nil?
+          raise PreviewTemplateError, "preview template for example #{example} does not exist"
+        end
+
+        path = Dir["#{preview_path}/#{preview_name}_preview/#{example}.html.*"].first
         Pathname.new(path).relative_path_from(Pathname.new(preview_path)).to_s
       end
 

--- a/lib/view_component/preview_template_error.rb
+++ b/lib/view_component/preview_template_error.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+module ViewComponent
+  class PreviewTemplateError < StandardError
+  end
+end

--- a/test/test/components/previews/inline_component_preview.rb
+++ b/test/test/components/previews/inline_component_preview.rb
@@ -6,11 +6,9 @@ class InlineComponentPreview < ViewComponent::Preview
   end
 
   def inside_form
-    render_with_template
   end
 
   def outside_form
-    render_with_template
   end
 
   def with_params(form_title: "Default Form Title")

--- a/test/test/components/previews/inline_component_preview.rb
+++ b/test/test/components/previews/inline_component_preview.rb
@@ -6,8 +6,36 @@ class InlineComponentPreview < ViewComponent::Preview
   end
 
   def inside_form
+    render_with_template
   end
 
   def outside_form
+    render_with_template
+  end
+
+  def with_params(form_title: "Default Form Title")
+    render_with_template(locals: { form_title: form_title })
+  end
+
+  def with_non_standard_template
+    render_with_template(template: "non_standard_path/with_non_standard_template")
+  end
+
+  def with_haml
+    render_with_template
+  end
+
+  def without_template
+    render_with_template
+  end
+
+  def with_several_options(form_title: "Another default")
+    render_with_template(
+      template: "non_standard_path/test_template",
+      locals: {
+        form_title: form_title,
+        submit_text: "Send this form!"
+      }
+    )
   end
 end

--- a/test/test/components/previews/inline_component_preview.rb
+++ b/test/test/components/previews/inline_component_preview.rb
@@ -20,7 +20,6 @@ class InlineComponentPreview < ViewComponent::Preview
   end
 
   def with_haml
-    render_with_template
   end
 
   def without_template

--- a/test/test/components/previews/inline_component_preview.rb
+++ b/test/test/components/previews/inline_component_preview.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class InlineComponentPreview < ViewComponent::Preview
+  def default
+    render(InlineComponent.new)
+  end
+
+  def inside_form
+  end
+
+  def outside_form
+  end
+end

--- a/test/test/components/previews/inline_component_preview/inside_form.html.erb
+++ b/test/test/components/previews/inline_component_preview/inside_form.html.erb
@@ -1,0 +1,4 @@
+<form>
+  <p>Inside Form</p>
+  <%= render InlineComponent.new %>
+</form>

--- a/test/test/components/previews/inline_component_preview/outside_form.html.erb
+++ b/test/test/components/previews/inline_component_preview/outside_form.html.erb
@@ -1,0 +1,4 @@
+<div>
+  <p>Outside Form</p>
+  <%= render InlineComponent.new %>
+</div>

--- a/test/test/components/previews/inline_component_preview/with_haml.html.haml
+++ b/test/test/components/previews/inline_component_preview/with_haml.html.haml
@@ -1,0 +1,2 @@
+%h1 Some HAML here
+= render(InlineComponent.new)

--- a/test/test/components/previews/inline_component_preview/with_params.html.erb
+++ b/test/test/components/previews/inline_component_preview/with_params.html.erb
@@ -1,0 +1,4 @@
+<form>
+  <p><%= form_title %></p>
+  <%= render InlineComponent.new %>
+</form>

--- a/test/test/components/previews/my_component_preview.rb
+++ b/test/test/components/previews/my_component_preview.rb
@@ -8,5 +8,6 @@ class MyComponentPreview < ViewComponent::Preview
   end
 
   def inside_banner
+    render_with_template
   end
 end

--- a/test/test/components/previews/my_component_preview.rb
+++ b/test/test/components/previews/my_component_preview.rb
@@ -6,4 +6,7 @@ class MyComponentPreview < ViewComponent::Preview
   def default
     render(MyComponent.new)
   end
+
+  def inside_banner
+  end
 end

--- a/test/test/components/previews/my_component_preview/inside_banner.html.erb
+++ b/test/test/components/previews/my_component_preview/inside_banner.html.erb
@@ -1,0 +1,3 @@
+<div class="banner">
+  <%= render MyComponent.new %>
+</div>

--- a/test/test/components/previews/non_standard_path/test_template.html.haml
+++ b/test/test/components/previews/non_standard_path/test_template.html.haml
@@ -1,0 +1,4 @@
+%form
+  %h1= form_title
+  = render(InlineComponent.new)
+  %input{type: 'submit', value: "#{submit_text}"}

--- a/test/test/components/previews/non_standard_path/with_non_standard_template.html.erb
+++ b/test/test/components/previews/non_standard_path/with_non_standard_template.html.erb
@@ -1,0 +1,2 @@
+<h1>This is not a standard place to have a preview template</h1>
+<%= render InlineComponent.new %>

--- a/test/view_component/integration_test.rb
+++ b/test/view_component/integration_test.rb
@@ -386,4 +386,31 @@ class IntegrationTest < ActionDispatch::IntegrationTest
       assert_includes response.body, "bar"
     end
   end
+
+  test "renders the inline component preview examples with default behaviour and with their own templates" do
+    get "/rails/view_components/inline_component/default"
+    assert_select "input" do
+      assert_select "[name=?]", "name"
+    end
+
+    get "/rails/view_components/inline_component/inside_form"
+    assert_select "form" do
+      assert_select "p", "Inside Form"
+      assert_select "input[name=?]", "name"
+    end
+
+    get "/rails/view_components/inline_component/outside_form"
+    assert_select "div" do
+      assert_select "p", "Outside Form"
+      assert_select "input[name=?]", "name"
+    end
+  end
+
+  test "render the preview example with its own template and a layout" do
+    get "/rails/view_components/my_component/inside_banner"
+    assert_includes response.body, "ViewComponent - Admin - Test"
+    assert_select ".banner" do
+      assert_select("div", "hello,world!")
+    end
+  end
 end

--- a/test/view_component/integration_test.rb
+++ b/test/view_component/integration_test.rb
@@ -406,11 +406,48 @@ class IntegrationTest < ActionDispatch::IntegrationTest
     end
   end
 
-  test "render the preview example with its own template and a layout" do
+  test "renders the preview example with its own template and a layout" do
     get "/rails/view_components/my_component/inside_banner"
     assert_includes response.body, "ViewComponent - Admin - Test"
     assert_select ".banner" do
       assert_select("div", "hello,world!")
+    end
+  end
+
+  test "renders an inline component preview using URL params and a template" do
+    get "/rails/view_components/inline_component/with_params?form_title=This is a test form"
+    assert_select "form" do
+      assert_select "p", "This is a test form"
+      assert_select "input[name=?]", "name"
+    end
+  end
+
+  test "renders the inline component using a non standard-located template" do
+    get "/rails/view_components/inline_component/with_non_standard_template"
+    assert_select "h1", "This is not a standard place to have a preview template"
+    assert_select "input[name=?]", "name"
+  end
+
+  test "renders an inline component preview using a HAML template" do
+    get "/rails/view_components/inline_component/with_haml"
+    assert_select "h1", "Some HAML here"
+    assert_select "input[name=?]", "name"
+  end
+
+  test "raises an error if the template is not present and the render_with_template method is used in the example" do
+    error = assert_raises ViewComponent::PreviewTemplateError do
+      get "/rails/view_components/inline_component/without_template"
+    end
+    assert_match /preview template for example without_template does not exist/, error.message
+  end
+
+  test "renders a preview template using HAML, params from URL, custom template and locals" do
+    get "/rails/view_components/inline_component/with_several_options?form_title=Title from params"
+
+    assert_select "form" do
+      assert_select "h1", "Title from params"
+      assert_select "input[name=?]", "name"
+      assert_select "input[value=?]", "Send this form!"
     end
   end
 end


### PR DESCRIPTION
Fixes #338 (or at least trying to)
<!-- See https://github.com/github/view_component/blob/master/CONTRIBUTING.md#submitting-a-pull-request  -->

### Summary
- Updated preview object to know about preview example templates
- Updated controller to render the actual preview example template if any
- Added specs

An example of usage would be:

`test/components/previews/cell_component_preview.rb`
```ruby
class CellComponentPreview < ViewComponent::Preview
  def normal
    render_with_template
  end
end
```

`test/components/previews/cell_component_preview/normal.html.erb`
```erb
<table class="table">
  <%= render CellComponent.new %>
</table>
```

Then the CellComponent preview would be available at the same path, but it will actually render the normal template. 

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

### To-do

- [x] Add tests

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file. -->
