### PR TITLE
Use render_component in render_inline test helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # master
 
+* Allow using `render_inline` in test when the render monkey patch is disabled with `config.view_component.render_monkey_patch_enabled = false` in versions of Rails < 6.1.
+
+    *Clément Joubert*
+
 # 2.14.0
 
 * Add `config.preview_paths` to support multiple locations of component preview files. Deprecate `config.preview_path`.

--- a/README.md
+++ b/README.md
@@ -929,10 +929,10 @@ ViewComponent is built by:
 |@maxbeizer|@franco|@tbroad-ramsey|@jensljungblad|@bbugh|
 |Nashville, TN|Switzerland|Spring Hill, TN|New York, NY|Austin, TX|
 
-|<img src="https://avatars.githubusercontent.com/johannesengl?s=256" alt="johannesengl" width="128" />|
+|<img src="https://avatars.githubusercontent.com/johannesengl?s=256" alt="johannesengl" width="128" />|<img src="https://avatars.githubusercontent.com/czj?s=256" alt="czj" width="128" />|
 |:---:|
-|@johannesengl|
-|Berlin, Germany|
+|@johannesengl|@czj|
+|Berlin, Germany|Paris, France|
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -930,7 +930,7 @@ ViewComponent is built by:
 |Nashville, TN|Switzerland|Spring Hill, TN|New York, NY|Austin, TX|
 
 |<img src="https://avatars.githubusercontent.com/johannesengl?s=256" alt="johannesengl" width="128" />|<img src="https://avatars.githubusercontent.com/czj?s=256" alt="czj" width="128" />|
-|:---:|
+|:---:|:---:|
 |@johannesengl|@czj|
 |Berlin, Germany|Paris, France|
 

--- a/coverage/coverage.txt
+++ b/coverage/coverage.txt
@@ -3,9 +3,9 @@ Incomplete test coverage
 --------------------------------------------------------------------------------
 
 /app/controllers/view_components_controller.rb: 97.22% (missed: 49)
-/lib/view_component/base.rb: 97.8% (missed: 170,253,281,344)
-/lib/view_component/engine.rb: 93.48% (missed: 21,25,38)
+/lib/view_component/base.rb: 97.86% (missed: 178,265,293,356)
+/lib/view_component/engine.rb: 94.64% (missed: 22,25,38)
 /lib/view_component/preview.rb: 92.31% (missed: 32,42,78)
 /lib/view_component/render_to_string_monkey_patch.rb: 83.33% (missed: 9)
 /lib/view_component/test_helpers.rb: 95.45% (missed: 17)
-/test/view_component/integration_test.rb: 97.57% (missed: 14,15,16,18,20)
+/test/view_component/integration_test.rb: 96.12% (missed: 14,15,16,18,20,365,366,367,369)

--- a/lib/view_component/test_helpers.rb
+++ b/lib/view_component/test_helpers.rb
@@ -20,7 +20,12 @@ module ViewComponent
     attr_reader :rendered_component
 
     def render_inline(component, **args, &block)
-      @rendered_component = controller.view_context.render_component(component, &block)
+      @rendered_component = 
+        if Rails.version.to_f >= 6.1
+          controller.view_context.render(component, &block)
+        else
+          controller.view_context.render_component(component, &block)
+        end
 
       Nokogiri::HTML.fragment(@rendered_component)
     end

--- a/lib/view_component/test_helpers.rb
+++ b/lib/view_component/test_helpers.rb
@@ -20,7 +20,7 @@ module ViewComponent
     attr_reader :rendered_component
 
     def render_inline(component, **args, &block)
-      @rendered_component = controller.view_context.render(component, args, &block)
+      @rendered_component = controller.view_context.render_component(component, &block)
 
       Nokogiri::HTML.fragment(@rendered_component)
     end

--- a/lib/view_component/test_helpers.rb
+++ b/lib/view_component/test_helpers.rb
@@ -20,7 +20,7 @@ module ViewComponent
     attr_reader :rendered_component
 
     def render_inline(component, **args, &block)
-      @rendered_component = 
+      @rendered_component =
         if Rails.version.to_f >= 6.1
           controller.view_context.render(component, args, &block)
         else

--- a/lib/view_component/test_helpers.rb
+++ b/lib/view_component/test_helpers.rb
@@ -22,7 +22,7 @@ module ViewComponent
     def render_inline(component, **args, &block)
       @rendered_component = 
         if Rails.version.to_f >= 6.1
-          controller.view_context.render(component, &block)
+          controller.view_context.render(component, args, &block)
         else
           controller.view_context.render_component(component, &block)
         end


### PR DESCRIPTION
### Summary

Using `render_component` in the the `render_inline` test helper instead of `render` allows tests to pass on any version of Rails (>= 6.1 and < 6.1 with or without monkey patch always pass.

Without this fix, when running Rails < 6.1 without the monkey patch, using `render_inline`would result in tests failure.

Closes https://github.com/github/view_component/issues/396