### PR TITLE
Slots return stripped HTML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # master
 
+* Slots return stripped HTML, removing leading and trailing whitespace.
+
+    *Jason Long, Joel Hawksley*
+
 # 2.16.0
 
 * Add `--sidecar` option to the erb, haml and slim generators. Places the generated template in the sidecar directory.

--- a/coverage/coverage.txt
+++ b/coverage/coverage.txt
@@ -8,4 +8,4 @@ Incomplete test coverage
 /lib/view_component/preview.rb: 94.0% (missed: 47,57,107)
 /lib/view_component/render_to_string_monkey_patch.rb: 83.33% (missed: 9)
 /lib/view_component/test_helpers.rb: 91.67% (missed: 17,25)
-/test/view_component/integration_test.rb: 96.69% (missed: 14,15,16,18,20,365,366,367,369)
+/test/view_component/integration_test.rb: 96.73% (missed: 14,15,16,18,20,370,371,372,374)

--- a/lib/view_component/slotable.rb
+++ b/lib/view_component/slotable.rb
@@ -98,7 +98,7 @@ module ViewComponent
       slot_instance = args.present? ? slot_class.new(**args) : slot_class.new
 
       # Capture block and assign to slot_instance#content
-      slot_instance.content = view_context.capture(&block) if block_given?
+      slot_instance.content = view_context.capture(&block).strip.html_safe if block_given?
 
       if slot[:collection]
         # Initialize instance variable as an empty array

--- a/test/view_component/integration_test.rb
+++ b/test/view_component/integration_test.rb
@@ -359,6 +359,11 @@ class IntegrationTest < ActionDispatch::IntegrationTest
     assert_select(".item.normal", count: 2)
 
     assert_select(".footer.text-blue h3", text: "This is the footer")
+
+    title_node = Nokogiri::HTML.fragment(response.body).css(".title").to_html
+    expected_title_html = "<div class=\"title\">\n    <p>This is my title!</p>\n  </div>"
+
+    assert_equal(title_node, expected_title_html)
   end
 
   if Rails.version.to_f >= 6.1


### PR DESCRIPTION
While building a component that leveraged Slots,
we ran into an issue where it was difficult to not introduce
unintended whitespace in the rendered HTML for the component.

This change strips the rendered HTML for slots, so that
we don't end up with unintentional whitespace in the rendered
output.

Co-authored-by: Jason Long <jasonlong@github.com>