### PR TITLE
Add `before_render`, deprecating `before_render_check`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # master
 
+* Add `before_render`, deprecating `before_render_check`.
+
+    *Joel Hawksley*
+
 # 2.7.0
 
 * Add `rendered_component` method to `ViewComponent::TestHelpers` which exposes the raw output of the rendered component.

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ end
 
 ### Sidecar Assets
 
-ViewComponents supports two options for defining view files. 
+ViewComponents supports two options for defining view files.
 
 #### Sidecar view
 
@@ -273,6 +273,19 @@ end
 ```
 
 _To assert that a component has not been rendered, use `refute_component_rendered` from `ViewComponent::TestHelpers`._
+
+### `before_render`
+
+Components can define a `before_render` method to be called before a component is rendered, when `helpers` is able to be used:
+
+`app/components/confirm_email_component.rb`
+```ruby
+class MyComponent < ViewComponent::Base
+  def before_render
+    @my_icon = helpers.star_icon
+  end
+end
+```
 
 ### Rendering collections
 

--- a/coverage/coverage.txt
+++ b/coverage/coverage.txt
@@ -3,7 +3,7 @@ Incomplete test coverage
 --------------------------------------------------------------------------------
 
 /app/controllers/view_components_controller.rb: 97.22% (missed: 49)
-/lib/view_component/base.rb: 97.7% (missed: 165,244,272,322)
+/lib/view_component/base.rb: 97.75% (missed: 169,254,282,332)
 /lib/view_component/preview.rb: 92.31% (missed: 32,42,78)
 /lib/view_component/render_to_string_monkey_patch.rb: 83.33% (missed: 9)
 /lib/view_component/test_helpers.rb: 95.45% (missed: 17)

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -66,7 +66,7 @@ module ViewComponent
       # Assign captured content passed to component as a block to @content
       @content = view_context.capture(self, &block) if block_given?
 
-      before_render_check
+      before_render
 
       if render?
         send(self.class.call_method_name(@variant))
@@ -75,6 +75,10 @@ module ViewComponent
       end
     ensure
       @current_template = old_current_template
+    end
+
+    def before_render
+      before_render_check
     end
 
     def before_render_check
@@ -203,6 +207,12 @@ module ViewComponent
         if template_errors.present?
           raise ViewComponent::TemplateError.new(template_errors) if raise_errors
           return false
+        end
+
+        if instance_methods(false).include?(:before_render_check)
+          ActiveSupport::Deprecation.warn(
+            "`before_render_check` will be removed in v3.0.0. Use `before_render` instead."
+          )
         end
 
         # Remove any existing singleton methods,

--- a/test/app/components/no_validations_component.html.erb
+++ b/test/app/components/no_validations_component.html.erb
@@ -1,1 +1,0 @@
-<div><%= content %></div>

--- a/test/app/components/no_validations_component.rb
+++ b/test/app/components/no_validations_component.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-class NoValidationsComponent < ViewComponent::Base
-  def before_render_check
-    #noop
-  end
-end

--- a/test/app/components/old_validations_component.html.erb
+++ b/test/app/components/old_validations_component.html.erb
@@ -1,0 +1,1 @@
+<span><%= content %></span>

--- a/test/app/components/old_validations_component.rb
+++ b/test/app/components/old_validations_component.rb
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
 
-class ValidationsComponent < ViewComponent::Base
+# TODO: Remove in v3.0.0
+class OldValidationsComponent < ViewComponent::Base
   include ActiveModel::Validations
 
   validates :content, presence: true
 
-  def before_render
+  def before_render_check
     validate!
   end
 end

--- a/test/view_component/view_component_test.rb
+++ b/test/view_component/view_component_test.rb
@@ -381,6 +381,15 @@ class ViewComponentTest < ViewComponent::TestCase
     assert_equal exception.message, "Validation failed: Content can't be blank"
   end
 
+  # TODO: Remove in v3.0.0
+  def test_before_render_check
+    exception = assert_raises ActiveModel::ValidationError do
+      render_inline(OldValidationsComponent.new)
+    end
+
+    assert_equal exception.message, "Validation failed: Content can't be blank"
+  end
+
   def test_compiles_unreferenced_component
     assert UnreferencedComponent.compiled?
   end

--- a/test/view_component/view_component_test.rb
+++ b/test/view_component/view_component_test.rb
@@ -373,12 +373,6 @@ class ViewComponentTest < ViewComponent::TestCase
     assert_selector("div")
   end
 
-  def test_no_validations_component
-    render_inline(NoValidationsComponent.new)
-
-    assert_selector("div")
-  end
-
   def test_validations_component
     exception = assert_raises ActiveModel::ValidationError do
       render_inline(ValidationsComponent.new)


### PR DESCRIPTION
`before_render_check`, an API we never documented,
is a confusing name for this lifecycle method.

`before_render` matches the naming conventions
for Rails callbacks.

Related issue: https://github.com/github/view_component/issues/346