### PR TITLE
lint before running tests

### DIFF
--- a/.github/workflows/ruby_on_rails.yml
+++ b/.github/workflows/ruby_on_rails.yml
@@ -1,4 +1,4 @@
-name: Ruby on Rails
+name: CI
 
 on: [push, pull_request]
 
@@ -17,7 +17,7 @@ jobs:
         bundle update
         bundle install --jobs 4 --retry 3
         bundle exec rubocop
-  build:
+  test:
     needs: lint
     runs-on: ubuntu-latest
     strategy:
@@ -55,7 +55,7 @@ jobs:
         name: simplecov-resultset-rails${{matrix.rails_version}}-ruby${{matrix.ruby_version}}
         path: coverage
   coverage:
-    needs: build
+    needs: test
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master

--- a/.github/workflows/ruby_on_rails.yml
+++ b/.github/workflows/ruby_on_rails.yml
@@ -13,6 +13,7 @@ jobs:
         ruby-version: 2.7.x
     - name: Build and test with Rake
       run: |
+        gem install bundler:1.17.3
         bundle update
         bundle install --jobs 4 --retry 3
         bundle exec rubocop

--- a/.github/workflows/ruby_on_rails.yml
+++ b/.github/workflows/ruby_on_rails.yml
@@ -3,7 +3,21 @@ name: Ruby on Rails
 on: [push, pull_request]
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Setup Ruby
+      uses: actions/setup-ruby@v1
+      with:
+        ruby-version: 2.7.x
+    - name: Build and test with Rake
+      run: |
+        bundle update
+        bundle install --jobs 4 --retry 3
+        bundle exec rubocop
   build:
+    needs: lint
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/ruby_on_rails.yml
+++ b/.github/workflows/ruby_on_rails.yml
@@ -11,7 +11,7 @@ jobs:
       uses: actions/setup-ruby@v1
       with:
         ruby-version: 2.7.x
-    - name: Build and test with Rake
+    - name: Lint with Rubocop
       run: |
         gem install bundler:1.17.3
         bundle update
@@ -71,4 +71,3 @@ jobs:
         bundle update
         bundle install --jobs 4 --retry 3
         bundle exec rake coverage:report
-

--- a/.github/workflows/ruby_on_rails.yml
+++ b/.github/workflows/ruby_on_rails.yml
@@ -45,7 +45,6 @@ jobs:
         bundle update
         bundle install --jobs 4 --retry 3
         bundle exec rake
-        bundle exec rubocop
       env:
         RAILS_VERSION: ${{ matrix.rails_version }}
     - name: Upload coverage results


### PR DESCRIPTION
This PR changes our CI workflow to run rubocop before
running our test matrices, as:

1) It's unnecessary to run `rubocop` for each of our
FOURTEEN matrices!

2) If a workflow is going to fail due to linters, it's
a nicer developer experience to have that failure happen as quickly
as possible.

cc @manuelpuyol