### PR TITLE
Fix kwargs in slotable

### DIFF
--- a/lib/view_component/slotable.rb
+++ b/lib/view_component/slotable.rb
@@ -95,7 +95,7 @@ module ViewComponent
       end
 
       # Instantiate Slot class, accommodating Slots that don't accept arguments
-      slot_instance = args.present? ? slot_class.new(args) : slot_class.new
+      slot_instance = args.present? ? slot_class.new(**args) : slot_class.new
 
       # Capture block and assign to slot_instance#content
       slot_instance.content = view_context.capture(&block) if block_given?


### PR DESCRIPTION
In GitHub and in these tests the slots_component takes keyword
arguments, not `args`. The `args` variable needs to be double splatted
in the initalization caller.

The warnings can be seen when running the tests before this change was
introduced.

Fixes:

```
view_component/lib/view_component/slotable.rb:98: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
view_component/test/app/components/slots_component.rb:18: warning: The called method `initialize' is defined here
```

cc/ @joelhawksley 