### PR TITLE
Fix auto-loading of previews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # master
 
+* Fix auto-loading of previews (changes no longer require a server restart)
+
+    *Matt Brictson*
+
 * Add `default_preview_layout` configuration option to load custom app/views/layouts.
 
     *Jared White, Juan Manuel Ramallo*

--- a/README.md
+++ b/README.md
@@ -998,10 +998,10 @@ ViewComponent is built by:
 |@maxbeizer|@franco|@tbroad-ramsey|@jensljungblad|@bbugh|
 |Nashville, TN|Switzerland|Spring Hill, TN|New York, NY|Austin, TX|
 
-|<img src="https://avatars.githubusercontent.com/johannesengl?s=256" alt="johannesengl" width="128" />|<img src="https://avatars.githubusercontent.com/czj?s=256" alt="czj" width="128" />|<img src="https://avatars.githubusercontent.com/mrrooijen?s=256" alt="mrrooijen" width="128" />|<img src="https://avatars.githubusercontent.com/bradparker?s=256" alt="bradparker" width="128" />|
-|:---:|:---:|:---:|:---:|
-|@johannesengl|@czj|@mrrooijen|@bradparker|
-|Berlin, Germany|Paris, France|The Netherlands|Brisbane, Australia|
+|<img src="https://avatars.githubusercontent.com/johannesengl?s=256" alt="johannesengl" width="128" />|<img src="https://avatars.githubusercontent.com/czj?s=256" alt="czj" width="128" />|<img src="https://avatars.githubusercontent.com/mrrooijen?s=256" alt="mrrooijen" width="128" />|<img src="https://avatars.githubusercontent.com/bradparker?s=256" alt="bradparker" width="128" />|<img src="https://avatars.githubusercontent.com/mattbrictson?s=256" alt="mattbrictson" width="128" />|
+|:---:|:---:|:---:|:---:|:---:|
+|@johannesengl|@czj|@mrrooijen|@bradparker|@mattbrictson|
+|Berlin, Germany|Paris, France|The Netherlands|Brisbane, Australia|San Francisco|
 
 ## License
 

--- a/coverage/coverage.txt
+++ b/coverage/coverage.txt
@@ -3,10 +3,9 @@ Incomplete test coverage
 --------------------------------------------------------------------------------
 
 /app/controllers/view_components_controller.rb: 98.18% (missed: 59)
-/lib/view_component/base.rb: 97.86% (missed: 178,265,293,356)
-/lib/view_component/engine.rb: 94.64% (missed: 22,25,38)
+/lib/view_component/base.rb: 97.87% (missed: 178,268,296,359)
+/lib/view_component/engine.rb: 96.43% (missed: 22,25)
 /lib/view_component/preview.rb: 94.0% (missed: 47,57,107)
 /lib/view_component/render_to_string_monkey_patch.rb: 83.33% (missed: 9)
 /lib/view_component/test_helpers.rb: 91.67% (missed: 17,25)
-/test/view_component/integration_test.rb: 96.74% (missed: 14,15,16,18,20,371,372,373,375)
-/test/view_component/integration_test.rb: 96.76% (missed: 14,15,16,18,20,376,377,378,380)
+/test/view_component/integration_test.rb: 96.77% (missed: 14,15,16,18,20,377,378,379,381)

--- a/lib/view_component/engine.rb
+++ b/lib/view_component/engine.rb
@@ -34,8 +34,8 @@ module ViewComponent
     initializer "view_component.set_autoload_paths" do |app|
       options = app.config.view_component
 
-      if options.show_previews && options.preview_path
-        ActiveSupport::Dependencies.autoload_paths << options.preview_path
+      if options.show_previews && !options.preview_paths.empty?
+        ActiveSupport::Dependencies.autoload_paths.concat(options.preview_paths)
       end
     end
 


### PR DESCRIPTION
### Summary

Currently, the Rails server has to be manually restarted in order to pick up changes to view_component preview files. This is a bug. Auto-loading for previews worked before, but I believe it was inadvertently broken in e45338f.

This PR restores the auto-loading behavior for previews. Now if you make a change to a preview `.rb` file, the changes take effect without a server restart.
