### PR TITLE
Align coverage.txt with the latest changes

### DIFF
--- a/coverage/coverage.txt
+++ b/coverage/coverage.txt
@@ -3,7 +3,7 @@ Incomplete test coverage
 --------------------------------------------------------------------------------
 
 /app/controllers/view_components_controller.rb: 97.22% (missed: 49)
-/lib/view_component/base.rb: 97.86% (missed: 181,268,296,359)
+/lib/view_component/base.rb: 97.86% (missed: 178,265,293,356)
 /lib/view_component/preview.rb: 92.31% (missed: 32,42,78)
 /lib/view_component/render_to_string_monkey_patch.rb: 83.33% (missed: 9)
 /lib/view_component/test_helpers.rb: 95.45% (missed: 17)


### PR DESCRIPTION
### Summary

Running `bundle exec rake` on fe8b6f24aa0635115e20920353a40b683b76cef7 (the current `HEAD` of the `master` branch) produced these changes in `coverage.txt` (despite there being no changes in my working directory).

It seems that 12e86669b8acf645ac565a674cdd736063636566 (the last commit of https://github.com/github/view_component/pull/358) removed 3 lines from `base.rb` which meant the line numbers in the coverage report were off by three for that file.