### PR TITLE
Add `--sidecar` to erb, haml and slim generators.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # master
 
+* Add `--sidecar` option to the erb, haml and slim generators. Places the generated template in the sidecar directory.
+
+    *Michael van Rooijen*
+
 # 2.15.0
 
 * Add support for templates as ViewComponent::Preview examples.

--- a/README.md
+++ b/README.md
@@ -350,7 +350,7 @@ app/components
 
 ```
 
-To generate this directory structure for a component, use the `--sidecar` flag:
+To generate a component with this directory structure, use the `--sidecar` flag:
 
 ```
 bin/rails generate component Example title content --sidecar

--- a/README.md
+++ b/README.md
@@ -350,7 +350,7 @@ app/components
 
 ```
 
-To generate a component with this directory structure, use the `--sidecar` flag:
+To generate a component with a sidecar directory, use the `--sidecar` flag:
 
 ```
 bin/rails generate component Example title content --sidecar

--- a/README.md
+++ b/README.md
@@ -341,13 +341,23 @@ As an alternative, views and other assets can be placed in a sidecar directory w
 ```
 app/components
 ├── ...
-├── test_component.rb
-├── test_component
-|   ├── test_component.css
-|   ├── test_component.html.erb
-|   └── test_component.js
+├── example_component.rb
+├── example_component
+|   ├── example_component.css
+|   ├── example_component.html.erb
+|   └── example_component.js
 ├── ...
 
+```
+
+You can generate this directory structure for a component using the `--sidecar` flag:
+
+```
+bin/rails generate component Example title content --sidecar
+      invoke  test_unit
+      create  test/components/example_component_test.rb
+      create  app/components/example_component.rb
+      create  app/components/example_component/example_component.html.erb
 ```
 
 ### Conditional Rendering
@@ -980,10 +990,10 @@ ViewComponent is built by:
 |@maxbeizer|@franco|@tbroad-ramsey|@jensljungblad|@bbugh|
 |Nashville, TN|Switzerland|Spring Hill, TN|New York, NY|Austin, TX|
 
-|<img src="https://avatars.githubusercontent.com/johannesengl?s=256" alt="johannesengl" width="128" />|<img src="https://avatars.githubusercontent.com/czj?s=256" alt="czj" width="128" />|
-|:---:|:---:|
-|@johannesengl|@czj|
-|Berlin, Germany|Paris, France|
+|<img src="https://avatars.githubusercontent.com/johannesengl?s=256" alt="johannesengl" width="128" />|<img src="https://avatars.githubusercontent.com/czj?s=256" alt="czj" width="128" />|<img src="https://avatars.githubusercontent.com/mrrooijen?s=256" alt="mrrooijen" width="128" />|
+|:---:|:---:|:---:|
+|@johannesengl|@czj|@mrrooijen|
+|Berlin, Germany|Paris, France|The Netherlands|
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -350,7 +350,7 @@ app/components
 
 ```
 
-You can generate this directory structure for a component using the `--sidecar` flag:
+To generate this directory structure for a component, use the `--sidecar` flag:
 
 ```
 bin/rails generate component Example title content --sidecar

--- a/lib/rails/generators/erb/component_generator.rb
+++ b/lib/rails/generators/erb/component_generator.rb
@@ -6,12 +6,21 @@ module Erb
   module Generators
     class ComponentGenerator < Base
       source_root File.expand_path("templates", __dir__)
+      class_option :sidecar, type: :boolean, default: false
 
       def copy_view_file
-        template "component.html.erb", File.join("app/components", class_path, "#{file_name}_component.html.erb")
+        template "component.html.erb", destination
       end
 
       private
+
+      def destination
+        if options["sidecar"]
+          File.join("app/components", class_path, "#{file_name}_component", "#{file_name}_component.html.erb")
+        else
+          File.join("app/components", class_path, "#{file_name}_component.html.erb")
+        end
+      end
 
       def file_name
         @_file_name ||= super.sub(/_component\z/i, "")

--- a/lib/rails/generators/haml/component_generator.rb
+++ b/lib/rails/generators/haml/component_generator.rb
@@ -6,12 +6,21 @@ module Haml
   module Generators
     class ComponentGenerator < Erb::Generators::ComponentGenerator
       source_root File.expand_path("templates", __dir__)
+      class_option :sidecar, type: :boolean, default: false
 
       def copy_view_file
-        template "component.html.haml", File.join("app/components", class_path, "#{file_name}_component.html.haml")
+        template "component.html.haml", destination
       end
 
       private
+
+      def destination
+        if options["sidecar"]
+          File.join("app/components", class_path, "#{file_name}_component", "#{file_name}_component.html.haml")
+        else
+          File.join("app/components", class_path, "#{file_name}_component.html.haml")
+        end
+      end
 
       def file_name
         @_file_name ||= super.sub(/_component\z/i, "")

--- a/lib/rails/generators/slim/component_generator.rb
+++ b/lib/rails/generators/slim/component_generator.rb
@@ -6,12 +6,21 @@ module Slim
   module Generators
     class ComponentGenerator < Erb::Generators::ComponentGenerator
       source_root File.expand_path("templates", __dir__)
+      class_option :sidecar, type: :boolean, default: false
 
       def copy_view_file
-        template "component.html.slim", File.join("app/components", class_path, "#{file_name}_component.html.slim")
+        template "component.html.slim", destination
       end
 
       private
+
+      def destination
+        if options["sidecar"]
+          File.join("app/components", class_path, "#{file_name}_component", "#{file_name}_component.html.slim")
+        else
+          File.join("app/components", class_path, "#{file_name}_component.html.slim")
+        end
+      end
 
       def file_name
         @_file_name ||= super.sub(/_component\z/i, "")

--- a/test/generators/erb_generator_test.rb
+++ b/test/generators/erb_generator_test.rb
@@ -21,9 +21,23 @@ class ErbGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_component_generator_with_sidecar
+    run_generator %w[user --sidecar]
+
+    assert_file "app/components/user_component/user_component.html.erb" do |view|
+      assert_match(/<div>Add User template here<\/div>/, view)
+    end
+  end
+
   def test_component_with_namespace
     run_generator %w[admins/user]
 
     assert_file "app/components/admins/user_component.html.erb"
+  end
+
+  def test_component_with_namespace_and_sidecar
+    run_generator %w[admins/user --sidecar]
+
+    assert_file "app/components/admins/user_component/user_component.html.erb"
   end
 end

--- a/test/generators/haml_generator_test.rb
+++ b/test/generators/haml_generator_test.rb
@@ -21,9 +21,23 @@ class HamlGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_component_with_sidecar
+    run_generator %w[user --sidecar]
+
+    assert_file "app/components/user_component/user_component.html.haml" do |view|
+      assert_match(/%div Add User template here/, view)
+    end
+  end
+
   def test_component_with_namespace
     run_generator %w[admins/user]
 
     assert_file "app/components/admins/user_component.html.haml"
+  end
+
+  def test_component_with_namespace_and_sidecar
+    run_generator %w[admins/user --sidecar]
+
+    assert_file "app/components/admins/user_component/user_component.html.haml"
   end
 end

--- a/test/generators/slim_generator_test.rb
+++ b/test/generators/slim_generator_test.rb
@@ -21,9 +21,23 @@ class SlimGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_component_with_sidecar
+    run_generator %w[user --sidecar]
+
+    assert_file "app/components/user_component/user_component.html.slim" do |view|
+      assert_match(/div Add User template here/, view)
+    end
+  end
+
   def test_component_with_namespace
     run_generator %w[admins/user]
 
     assert_file "app/components/admins/user_component.html.slim"
+  end
+
+  def test_component_with_namespace_and_sidecar
+    run_generator %w[admins/user --sidecar]
+
+    assert_file "app/components/admins/user_component/user_component.html.slim"
   end
 end


### PR DESCRIPTION
When generating a component using the `--sidecar` flag, the template will be placed in the sidecar directory.

This option is false (disabled) by default.