### PR TITLE
Inline component variant bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## master
 
+## 2.22.0
+
+* Add #with_variant to enable inline component variant rendering without template files.
+
+    *Nathan Jones*
+
 ## 2.21.0
 
 * Only compile components at application initialization if eager loading is enabled.

--- a/docs/index.md
+++ b/docs/index.md
@@ -325,7 +325,7 @@ class InlineVariantComponent < ViewComponent::Base
 end
 ```
 
-And render them #with_variant:
+And render them `with_variant`:
 
 ```ruby
 <%= render InlineVariantComponent.new.with_variant(:phone) %>

--- a/docs/index.md
+++ b/docs/index.md
@@ -325,6 +325,14 @@ class InlineVariantComponent < ViewComponent::Base
 end
 ```
 
+And render them #with_variant:
+
+```ruby
+<%= render InlineVariantComponent.new.with_variant(:phone) %>
+
+# output: <%= link_to "Phone", phone_path %>
+```
+
 ### Template Inheritance
 
 Components that subclass another component inherit the parent component's

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -64,7 +64,7 @@ module ViewComponent
       @virtual_path ||= virtual_path
 
       # For template variants (+phone, +desktop, etc.)
-      @variant = @lookup_context.variants.first
+      @variant ||= @lookup_context.variants.first
 
       # For caching, such as #cache_if
       @current_template = nil unless defined?(@current_template)
@@ -147,6 +147,12 @@ module ViewComponent
 
       instance_variable_set("@#{area}".to_sym, content)
       nil
+    end
+
+    def with_variant(variant)
+      @variant = variant
+
+      self
     end
 
     private

--- a/test/app/components/inline_component.rb
+++ b/test/app/components/inline_component.rb
@@ -4,4 +4,8 @@ class InlineComponent < ViewComponent::Base
   def call
     text_field_tag :name
   end
+
+  def call_email
+    text_field_tag :email
+  end
 end

--- a/test/view_component/view_component_test.rb
+++ b/test/view_component/view_component_test.rb
@@ -40,6 +40,13 @@ class ViewComponentTest < ViewComponent::TestCase
     assert_selector("input[type='text'][name='name']")
   end
 
+  def test_render_without_template_variant
+    render_inline(InlineComponent.new.with_variant(:email))
+
+    assert_predicate InlineComponent, :compiled?
+    assert_selector("input[type='text'][name='email']")
+  end
+
   def test_render_child_without_template
     render_inline(InlineChildComponent.new)
 


### PR DESCRIPTION
<!-- See https://github.com/github/view_component/blob/master/CONTRIBUTING.md#submitting-a-pull-request  -->
Resolves #319 

### Summary

While rendering inline components without template files, unable to render variant `call` methods -- eg. `call_email` -- using the `#render :variants` option.

Non working example: 
```ruby
render(InlineComponent.new, variants: [:email])
```

### Changes

Introduces the `#with_variant` instance method, which sets the variant to be rendered inline (with and without template).