### PR TITLE
Update Readme for Component class inside Sidecar folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,9 +360,9 @@ bin/rails generate component Example title content --sidecar
       create  app/components/example_component/example_component.html.erb
 ```
 
-#### Component inside Sidecar directory
+#### Component file inside Sidecar directory
 
-ViewComponents also support the possibility of placing the Ruby component class inside the sidecar directory, grouping all related files in the same folder.
+It's also possible to place the Ruby component file inside the sidecar directory, grouping all related files in the same folder:
 
 _Note: Avoid giving your containing folder the same name as your `.rb` file or there will be a conflict between Module and Class definitions_
 

--- a/README.md
+++ b/README.md
@@ -364,7 +364,7 @@ bin/rails generate component Example title content --sidecar
 
 ViewComponents also support the possibility of placing the Ruby component class inside the sidecar directory, grouping all related files in the same folder.
 
-> **Avoid** giving your containing folder the same name as your `.rb` file or there will be a conflict between Module and Class definitions
+_Note: Avoid giving your containing folder the same name as your `.rb` file or there will be a conflict between Module and Class definitions_
 
 ```
 app/components
@@ -378,7 +378,7 @@ app/components
 
 ```
 
-Rendering is as simple as using the folder's name as a namespace:
+The component can then be rendered using the folder name as a namespace:
 
 ```erb
 <%= render(Example::Component.new(title: "my title")) do %>

--- a/README.md
+++ b/README.md
@@ -360,6 +360,32 @@ bin/rails generate component Example title content --sidecar
       create  app/components/example_component/example_component.html.erb
 ```
 
+#### Component inside Sidecar directory
+
+ViewComponents also support the possibility of placing the Ruby component class inside the sidecar directory, grouping all related files in the same folder.
+
+> **Avoid** giving your containing folder the same name as your `.rb` file or there will be a conflict between Module and Class definitions
+
+```
+app/components
+├── ...
+├── example
+|   ├── component.rb
+|   ├── component.css
+|   ├── component.html.erb
+|   └── component.js
+├── ...
+
+```
+
+Rendering is as simple as using the folder's name as a namespace:
+
+```erb
+<%= render(Example::Component.new(title: "my title")) do %>
+  Hello, World!
+<% end %>
+```
+
 ### Conditional Rendering
 
 Components can implement a `#render?` method to be called after initialization to determine if the component should render.
@@ -1002,6 +1028,11 @@ ViewComponent is built by:
 |:---:|:---:|:---:|:---:|:---:|
 |@johannesengl|@czj|@mrrooijen|@bradparker|@mattbrictson|
 |Berlin, Germany|Paris, France|The Netherlands|Brisbane, Australia|San Francisco|
+
+|<img src="https://avatars.githubusercontent.com/mixergtz?s=256" alt="mixergtz" width="128" />|
+|:---:|
+|@mixergtz|
+|Medellin, Colombia|
 
 ## License
 

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -381,17 +381,17 @@ module ViewComponent
 
         location_without_extension = source_location.chomp(File.extname(source_location))
 
-        extenstions = ActionView::Template.template_handler_extensions.join(",")
+        extensions = ActionView::Template.template_handler_extensions.join(",")
 
-        # view files in the same directory as te component
-        sidecar_files = Dir["#{location_without_extension}.*{#{extenstions}}"]
+        # view files in the same directory as the component
+        sidecar_files = Dir["#{location_without_extension}.*{#{extensions}}"]
 
         # view files in a directory named like the component
         directory = File.dirname(source_location)
         filename = File.basename(source_location, ".rb")
         component_name = name.demodulize.underscore
 
-        sidecar_directory_files = Dir["#{directory}/#{component_name}/#{filename}.*{#{extenstions}}"]
+        sidecar_directory_files = Dir["#{directory}/#{component_name}/#{filename}.*{#{extensions}}"]
 
         (sidecar_files - [source_location] + sidecar_directory_files)
       end


### PR DESCRIPTION
<!-- See https://github.com/github/view_component/blob/master/CONTRIBUTING.md#submitting-a-pull-request  -->

### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->
Hi guys! 👋  

This time it's a small PR updating the Readme on having the component main class inside the same folder as other assets. As pointed out [here](https://github.com/github/view_component/pull/441#issuecomment-670805497)

The overall idea is to provide a small note to some folks trying to organize all their component code inside the same folder.

### Extra

There's a [bonus commit](https://github.com/github/view_component/commit/c44ed5f13f4ea975fe04694e9d5d351364b4b474) fixing 2 small typos on `ViewComponent::Base#matching_views_in_source_location`

I'm always happy to work on feedback 😄 