### PR TITLE
[Idea] Allow using component inside sidecar folder 

### DIFF
--- a/coverage/coverage.txt
+++ b/coverage/coverage.txt
@@ -3,7 +3,7 @@ Incomplete test coverage
 --------------------------------------------------------------------------------
 
 /app/controllers/view_components_controller.rb: 98.18% (missed: 59)
-/lib/view_component/base.rb: 97.87% (missed: 178,268,296,359)
+/lib/view_component/base.rb: 97.91% (missed: 178,268,296,359)
 /lib/view_component/engine.rb: 96.43% (missed: 22,25)
 /lib/view_component/preview.rb: 94.12% (missed: 49,59,109)
 /lib/view_component/render_to_string_monkey_patch.rb: 83.33% (missed: 9)

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -391,7 +391,15 @@ module ViewComponent
         filename = File.basename(source_location, ".rb")
         component_name = name.demodulize.underscore
 
-        sidecar_directory_files = Dir["#{directory}/#{component_name}/#{filename}.*{#{extenstions}}"]
+        # If filename is called base, source file is in sidecar folder
+        # so component name should be equal to parent folder
+        sidecar_directory_files =
+          if filename == "base"
+            component_name = File.basename(directory)
+            Dir["#{directory}/#{component_name}.*{#{extenstions}}"]
+          else
+            Dir["#{directory}/#{component_name}/#{filename}.*{#{extenstions}}"]
+          end
 
         (sidecar_files - [source_location] + sidecar_directory_files)
       end

--- a/test/app/components/inside_sidecar_directory_component/base.rb
+++ b/test/app/components/inside_sidecar_directory_component/base.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class InsideSidecarDirectoryComponent::Base < ViewComponent::Base
+end

--- a/test/app/components/inside_sidecar_directory_component/inside_sidecar_directory_component.html.erb
+++ b/test/app/components/inside_sidecar_directory_component/inside_sidecar_directory_component.html.erb
@@ -1,0 +1,1 @@
+<div>hello, world!</div>

--- a/test/view_component/view_component_test.rb
+++ b/test/view_component/view_component_test.rb
@@ -363,6 +363,12 @@ class ViewComponentTest < ViewComponent::TestCase
     assert_text("hello, world!")
   end
 
+  def test_renders_component_inside_sidecar_directory
+    render_inline(InsideSidecarDirectoryComponent::Base.new)
+
+    assert_text("hello, world!")
+  end
+
   def test_renders_component_with_request_context
     render_inline(RequestComponent.new)
 


### PR DESCRIPTION
Hi again! @joelhawksley 

We currently have ~40 components and growing! and we were wondering if there is a way to place the main component class inside the sidecar folder. That would help us to keep a tidy `/components` folder and search for component files faster (due to folders being listed first than files)

I tried the following structure:
```
components
  |--> test_component
          |--> test_component.rb
          |--> test_component.html.erb
```
But it raises an error for `TestComponent` for being defined as a `Module` and as a `Class`

Defining a different name for the class can be a bit confusing and also causes a disconnection between the Component and its sidecar assets. 

I did a small PoC using `base` as a default name for the main file inside the sidecar folder. It is working but the test is failing randomly. 

Before continuing I'd like to know if this is something worth pursuing? What are your thoughts about this use case? or maybe I missed something in the docs?

Happy to hear from you 😄 