### PR TITLE
DOC: Add example of testing for with_content_areas

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,6 +439,21 @@ test "render component" do
 end
 ```
 
+To test components that use `with_content_areas`:
+
+```ruby
+test "renders content_areas template with content " do
+  render_inline(ContentAreasComponent.new(footer: "Bye!")) do |component|
+    component.with(:title, "Hello!")
+    component.with(:body) { "Have a nice day." }
+  end
+
+  assert_selector(".title", text: "Hello!")
+  assert_selector(".body", text: "Have a nice day.")
+  assert_selector(".footer", text: "Bye!")
+end
+```
+
 #### Action Pack Variants
 
 Use the `with_variant` helper to test specific variants:


### PR DESCRIPTION
CHANGES
Just added a small documentation change to the testing section of README.md. Provided an example of testing a component that uses `with_content_areas`. I just grabbed the example from the actual tests.

<!-- See https://github.com/github/view_component/blob/master/CONTRIBUTING.md#submitting-a-pull-request  -->

### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file. -->
