### PR TITLE
Fix issue with inaccessible helpers from nested components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # master
 
+* Fix bug where global Rails helpers are inaccessible from nested components.
+
+    *Franco Sebregondi*
+
+
 * Raise an `ArgumentError` with a helpful message when Ruby cannot parse a component class.
 
     *Max Beizer*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 
     *Franco Sebregondi*
 
-
 * Raise an `ArgumentError` with a helpful message when Ruby cannot parse a component class.
 
     *Max Beizer*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # master
 
-* Fix bug where global Rails helpers are inaccessible from nested components.
+* Fix bug where global Rails helpers are inaccessible from nested components. Before, `helpers` was pointing to parent component.
 
     *Franco Sebregondi*
 

--- a/README.md
+++ b/README.md
@@ -783,10 +783,11 @@ ViewComponent is built by:
 |@simonrand|@fugufish|@cover|@franks921|@fsateler|
 |Dublin, Ireland|Salt Lake City, Utah|Barcelona|South Africa|Chile|
 
-|<img src="https://avatars.githubusercontent.com/maxbeizer?s=256" alt="maxbeizer" width="128" />|
-|:---:|
-|@maxbeizer|
-|Nashville, TN|
+|<img src="https://avatars.githubusercontent.com/maxbeizer?s=256" alt="maxbeizer" width="128" />|<img src="https://avatars.githubusercontent.com/franco?s=256" alt="franco" width="128" />|
+|:---:|:---:|
+|@maxbeizer|@franco|
+|Nashville, TN| Switzerland |
+
 
 ## License
 

--- a/coverage/coverage.txt
+++ b/coverage/coverage.txt
@@ -3,9 +3,8 @@ Incomplete test coverage
 --------------------------------------------------------------------------------
 
 /app/controllers/view_components_controller.rb: 97.22% (missed: 49)
-/lib/view_component/base.rb: 97.8% (missed: 169,254,282,343)
+/lib/view_component/base.rb: 97.8% (missed: 170,253,281,344)
 /lib/view_component/preview.rb: 92.31% (missed: 32,42,78)
 /lib/view_component/render_to_string_monkey_patch.rb: 83.33% (missed: 9)
-/lib/view_component/test_helpers.rb: 95.65% (missed: 17)
-/test/app/components/product_reader_oops_component.rb: 50.0% (missed: 8,9)
-/test/view_component/integration_test.rb: 97.55% (missed: 14,15,16,18,20)
+/lib/view_component/test_helpers.rb: 95.45% (missed: 17)
+/test/view_component/integration_test.rb: 97.54% (missed: 14,15,16,18,20)

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -106,9 +106,9 @@ module ViewComponent
       @controller ||= view_context.controller
     end
 
-    # Provides a proxy to access helper methods
+    # Provides a proxy to access helper methods from the context of the current controller
     def helpers
-      @helpers ||= view_context.controller.view_context
+      @helpers ||= controller.view_context
     end
 
     # Removes the first part of the path and the extension.

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -108,7 +108,7 @@ module ViewComponent
 
     # Provides a proxy to access helper methods
     def helpers
-      @helpers ||= view_context
+      @helpers ||= view_context.controller.view_context
     end
 
     # Removes the first part of the path and the extension.

--- a/test/app/components/container_component.rb
+++ b/test/app/components/container_component.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class ContainerComponent < ViewComponent::Base
+  def initialize(nested_component:)
+    @nested_component = nested_component
+  end
+
+  def call
+    render @nested_component
+  end
+end

--- a/test/app/components/container_component.rb
+++ b/test/app/components/container_component.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 class HelpersContainerComponent < ViewComponent::Base
-
   def call
     render HelpersProxyComponent.new
   end

--- a/test/app/components/container_component.rb
+++ b/test/app/components/container_component.rb
@@ -1,11 +1,8 @@
 # frozen_string_literal: true
 
-class ContainerComponent < ViewComponent::Base
-  def initialize(nested_component:)
-    @nested_component = nested_component
-  end
+class HelpersContainerComponent < ViewComponent::Base
 
   def call
-    render @nested_component
+    render HelpersProxyComponent.new
   end
 end

--- a/test/view_component/view_component_test.rb
+++ b/test/view_component/view_component_test.rb
@@ -222,7 +222,7 @@ class ViewComponentTest < ViewComponent::TestCase
   end
 
   def test_renders_helper_method_within_nested_component
-    render_inline(ContainerComponent.new)
+    render_inline(HelpersContainerComponent.new)
 
     assert_text("Hello helper method")
   end

--- a/test/view_component/view_component_test.rb
+++ b/test/view_component/view_component_test.rb
@@ -222,7 +222,7 @@ class ViewComponentTest < ViewComponent::TestCase
   end
 
   def test_renders_helper_method_within_nested_component
-    render_inline(ContainerComponent.new(nested_component: HelpersProxyComponent.new))
+    render_inline(ContainerComponent.new)
 
     assert_text("Hello helper method")
   end

--- a/test/view_component/view_component_test.rb
+++ b/test/view_component/view_component_test.rb
@@ -221,6 +221,12 @@ class ViewComponentTest < ViewComponent::TestCase
     assert_text("Hello helper method")
   end
 
+  def test_renders_helper_method_within_nested_component
+    render_inline(ContainerComponent.new(nested_component: HelpersProxyComponent.new))
+
+    assert_text("Hello helper method")
+  end
+
   def test_renders_path_helper
     render_inline(PathComponent.new)
 


### PR DESCRIPTION
As reported in #321, global Rails helpers are not accessible within
nested components. This is because their view context is the parent
component, where global helpers are not available.

<!-- See https://github.com/github/view_component/blob/master/CONTRIBUTING.md#submitting-a-pull-request  -->