### PR TITLE
Enabling caching in development, and discard on each request.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # master
 
+* Cache components per-request in development, preventing unnecessary recompilation during a single request.
+
+    *Felipe Sateler*
+
 # 2.8.0
 
 * Add `before_render`, deprecating `before_render_check`.

--- a/README.md
+++ b/README.md
@@ -780,7 +780,7 @@ ViewComponent is built by:
 
 |<img src="https://avatars.githubusercontent.com/simonrand?s=256" alt="simonrand" width="128" />|<img src="https://avatars.githubusercontent.com/fugufish?s=256" alt="fugufish" width="128" />|<img src="https://avatars.githubusercontent.com/cover?s=256" alt="cover" width="128" />|<img src="https://avatars.githubusercontent.com/franks921?s=256" alt="franks921" width="128" />|<img src="https://avatars.githubusercontent.com/fsateler?s=256" alt="fsateler" width="128" />|
 |:---:|:---:|:---:|:---:|:---:|
-|@simonrand|@fugufish|@cover|@franks921|fsateler|
+|@simonrand|@fugufish|@cover|@franks921|@fsateler|
 |Dublin, Ireland|Salt Lake City, Utah|Barcelona|South Africa|Chile|
 
 ## License

--- a/README.md
+++ b/README.md
@@ -778,10 +778,10 @@ ViewComponent is built by:
 |@blakewilliams|@seanpdoyle|@tclem|@nashby|@jaredcwhite|
 |Boston, MA|New York, NY|San Francisco, CA|Minsk|Portland, OR|
 
-|<img src="https://avatars.githubusercontent.com/simonrand?s=256" alt="simonrand" width="128" />|<img src="https://avatars.githubusercontent.com/fugufish?s=256" alt="fugufish" width="128" />|<img src="https://avatars.githubusercontent.com/cover?s=256" alt="cover" width="128" />|<img src="https://avatars.githubusercontent.com/franks921?s=256" alt="franks921" width="128" />|
-|:---:|:---:|:---:|:---:|
-|@simonrand|@fugufish|@cover|@franks921|
-|Dublin, Ireland|Salt Lake City, Utah|Barcelona|South Africa|
+|<img src="https://avatars.githubusercontent.com/simonrand?s=256" alt="simonrand" width="128" />|<img src="https://avatars.githubusercontent.com/fugufish?s=256" alt="fugufish" width="128" />|<img src="https://avatars.githubusercontent.com/cover?s=256" alt="cover" width="128" />|<img src="https://avatars.githubusercontent.com/franks921?s=256" alt="franks921" width="128" />|<img src="https://avatars.githubusercontent.com/fsateler?s=256" alt="fsateler" width="128" />|
+|:---:|:---:|:---:|:---:|:---:|
+|@simonrand|@fugufish|@cover|@franks921|fsateler|
+|Dublin, Ireland|Salt Lake City, Utah|Barcelona|South Africa|Chile|
 
 ## License
 

--- a/coverage/coverage.txt
+++ b/coverage/coverage.txt
@@ -3,8 +3,8 @@ Incomplete test coverage
 --------------------------------------------------------------------------------
 
 /app/controllers/view_components_controller.rb: 97.22% (missed: 49)
-/lib/view_component/base.rb: 97.75% (missed: 169,254,282,332)
+/lib/view_component/base.rb: 97.78% (missed: 170,253,281,331)
 /lib/view_component/preview.rb: 92.31% (missed: 32,42,78)
 /lib/view_component/render_to_string_monkey_patch.rb: 83.33% (missed: 9)
-/lib/view_component/test_helpers.rb: 95.45% (missed: 17)
-/test/view_component/integration_test.rb: 97.16% (missed: 14,15,16,18,20)
+/lib/view_component/test_helpers.rb: 95.65% (missed: 17)
+/test/view_component/integration_test.rb: 97.55% (missed: 14,15,16,18,20)

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -3,6 +3,7 @@
 require "action_view"
 require "active_support/configurable"
 require "view_component/collection"
+require "view_component/compile_cache"
 require "view_component/previewable"
 
 module ViewComponent
@@ -192,9 +193,7 @@ module ViewComponent
       end
 
       def compiled?
-        @compiled ||= false
-
-        @compiled && ActionView::Base.cache_template_loading
+        CompileCache.compiled?(self)
       end
 
       # Compile templates to instance methods, assuming they haven't been compiled already.
@@ -270,7 +269,7 @@ module ViewComponent
           RUBY
         end
 
-        @compiled = true
+        CompileCache.register self
       end
 
       # we'll eventually want to update this to support other types

--- a/lib/view_component/compile_cache.rb
+++ b/lib/view_component/compile_cache.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module ViewComponent
+  # Keeps track of which templates have already been compiled
+  # This is not part of the public API
+  module CompileCache
+    mattr_accessor :cache, instance_reader: false, instance_accessor: false do
+      Set.new
+    end
+    module_function
+
+    def register(klass)
+      cache << klass
+    end
+
+    def compiled?(klass)
+      cache.include? klass
+    end
+
+    def invalidate!
+      cache.clear
+    end
+  end
+end

--- a/lib/view_component/engine.rb
+++ b/lib/view_component/engine.rb
@@ -69,6 +69,10 @@ module ViewComponent
           get "#{options.preview_route}/*path", to: "view_components#previews", as: :preview_view_component, internal: true
         end
       end
+
+      app.executor.to_run :before do
+        CompileCache.invalidate! unless ActionView::Base.cache_template_loading
+      end
     end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -30,3 +30,14 @@ def with_preview_route(new_value)
   Rails.application.config.view_component.preview_route = old_value
   app.reloader.reload!
 end
+
+def modify_file(file, content)
+  filename = Rails.root.join(file)
+  old_content = File.read(filename)
+  begin
+    File.open(filename, "wb+") { |f| f.write(content) }
+    yield
+  ensure
+    File.open(filename, "wb+") { |f| f.write(old_content) }
+  end
+end

--- a/test/view_component/view_component_test.rb
+++ b/test/view_component/view_component_test.rb
@@ -390,7 +390,7 @@ class ViewComponentTest < ViewComponent::TestCase
     assert_equal exception.message, "Validation failed: Content can't be blank"
   end
 
-  def test_compiles_unreferenced_component
+  def test_compiles_unrendered_component
     assert UnreferencedComponent.compiled?
   end
 

--- a/test/view_component/view_component_test.rb
+++ b/test/view_component/view_component_test.rb
@@ -275,9 +275,7 @@ class ViewComponentTest < ViewComponent::TestCase
     assert_text(%r{http://assets.example.com/assets/application-\w+.css})
   end
 
-  def test_template_changes_are_not_reflected_in_production
-    old_value = ActionView::Base.cache_template_loading
-    ActionView::Base.cache_template_loading = true
+  def test_template_changes_are_not_reflected_if_cache_is_not_cleared
 
     render_inline(MyComponent.new)
 
@@ -290,29 +288,6 @@ class ViewComponentTest < ViewComponent::TestCase
     end
 
     render_inline(MyComponent.new)
-
-    ActionView::Base.cache_template_loading = old_value
-  end
-
-  def test_template_changes_are_reflected_outside_production
-    old_value = ActionView::Base.cache_template_loading
-    ActionView::Base.cache_template_loading = false
-
-    render_inline(MyComponent.new)
-
-    assert_text("hello,world!")
-
-    modify_file "app/components/my_component.html.erb", "<div>Goodbye world!</div>" do
-      render_inline(MyComponent.new)
-
-      assert_text("Goodbye world!")
-    end
-
-    render_inline(MyComponent.new)
-
-    assert_text("hello,world!")
-
-    ActionView::Base.cache_template_loading = old_value
   end
 
   def test_that_it_has_a_version_number
@@ -547,18 +522,5 @@ class ViewComponentTest < ViewComponent::TestCase
     end
 
     assert_match(/MissingDefaultCollectionParameterComponent initializer must accept `missing_default_collection_parameter` collection parameter/, exception.message)
-  end
-
-  private
-
-  def modify_file(file, content)
-    filename = Rails.root.join(file)
-    old_content = File.read(filename)
-    begin
-      File.open(filename, "wb+") { |f| f.write(content) }
-      yield
-    ensure
-      File.open(filename, "wb+") { |f| f.write(old_content) }
-    end
   end
 end


### PR DESCRIPTION
This is the same strategy as followed by ActionView.

Closes: #345

### Summary

ViewComponent will on development never cache templates, and thus they are always recompiled. If a given component is rendered in a loop (imagine a component that is rendered on a table), the recompile time starts to add up.

OTOH, ActionView caches, but when ActionView::Resolver.caching? is false, it registers a callback to clear the cache on each request:

https://github.com/rails/rails/blob/3cd1b19ff2e49642191c598d620b87ffe5ec6cda/actionview/lib/action_view/railtie.rb#L96-L99

Thus, the optimal solution would be to do something similar: invalidate the cache on each request.

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file. -->

I'm creating as draft because:

1. ~I have yet to test this.~
2. There is a test failure:

```
Failure:
ViewComponentTest#test_compiles_unreferenced_component [test/view_component/view_component_test.rb:387]:
Failed assertion, no message given.
```

I'm not sure why it would be expected that an unreferenced component is compiled