### PR TITLE
Ruby parse errors throw confusing error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # master
 
+* Raise an `ArgumentError` with a helpful message when Ruby cannot parse a component class.
+
+    *Max Beizer*
+
 # 2.9.0
 
 * Cache components per-request in development, preventing unnecessary recompilation during a single request.

--- a/README.md
+++ b/README.md
@@ -783,6 +783,11 @@ ViewComponent is built by:
 |@simonrand|@fugufish|@cover|@franks921|@fsateler|
 |Dublin, Ireland|Salt Lake City, Utah|Barcelona|South Africa|Chile|
 
+|<img src="https://avatars.githubusercontent.com/maxbeizer?s=256" alt="maxbeizer" width="128" />|
+|:---:|
+|@maxbeizer|
+|Nashville, TN|
+
 ## License
 
 ViewComponent is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).

--- a/coverage/coverage.txt
+++ b/coverage/coverage.txt
@@ -3,7 +3,7 @@ Incomplete test coverage
 --------------------------------------------------------------------------------
 
 /app/controllers/view_components_controller.rb: 97.22% (missed: 49)
-/lib/view_component/base.rb: 97.78% (missed: 170,253,281,331)
+/lib/view_component/base.rb: 97.8% (missed: 169,254,282,343)
 /lib/view_component/preview.rb: 92.31% (missed: 32,42,78)
 /lib/view_component/render_to_string_monkey_patch.rb: 83.33% (missed: 9)
 /lib/view_component/test_helpers.rb: 95.65% (missed: 17)

--- a/coverage/coverage.txt
+++ b/coverage/coverage.txt
@@ -7,4 +7,5 @@ Incomplete test coverage
 /lib/view_component/preview.rb: 92.31% (missed: 32,42,78)
 /lib/view_component/render_to_string_monkey_patch.rb: 83.33% (missed: 9)
 /lib/view_component/test_helpers.rb: 95.65% (missed: 17)
+/test/app/components/product_reader_oops_component.rb: 50.0% (missed: 8,9)
 /test/view_component/integration_test.rb: 97.55% (missed: 14,15,16,18,20)

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -307,7 +307,14 @@ module ViewComponent
         parameter = validate_default ? collection_parameter : provided_collection_parameter
 
         return unless parameter
-        return if instance_method(:initialize).parameters.map(&:last).include?(parameter)
+        return if initialize_parameters.map(&:last).include?(parameter)
+
+        # See https://github.com/github/view_component/pull/364
+        if initialize_parameters.empty?
+          raise ArgumentError.new(
+            "#{self} initializer is empty or invalid."
+          )
+        end
 
         raise ArgumentError.new(
           "#{self} initializer must accept " \
@@ -316,6 +323,10 @@ module ViewComponent
       end
 
       private
+
+      def initialize_parameters
+        instance_method(:initialize).parameters
+      end
 
       def provided_collection_parameter
         @provided_collection_parameter ||= nil

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -309,7 +309,9 @@ module ViewComponent
         return unless parameter
         return if initialize_parameters.map(&:last).include?(parameter)
 
-        # See https://github.com/github/view_component/pull/364
+        # If Ruby cannot parse the component class, then the initalize
+        # parameters will be empty and ViewComponent will not be able to render
+        # the component.
         if initialize_parameters.empty?
           raise ArgumentError.new(
             "#{self} initializer is empty or invalid."

--- a/test/app/components/product_reader_oops_component.html.erb
+++ b/test/app/components/product_reader_oops_component.html.erb
@@ -1,0 +1,5 @@
+<li>
+  <h1>Product</h1>
+  <h2><%= product.name %></h2>
+  <p><%= notice %></p>
+</li>

--- a/test/app/components/product_reader_oops_component.html.erb
+++ b/test/app/components/product_reader_oops_component.html.erb
@@ -1,5 +1,1 @@
-<li>
-  <h1>Product</h1>
-  <h2><%= product.name %></h2>
-  <p><%= notice %></p>
-</li>
+<div>Hello, World!</div>

--- a/test/app/components/product_reader_oops_component.rb
+++ b/test/app/components/product_reader_oops_component.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class ProductReaderOopsComponent < ViewComponent::Base
+  attr_reader :product,
+              :notice,
+
+  def initialize(product_reader_oops:, notice:)
+    @product = product_reader_oops
+    @notice  = notice
+  end
+end

--- a/test/app/components/product_reader_oops_component.rb
+++ b/test/app/components/product_reader_oops_component.rb
@@ -4,8 +4,6 @@ class ProductReaderOopsComponent < ViewComponent::Base
   attr_reader :product,
               :notice,
 
-  def initialize(product_reader_oops:, notice:)
-    @product = product_reader_oops
-    @notice  = notice
+  def initialize(product_reader_oops:)
   end
 end

--- a/test/view_component/view_component_test.rb
+++ b/test/view_component/view_component_test.rb
@@ -533,17 +533,4 @@ class ViewComponentTest < ViewComponent::TestCase
 
     assert_match(/ProductReaderOopsComponent initializer is empty or invalid/, exception.message)
   end
-
-  private
-
-  def modify_file(file, content)
-    filename = Rails.root.join(file)
-    old_content = File.read(filename)
-    begin
-      File.open(filename, "wb+") { |f| f.write(content) }
-      yield
-    ensure
-      File.open(filename, "wb+") { |f| f.write(old_content) }
-    end
-  end
 end

--- a/test/view_component/view_component_test.rb
+++ b/test/view_component/view_component_test.rb
@@ -531,7 +531,7 @@ class ViewComponentTest < ViewComponent::TestCase
       )
     end
 
-    assert_match(/MissingDefaultCollectionParameterComponent initializer must accept `missing_default_collection_parameter` collection parameter/, exception.message)
+    refute_match(/ProductReaderOopsComponent initializer must accept `product_reader_oops` collection parameter/, exception.message)
   end
 
   private

--- a/test/view_component/view_component_test.rb
+++ b/test/view_component/view_component_test.rb
@@ -523,4 +523,27 @@ class ViewComponentTest < ViewComponent::TestCase
 
     assert_match(/MissingDefaultCollectionParameterComponent initializer must accept `missing_default_collection_parameter` collection parameter/, exception.message)
   end
+
+  def test_collection_component_with_trailing_comma_attr_rader
+    exception = assert_raises ArgumentError do
+      render_inline(
+        ProductReaderOopsComponent.with_collection([OpenStruct.new(name: "Mints")])
+      )
+    end
+
+    assert_match(/MissingDefaultCollectionParameterComponent initializer must accept `missing_default_collection_parameter` collection parameter/, exception.message)
+  end
+
+  private
+
+  def modify_file(file, content)
+    filename = Rails.root.join(file)
+    old_content = File.read(filename)
+    begin
+      File.open(filename, "wb+") { |f| f.write(content) }
+      yield
+    ensure
+      File.open(filename, "wb+") { |f| f.write(old_content) }
+    end
+  end
 end

--- a/test/view_component/view_component_test.rb
+++ b/test/view_component/view_component_test.rb
@@ -527,7 +527,7 @@ class ViewComponentTest < ViewComponent::TestCase
   def test_collection_component_with_trailing_comma_attr_reader
     exception = assert_raises ArgumentError do
       render_inline(
-        ProductReaderOopsComponent.with_collection([OpenStruct.new(name: "Mints")])
+        ProductReaderOopsComponent.with_collection(["foo"])
       )
     end
 

--- a/test/view_component/view_component_test.rb
+++ b/test/view_component/view_component_test.rb
@@ -524,14 +524,14 @@ class ViewComponentTest < ViewComponent::TestCase
     assert_match(/MissingDefaultCollectionParameterComponent initializer must accept `missing_default_collection_parameter` collection parameter/, exception.message)
   end
 
-  def test_collection_component_with_trailing_comma_attr_rader
+  def test_collection_component_with_trailing_comma_attr_reader
     exception = assert_raises ArgumentError do
       render_inline(
         ProductReaderOopsComponent.with_collection([OpenStruct.new(name: "Mints")])
       )
     end
 
-    refute_match(/ProductReaderOopsComponent initializer must accept `product_reader_oops` collection parameter/, exception.message)
+    assert_match(/ProductReaderOopsComponent initializer is empty or invalid/, exception.message)
   end
 
   private


### PR DESCRIPTION
### Summary

I ran into this fun today when I left a trailing comma on an `attr_reader`

If the Ruby class is invalid, the library should not fail with `initializer must accept ...` ArgumentErrors. Instead it should throw an error better explaining the issue.

Open question: is it valid to initialize a class for a view component without an initialize parameter? It seems like it should be 🤔 .

### Other Information
