### PR TITLE
Calculate virtual_path once for all instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # master
 
+* Calculate virtual_path once for all instances of a component class to improve performance.
+
+    *Brad Parker*
+
 # 2.17.1
 
 * Fix bug where rendering Slot with empty block resulted in error.

--- a/README.md
+++ b/README.md
@@ -990,10 +990,10 @@ ViewComponent is built by:
 |@maxbeizer|@franco|@tbroad-ramsey|@jensljungblad|@bbugh|
 |Nashville, TN|Switzerland|Spring Hill, TN|New York, NY|Austin, TX|
 
-|<img src="https://avatars.githubusercontent.com/johannesengl?s=256" alt="johannesengl" width="128" />|<img src="https://avatars.githubusercontent.com/czj?s=256" alt="czj" width="128" />|<img src="https://avatars.githubusercontent.com/mrrooijen?s=256" alt="mrrooijen" width="128" />|
-|:---:|:---:|:---:|
-|@johannesengl|@czj|@mrrooijen|
-|Berlin, Germany|Paris, France|The Netherlands|
+|<img src="https://avatars.githubusercontent.com/johannesengl?s=256" alt="johannesengl" width="128" />|<img src="https://avatars.githubusercontent.com/czj?s=256" alt="czj" width="128" />|<img src="https://avatars.githubusercontent.com/mrrooijen?s=256" alt="mrrooijen" width="128" />|<img src="https://avatars.githubusercontent.com/bradparker?s=256" alt="bradparker" width="128" />|
+|:---:|:---:|:---:|:---:|
+|@johannesengl|@czj|@mrrooijen|@bradparker|
+|Berlin, Germany|Paris, France|The Netherlands|Brisbane, Australia|
 
 ## License
 

--- a/coverage/coverage.txt
+++ b/coverage/coverage.txt
@@ -3,7 +3,7 @@ Incomplete test coverage
 --------------------------------------------------------------------------------
 
 /app/controllers/view_components_controller.rb: 97.67% (missed: 54)
-/lib/view_component/base.rb: 97.86% (missed: 178,265,293,356)
+/lib/view_component/base.rb: 97.87% (missed: 178,268,296,359)
 /lib/view_component/engine.rb: 94.64% (missed: 22,25,38)
 /lib/view_component/preview.rb: 94.0% (missed: 47,57,107)
 /lib/view_component/render_to_string_monkey_patch.rb: 83.33% (missed: 9)

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -116,9 +116,9 @@ module ViewComponent
       @helpers ||= controller.view_context
     end
 
-    # Removes the first part of the path and the extension.
+    # Exposes .virutal_path as an instance method
     def virtual_path
-      self.class.source_location.gsub(%r{(.*app/components)|(\.rb)}, "")
+      self.class.virtual_path
     end
 
     # For caching, such as #cache_if
@@ -166,7 +166,7 @@ module ViewComponent
     mattr_accessor :render_monkey_patch_enabled, instance_writer: false, default: true
 
     class << self
-      attr_accessor :source_location
+      attr_accessor :source_location, :virtual_path
 
       # Render a component collection.
       def with_collection(collection, **args)
@@ -188,6 +188,9 @@ module ViewComponent
         # We need to ignore `inherited` frames here as they indicate that `inherited`
         # has been re-defined by the consuming application, likely in ApplicationComponent.
         child.source_location = caller_locations(1, 10).reject { |l| l.label == "inherited" }[0].absolute_path
+
+        # Removes the first part of the path and the extension.
+        child.virtual_path = child.source_location.gsub(%r{(.*app/components)|(\.rb)}, "")
 
         # Clone slot configuration into child class
         # see #test_slots_pollution


### PR DESCRIPTION
I don't think this will vary per instance but I'm really not familiar
with Rails' view rendering.

My, possibly flawed, micro-benchmarking suggests this'll get
ViewComponent a 5 time speed up. Those same benchmarks suggest this
takes ViewComponent from being a bit faster than partials to being much
faster :D. **N.B** This'll only have an impact when a view is rendering
many instances of the same component. Though now I say that ... it
might have an impact over time when class caching is turned on
in production mode, I haven't tested that.

Setup
=====

This is a sketch of what we've been using to bench:

    require "benchmark/ips"

    class ViewComponentPerformanceRenderer
      def initialize
        @controller = ViewComponent::Base.test_controller.constantize.new
        @controller.request = ActionDispatch::TestRequest.create
        @controller.extend(Rails.application.routes.url_helpers)
      end

      def render_komponent(name, **args, &block)
        @controller.helpers.component(name, args, &block)
      end

      def render_inline(component, **args, &block)
        @controller.view_context.render(component, args, &block)
      end
    end

    renderer = ViewComponentPerformanceRenderer.new

    Benchmark.ips do |benchmark|
      benchmark.report("Partial") do
        renderer.render_inline("shared/dummy") do
          "Hey, there"
        end
      end

      benchmark.report("ViewComponent") do
        renderer.render_inline(DummyComponent.new) do
          "Hey, there"
        end
      end

      benchmark.report("Komponent") do
        renderer.render_komponent("dummy") do
          "Hey, there"
        end
      end
    end

I've tried to make the components almost as simple as possible (they all
accept content so I could test the effect of nesting).

**N.B** I also enabled template caching but made sure that each example
still had an ERB template (E.G. no #call components).

Partial
=======

views/shared/_dummy.html.erb

    <div>
      <%= yield %>
    </div>

Komponent
=========

frontend/components/dummy/dummy_component.rb

    module DummyComponent
      extend ComponentHelper
    end

frontend/components/dummy/_dummy.html.erb

    <div>
      <%= yield %>
    </div>

ViewComponent
=============

app/components/dummy_component.rb

    class DummyComponent < ViewComponent::Base
    end

app/components/dummy_component.html.erb

    <div>
      <%= content %>
    </div>

Results
=======

Without this change:

    Warming up --------------------------------------
                 Partial   950.000  i/100ms
           ViewComponent     1.344k i/100ms
               Komponent   440.000  i/100ms
    Calculating -------------------------------------
                 Partial     11.522k (± 9.0%) i/s -     57.950k in   5.071796s
           ViewComponent     13.717k (± 6.7%) i/s -     68.544k in   5.021419s
               Komponent      4.442k (± 7.0%) i/s -     22.440k in   5.075137s

And with:

    Warming up --------------------------------------
                 Partial   946.000  i/100ms
           ViewComponent     5.731k i/100ms
               Komponent   431.000  i/100ms
    Calculating -------------------------------------
                 Partial     11.339k (± 9.2%) i/s -     56.760k in   5.048910s
           ViewComponent     56.099k (± 5.4%) i/s -    280.819k in   5.019196s
               Komponent      4.468k (± 7.3%) i/s -     22.412k in   5.041259s

---

I suspect that this is good for our ([Five Good Friends](https://github.com/fivegoodfriends/)) use-case, we
want to use lots of little ViewComponents as a way to build out a bit
of a component library. We'd like to have a few tiny components that
handle things like error states, laying things out in nicely spaced
rows, consistent border styles, spacing etc. This means that a few
basic components are used to build out the more complicated ones, and
those basic components get rendered a lot per view.