### PR TITLE
Strip whitespace between html tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # master
 
+* Remove whitespace between rendered html tags.
+
+    *Jon Rohan*
+
 # 2.17.0
 
 * Slots return stripped HTML, removing leading and trailing whitespace.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # master
 
-* Remove whitespace between rendered html tags.
+* Remove whitespace between rendered HTML tags.
 
     *Jon Rohan*
 

--- a/README.md
+++ b/README.md
@@ -990,10 +990,10 @@ ViewComponent is built by:
 |@maxbeizer|@franco|@tbroad-ramsey|@jensljungblad|@bbugh|
 |Nashville, TN|Switzerland|Spring Hill, TN|New York, NY|Austin, TX|
 
-|<img src="https://avatars.githubusercontent.com/johannesengl?s=256" alt="johannesengl" width="128" />|<img src="https://avatars.githubusercontent.com/czj?s=256" alt="czj" width="128" />|<img src="https://avatars.githubusercontent.com/mrrooijen?s=256" alt="mrrooijen" width="128" />|
+|<img src="https://avatars.githubusercontent.com/johannesengl?s=256" alt="johannesengl" width="128" />|<img src="https://avatars.githubusercontent.com/czj?s=256" alt="czj" width="128" />|<img src="https://avatars.githubusercontent.com/mrrooijen?s=256" alt="mrrooijen" width="128" />|<img src="https://avatars.githubusercontent.com/jonrohan?s=256" alt="jonrohan" width="128" />|
 |:---:|:---:|:---:|
-|@johannesengl|@czj|@mrrooijen|
-|Berlin, Germany|Paris, France|The Netherlands|
+|@johannesengl|@czj|@mrrooijen|@jonrohan|
+|Berlin, Germany|Paris, France|The Netherlands|San Francisco, CA|
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -991,7 +991,7 @@ ViewComponent is built by:
 |Nashville, TN|Switzerland|Spring Hill, TN|New York, NY|Austin, TX|
 
 |<img src="https://avatars.githubusercontent.com/johannesengl?s=256" alt="johannesengl" width="128" />|<img src="https://avatars.githubusercontent.com/czj?s=256" alt="czj" width="128" />|<img src="https://avatars.githubusercontent.com/mrrooijen?s=256" alt="mrrooijen" width="128" />|<img src="https://avatars.githubusercontent.com/jonrohan?s=256" alt="jonrohan" width="128" />|
-|:---:|:---:|:---:|
+|:---:|:---:|:---:|:---:|
 |@johannesengl|@czj|@mrrooijen|@jonrohan|
 |Berlin, Germany|Paris, France|The Netherlands|San Francisco, CA|
 

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -75,7 +75,7 @@ module ViewComponent
       before_render
 
       if render?
-        send(self.class.call_method_name(@variant)).gsub(/>[\n\s]+</, "><")
+        send(self.class.call_method_name(@variant)).gsub(/>[\n\s]+</, "><").html_safe
       else
         ""
       end

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -75,7 +75,7 @@ module ViewComponent
       before_render
 
       if render?
-        send(self.class.call_method_name(@variant))
+        send(self.class.call_method_name(@variant)).gsub(/>[\n\s]+</, "><")
       else
         ""
       end

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -75,7 +75,7 @@ module ViewComponent
       before_render
 
       if render?
-        send(self.class.call_method_name(@variant)).gsub(/>[\n\s]+</, "><").html_safe
+        send(self.class.call_method_name(@variant)).gsub(/>[\n\s]+</, "><").strip.html_safe
       else
         ""
       end

--- a/test/view_component/integration_test.rb
+++ b/test/view_component/integration_test.rb
@@ -360,7 +360,7 @@ class IntegrationTest < ActionDispatch::IntegrationTest
 
     assert_select(".footer.text-blue h3", text: "This is the footer")
 
-    title_node = Nokogiri::HTML.fragment(response.body).css(".title").to_html
+    title_node = Nokogiri::HTML.fragment(response.body).css(".title").to_html.strip
     expected_title_html = "<div class=\"title\"><p>This is my title!</p></div>"
 
     assert_equal(expected_title_html, title_node)

--- a/test/view_component/integration_test.rb
+++ b/test/view_component/integration_test.rb
@@ -361,7 +361,7 @@ class IntegrationTest < ActionDispatch::IntegrationTest
     assert_select(".footer.text-blue h3", text: "This is the footer")
 
     title_node = Nokogiri::HTML.fragment(response.body).css(".title").to_html
-    expected_title_html = "<div class=\"title\">\n    <p>This is my title!</p>\n  </div>"
+    expected_title_html = "<div class=\"title\"><p>This is my title!</p></div>"
 
     assert_equal(title_node, expected_title_html)
   end

--- a/test/view_component/integration_test.rb
+++ b/test/view_component/integration_test.rb
@@ -27,7 +27,7 @@ class IntegrationTest < ActionDispatch::IntegrationTest
     assert_select("div", "bar")
     assert_response :success
 
-    baseline_response = response.body
+    baseline_response = response.body.gsub(/>[\s\n]+</, "><").strip
 
     get "/controller_inline"
     assert_select("div", "bar")
@@ -87,7 +87,7 @@ class IntegrationTest < ActionDispatch::IntegrationTest
     assert_select("div", "bar")
     assert_response :success
 
-    baseline_response = response.body
+    baseline_response = response.body.gsub(/>[\s\n]+</, "><").strip
 
     get "/controller_to_string"
     assert_select("div", "bar")

--- a/test/view_component/integration_test.rb
+++ b/test/view_component/integration_test.rb
@@ -363,7 +363,7 @@ class IntegrationTest < ActionDispatch::IntegrationTest
     title_node = Nokogiri::HTML.fragment(response.body).css(".title").to_html
     expected_title_html = "<div class=\"title\"><p>This is my title!</p></div>"
 
-    assert_equal(title_node, expected_title_html)
+    assert_equal(expected_title_html, title_node)
   end
 
   if Rails.version.to_f >= 6.1

--- a/test/view_component/view_component_test.rb
+++ b/test/view_component/view_component_test.rb
@@ -647,7 +647,7 @@ class ViewComponentTest < ViewComponent::TestCase
   end
 
   def test_strips_whitespace_from_between_tags
-    html = render_inline(PreviewComponent.new(title: "Preview"))
+    html = render_inline(PreviewComponent.new(title: "Preview")).to_html
     expected_html = "<div class=\"preview-component\"><h1>Preview</h1></div>"
 
     assert_equal expected_html, html

--- a/test/view_component/view_component_test.rb
+++ b/test/view_component/view_component_test.rb
@@ -650,6 +650,6 @@ class ViewComponentTest < ViewComponent::TestCase
     html = render_inline(PreviewComponent.new(title: "Preview")).to_html
     expected_html = "<div class=\"preview-component\"><h1>Preview</h1></div>"
 
-    assert_equal expected_html, html
+    assert_includes html, expected_html
   end
 end

--- a/test/view_component/view_component_test.rb
+++ b/test/view_component/view_component_test.rb
@@ -645,4 +645,11 @@ class ViewComponentTest < ViewComponent::TestCase
 
     assert_text("http://assets.example.com")
   end
+
+  def test_strips_whitespace_from_between_tags
+    html = render_inline(PreviewComponent.new(title: "Preview"))
+    expected_html = "<div class=\"preview-component\"><h1>Preview</h1></div>"
+
+    assert_equal expected_html, html
+  end
 end


### PR DESCRIPTION
### Summary

This addresses the feature brought up in https://github.com/github/view_component/pull/414/files#r458362252

This will strip out any whitespace characters between html tags in the rendered output. Browsers don't treat these differently when rendering them, but having the whitespace in the delivered html increases the amount of bytes downloaded. These savings are extremely small, but when you think about a giant page rendered entirely out of ViewComponents, this savings can add up.

**Before**

```html
<p>
    <a href="foo/">Foo</a>
</p>
```

**After**

```html
<p><a href="foo/">Foo</a></p>
```

**Note this will not remove space between text and tags**

```html
<strong>
    Hello
</strong>
```
