### PR TITLE
Avoid printing the missing capybara dependency warning by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # master
 
+* Only print warning about a missing capybara dependency if the `DEBUG` environment variable is set.
+
+    *Richard Macklin*
+
 # 2.13.0
 
 * Add the ability to disable the render monkey patch with `config.view_component.render_monkey_patch_enabled`. In versions of Rails < 6.1, add `render_component` and `render_component_to_string` methods which can be used for rendering components instead of `render`.

--- a/lib/view_component/test_helpers.rb
+++ b/lib/view_component/test_helpers.rb
@@ -14,7 +14,7 @@ module ViewComponent
         assert_no_selector("body")
       end
     rescue LoadError
-      warn "WARNING in `ViewComponent::TestHelpers`: You must add `capybara` to your Gemfile to use Capybara assertions."
+      warn "WARNING in `ViewComponent::TestHelpers`: You must add `capybara` to your Gemfile to use Capybara assertions." if ENV["DEBUG"]
     end
 
     attr_reader :rendered_component


### PR DESCRIPTION
### Summary

https://github.com/github/view_component/issues/304#issuecomment-651419797 mentioned being annoyed by the warning about a missing capybara dependency in an application which uses view_component but not capybara.

My first instinct was to simply remove the warning. However, it still seems helpful for users who want to use the capybara assertions but are getting errors because they don't have a capybara dependency.

So, in this PR, I've adjusted it such that the warning is silenced unless the `DEBUG` environment variable is set. This seemed like a good compromise, since it seems reasonable that running tests with `DEBUG=1` may result in additional output for debugging purposes.

That said, I realize we aren't using the `DEBUG` environment variable elsewhere in the gem, so if we'd rather avoid it and simply remove the warning altogether, that's fine too.