### PR TITLE
Allow customization of the controller used in component tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## main
 
+* Allow customization of the controller used in component tests.
+
+    *Alex Robbin*
+
 * Generate preview at overridden path if one exists when using `--preview` flag.
 
     *Nishiki Liu*

--- a/docs/index.md
+++ b/docs/index.md
@@ -936,14 +936,34 @@ Previews can be extended to allow users to add authentication, authorization, be
 config.view_component.preview_controller = "MyPreviewController"
 ```
 
-#### Configuring TestController
+### Configuring the controller used in tests
 
-Component tests assume the existence of an `ApplicationController` class, which be can be configured using the `test_controller` option:
-
-`config/application.rb`
+Component tests assume the existence of an `ApplicationController` class, which can be configured globally using the `test_controller` option:
 
 ```ruby
 config.view_component.test_controller = "BaseController"
+```
+
+To configure the controller used for a test case, use `with_controller_class` from `ViewComponent::TestHelpers`.
+
+```ruby
+class ExampleComponentTest < ViewComponent::TestCase
+  def test_component_in_public_controller
+    with_controller_class PublicController do
+      render_inline ExampleComponent.new
+
+      assert_text "foo"
+    end
+  end
+
+  def test_component_in_authenticated_controller
+    with_controller_class AuthenticatedController do
+      render_inline ExampleComponent.new
+
+      assert_text "bar"
+    end
+  end
+end
 ```
 
 ### Setting up RSpec

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -193,8 +193,9 @@ module ViewComponent
     end
 
     # The controller used for testing components.
-    # Defaults to ApplicationController. This should be set early
-    # in the initialization process and should be set to a string.
+    # Defaults to ApplicationController, but can be configured
+    # on a per-test basis using `with_controller_class`.
+    # This should be set early in the initialization process and should be a string.
     mattr_accessor :test_controller
     @@test_controller = "ApplicationController"
 

--- a/lib/view_component/test_helpers.rb
+++ b/lib/view_component/test_helpers.rb
@@ -35,7 +35,7 @@ module ViewComponent
     end
 
     def controller
-      @controller ||= Base.test_controller.constantize.new.tap { |c| c.request = request }.extend(Rails.application.routes.url_helpers)
+      @controller ||= build_controller(Base.test_controller.constantize)
     end
 
     def request
@@ -47,7 +47,21 @@ module ViewComponent
 
       controller.view_context.lookup_context.variants = variant
       yield
+    ensure
       controller.view_context.lookup_context.variants = old_variants
+    end
+
+    def with_controller_class(klass)
+      old_controller = defined?(@controller) && @controller
+
+      @controller = build_controller(klass)
+      yield
+    ensure
+      @controller = old_controller
+    end
+
+    def build_controller(klass)
+      klass.new.tap { |c| c.request = request }.extend(Rails.application.routes.url_helpers)
     end
   end
 end

--- a/test/app/components/custom_test_controller_component.rb
+++ b/test/app/components/custom_test_controller_component.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class CustomTestControllerComponent < ViewComponent::Base
+  def call
+    helpers.foo
+  end
+end

--- a/test/app/controllers/custom_test_controller_controller.rb
+++ b/test/app/controllers/custom_test_controller_controller.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class CustomTestControllerController < ActionController::Base
+  helper_method :foo
+
+  private
+
+  def foo
+    "foo"
+  end
+end

--- a/test/view_component/view_component_test.rb
+++ b/test/view_component/view_component_test.rb
@@ -478,6 +478,14 @@ class ViewComponentTest < ViewComponent::TestCase
     assert_includes error.message, "More than one template found for TemplateAndSidecarDirectoryTemplateComponent."
   end
 
+  def test_with_custom_test_controller
+    with_controller_class CustomTestControllerController do
+      render_inline(CustomTestControllerComponent.new)
+
+      assert_text("foo")
+    end
+  end
+
   def test_backtrace_returns_correct_file_and_line_number
     error = assert_raises NameError do
       render_inline(ExceptionInTemplateComponent.new)


### PR DESCRIPTION
Sorry this took me so long to get back to @joelhawksley! Finally was able to spend some time here during the long weekend.

### Summary

If you have different namespaces within your application, or possibly public and authenticated controllers, which change component functionality in specific ways, you can now configure a different controller in component tests.

Closes #440.