### PR TITLE
Ensure Rails configuration values are accessible in components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # master
 
+# 2.10.1
+
+* Ensure Rails configuration is available within components
+
+    *Trevor Broaddus*
+
 # 2.10.0
 
 * Raise an `ArgumentError` with a helpful message when Ruby cannot parse a component class.

--- a/README.md
+++ b/README.md
@@ -785,7 +785,7 @@ ViewComponent is built by:
 |Dublin, Ireland|Salt Lake City, Utah|Barcelona|South Africa|Chile|
 
 |<img src="https://avatars.githubusercontent.com/maxbeizer?s=256" alt="maxbeizer" width="128" />|<img src="https://avatars.githubusercontent.com/franco?s=256" alt="franco" width="128" />|<img src="https://avatars.githubusercontent.com/tbroad-ramsey?s=256" alt="tbroad-ramsey" width="128" />|
-|:---:|:---:||:---:|
+|:---:|:---:|:---:|
 |@maxbeizer|@franco|@tbroad-ramsey|
 |Nashville, TN|Switzerland|Spring Hill, TN|
 

--- a/README.md
+++ b/README.md
@@ -784,10 +784,10 @@ ViewComponent is built by:
 |@simonrand|@fugufish|@cover|@franks921|@fsateler|
 |Dublin, Ireland|Salt Lake City, Utah|Barcelona|South Africa|Chile|
 
-|<img src="https://avatars.githubusercontent.com/maxbeizer?s=256" alt="maxbeizer" width="128" />|
-|:---:|
-|@maxbeizer|
-|Nashville, TN|
+|<img src="https://avatars.githubusercontent.com/maxbeizer?s=256" alt="maxbeizer" width="128" />|<img src="https://avatars.githubusercontent.com/tbroad-ramsey?s=256" alt="tbroad-ramsey" width="128" />|
+|:---:|:---:|
+|@maxbeizer|@tbroad-ramsey|
+|Nashville, TN|Spring Hill, TN|
 
 ## License
 

--- a/coverage/coverage.txt
+++ b/coverage/coverage.txt
@@ -3,9 +3,8 @@ Incomplete test coverage
 --------------------------------------------------------------------------------
 
 /app/controllers/view_components_controller.rb: 97.22% (missed: 49)
-/lib/view_component/base.rb: 97.8% (missed: 169,254,282,343)
+/lib/view_component/base.rb: 97.8% (missed: 170,253,281,344)
 /lib/view_component/preview.rb: 92.31% (missed: 32,42,78)
 /lib/view_component/render_to_string_monkey_patch.rb: 83.33% (missed: 9)
-/lib/view_component/test_helpers.rb: 95.65% (missed: 17)
-/test/app/components/product_reader_oops_component.rb: 50.0% (missed: 8,9)
-/test/view_component/integration_test.rb: 97.55% (missed: 14,15,16,18,20)
+/lib/view_component/test_helpers.rb: 95.45% (missed: 17)
+/test/view_component/integration_test.rb: 97.54% (missed: 14,15,16,18,20)

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -12,7 +12,7 @@ module ViewComponent
     include ViewComponent::Previewable
 
     # For CSRF authenticity tokens in forms
-    delegate :form_authenticity_token, :protect_against_forgery?, to: :helpers
+    delegate :form_authenticity_token, :protect_against_forgery?, :config, to: :helpers
 
     class_attribute :content_areas
     self.content_areas = [] # class_attribute:default doesn't work until Rails 5.2

--- a/test/app/components/rails_config_component.html.erb
+++ b/test/app/components/rails_config_component.html.erb
@@ -1,0 +1,1 @@
+<%= config.asset_host %>

--- a/test/app/components/rails_config_component.rb
+++ b/test/app/components/rails_config_component.rb
@@ -1,0 +1,2 @@
+class RailsConfigComponent < ViewComponent::Base
+end

--- a/test/app/components/rails_config_component.rb
+++ b/test/app/components/rails_config_component.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 class RailsConfigComponent < ViewComponent::Base
 end

--- a/test/view_component/view_component_test.rb
+++ b/test/view_component/view_component_test.rb
@@ -533,4 +533,10 @@ class ViewComponentTest < ViewComponent::TestCase
 
     assert_match(/ProductReaderOopsComponent initializer is empty or invalid/, exception.message)
   end
+
+  def test_renders_component_using_rails_config
+    render_inline(RailsConfigComponent.new)
+  
+    assert_text("http://assets.example.com")
+  end
 end

--- a/test/view_component/view_component_test.rb
+++ b/test/view_component/view_component_test.rb
@@ -536,7 +536,7 @@ class ViewComponentTest < ViewComponent::TestCase
 
   def test_renders_component_using_rails_config
     render_inline(RailsConfigComponent.new)
-  
+
     assert_text("http://assets.example.com")
   end
 end


### PR DESCRIPTION
<!-- See https://github.com/github/view_component/blob/master/CONTRIBUTING.md#submitting-a-pull-request  -->

### Summary
ViewComponent::Base initializes its own `config` that is empty
by default, and thus overrides the `view_context.config` values which
contain all of the `Rails.configuration` values we know and love.

This commit ensures that components (and various helpers that may access
the `config` attribute) are able to access the Rails configuration
values. By delegating calls to `config`, we are able to access Rails
configuration values. 

### Other Information