### PR TITLE
Fix bug where rendering Slot with empty block resulted in error.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # master
 
+# 2.17.1
+
+* Fix bug where rendering Slot with empty block resulted in error.
+
+    *Joel Hawksley*
+
 # 2.17.0
 
 * Slots return stripped HTML, removing leading and trailing whitespace.

--- a/coverage/coverage.txt
+++ b/coverage/coverage.txt
@@ -8,4 +8,4 @@ Incomplete test coverage
 /lib/view_component/preview.rb: 94.0% (missed: 47,57,107)
 /lib/view_component/render_to_string_monkey_patch.rb: 83.33% (missed: 9)
 /lib/view_component/test_helpers.rb: 91.67% (missed: 17,25)
-/test/view_component/integration_test.rb: 96.73% (missed: 14,15,16,18,20,370,371,372,374)
+/test/view_component/integration_test.rb: 96.76% (missed: 14,15,16,18,20,376,377,378,380)

--- a/lib/view_component/slotable.rb
+++ b/lib/view_component/slotable.rb
@@ -98,7 +98,7 @@ module ViewComponent
       slot_instance = args.present? ? slot_class.new(**args) : slot_class.new
 
       # Capture block and assign to slot_instance#content
-      slot_instance.content = view_context.capture(&block).strip.html_safe if block_given?
+      slot_instance.content = view_context.capture(&block).to_s.strip.html_safe if block_given?
 
       if slot[:collection]
         # Initialize instance variable as an empty array

--- a/test/app/components/empty_slot_component.rb
+++ b/test/app/components/empty_slot_component.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class EmptySlotComponent < ViewComponent::Base
+  include ViewComponent::Slotable
+
+  with_slot :title
+
+  def call
+    title.content
+  end
+end

--- a/test/app/views/integration_examples/empty_slot.html.erb
+++ b/test/app/views/integration_examples/empty_slot.html.erb
@@ -1,0 +1,4 @@
+<%= render(EmptySlotComponent.new) do |component| %>
+  <% component.slot(:title) do %>
+  <% end %>
+<% end %>

--- a/test/config/routes.rb
+++ b/test/config/routes.rb
@@ -4,6 +4,7 @@ Dummy::Application.routes.draw do
   root to: "integration_examples#index"
   get :content_areas, to: "integration_examples#content_areas"
   get :slots, to: "integration_examples#slots"
+  get :empty_slot, to: "integration_examples#empty_slot"
   get :partial, to: "integration_examples#partial"
   get :content, to: "integration_examples#content"
   get :variants, to: "integration_examples#variants"

--- a/test/view_component/integration_test.rb
+++ b/test/view_component/integration_test.rb
@@ -366,6 +366,12 @@ class IntegrationTest < ActionDispatch::IntegrationTest
     assert_equal(title_node, expected_title_html)
   end
 
+  test "renders empty slot without error" do
+    get "/empty_slot"
+
+    assert_response :success
+  end
+
   if Rails.version.to_f >= 6.1
     test "rendering component using the render_component helper raises an error" do
       error = assert_raises ActionView::Template::Error do


### PR DESCRIPTION
When rendering a slot with an empty block, capturing the block
returns nil, which does not respond_to `strip`.

This bug was introduced in https://github.com/github/view_component/pull/414, part of v2.17.0.