### PR TITLE
Raise errors if helpers/controller are called before render

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # master
 
+* Raise an error if controller or view context is accessed during initialize as they are only available in render.
+
+    *Julian Nadeau*
+
 * Collate test coverage across CI builds, ensuring 100% test coverage.
 
     *Joel Hawksley*

--- a/README.md
+++ b/README.md
@@ -1031,10 +1031,10 @@ ViewComponent is built by:
 |@johannesengl|@czj|@mrrooijen|@bradparker|@mattbrictson|
 |Berlin, Germany|Paris, France|The Netherlands|Brisbane, Australia|San Francisco|
 
-|<img src="https://avatars.githubusercontent.com/mixergtz?s=256" alt="mixergtz" width="128" />|
-|:---:|
-|@mixergtz|
-|Medellin, Colombia|
+|<img src="https://avatars.githubusercontent.com/mixergtz?s=256" alt="mixergtz" width="128" />|<img src="https://avatars.githubusercontent.com/jules2689?s=256" alt="jules2689" width="128" />|
+|:---:|:---:|
+|@mixergtz|@jules2689|
+|Medellin, Colombia|Toronto, Canada|
 
 ## License
 

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -116,7 +116,7 @@ module ViewComponent
 
     # Provides a proxy to access helper methods from the context of the current controller
     def helpers
-      raise ViewContextCalledBeforeRenderError, "`helpers` can only be called at render time." if controller.view_context.nil?
+      raise ViewContextCalledBeforeRenderError, "`helpers` can only be called at render time." if view_context.nil?
       @helpers ||= controller.view_context
     end
 

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -75,7 +75,6 @@ module ViewComponent
       @content = view_context.capture(self, &block) if block_given?
 
       before_render
-      @render_in_called = true
 
       if render?
         send(self.class.call_method_name(@variant))
@@ -111,13 +110,13 @@ module ViewComponent
     end
 
     def controller
-      raise ViewContextCalledBeforeRenderError, "Cannot call `controller` from initialize. Must be called during render" unless @render_in_called
+      raise ViewContextCalledBeforeRenderError, "`controller` can only be called at render time." if view_context.nil?
       @controller ||= view_context.controller
     end
 
     # Provides a proxy to access helper methods from the context of the current controller
     def helpers
-      raise ViewContextCalledBeforeRenderError, "Cannot call `helpers` from initialize. Must be called during render" unless @render_in_called
+      raise ViewContextCalledBeforeRenderError, "`helpers` can only be called at render time." if controller.nil?
       @helpers ||= controller.view_context
     end
 

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -116,7 +116,7 @@ module ViewComponent
 
     # Provides a proxy to access helper methods from the context of the current controller
     def helpers
-      raise ViewContextCalledBeforeRenderError, "`helpers` can only be called at render time." if controller.nil?
+      raise ViewContextCalledBeforeRenderError, "`helpers` can only be called at render time." if view_context.nil?
       @helpers ||= controller.view_context
     end
 

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -116,7 +116,7 @@ module ViewComponent
 
     # Provides a proxy to access helper methods from the context of the current controller
     def helpers
-      raise ViewContextCalledBeforeRenderError, "`helpers` can only be called at render time." if view_context.nil?
+      raise ViewContextCalledBeforeRenderError, "`helpers` can only be called at render time." if controller.view_context.nil?
       @helpers ||= controller.view_context
     end
 

--- a/test/view_component/base_test.rb
+++ b/test/view_component/base_test.rb
@@ -31,7 +31,7 @@ class ViewComponent::Base::UnitTest < Minitest::Test
     err = assert_raises ViewComponent::Base::ViewContextCalledBeforeRenderError do
       component.helpers
     end
-    assert_equal "Cannot call `helpers` from initialize. Must be called during render", err.message
+    assert_equal "`helpers` can only be called at render time.", err.message
   end
 
   def test_calling_controller_outside_render_raises
@@ -39,6 +39,6 @@ class ViewComponent::Base::UnitTest < Minitest::Test
     err = assert_raises ViewComponent::Base::ViewContextCalledBeforeRenderError do
       component.controller
     end
-    assert_equal "Cannot call `controller` from initialize. Must be called during render", err.message
+    assert_equal "`controller` can only be called at render time.", err.message
   end
 end

--- a/test/view_component/base_test.rb
+++ b/test/view_component/base_test.rb
@@ -25,4 +25,20 @@ class ViewComponent::Base::UnitTest < Minitest::Test
       end
     end
   end
+
+  def test_calling_helpers_outside_render_raises
+    component = ViewComponent::Base.new
+    err = assert_raises ViewComponent::Base::ViewContextCalledBeforeRenderError do
+      component.helpers
+    end
+    assert_equal "Cannot call `helpers` from initialize. Must be called during render", err.message
+  end
+
+  def test_calling_controller_outside_render_raises
+    component = ViewComponent::Base.new
+    err = assert_raises ViewComponent::Base::ViewContextCalledBeforeRenderError do
+      component.controller
+    end
+    assert_equal "Cannot call `controller` from initialize. Must be called during render", err.message
+  end
 end


### PR DESCRIPTION
As we only set view context during render, we cannot call into any view-context
objects like helpers or controllers.

Unfortunately the error is really obtuse, so this adds a proper exception to tell
the developer exactly what is going on
