### PR TITLE
Fixes 'Can't modify frozen autoload_paths' issue

### DIFF
--- a/lib/view_component/engine.rb
+++ b/lib/view_component/engine.rb
@@ -22,7 +22,7 @@ module ViewComponent
       end
     end
 
-    initializer "view_component.set_autoload_paths" do |app|
+    initializer "view_component.set_autoload_paths", before: :bootstrap_hook do |app|
       options = app.config.view_component
 
       if options.show_previews && options.preview_path


### PR DESCRIPTION
### Summary

This PR adds `before: :bootstrap_hook` to `view_component.set_autoload_paths` initializer as a way to avoid the app loading process crashing due to frozen autoload_paths as described in #365 

### Other Information

I'm not sure this is the right way to fix this issue but it was the only workaround I found to start using View Components in my Rails application. I'm more than open to do any change to this PR based on your guidance on the best way to fix this problem.

Fixes #365 
