### PR TITLE
add more exempt labels to stalebot

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -6,6 +6,8 @@ daysUntilClose: 7
 exemptLabels:
   - pinned
   - security
+  - active
+  - help wanted
 # Label to use when marking an issue as stale
 staleLabel: stale
 # Comment to post when marking an issue as stale. Set to `false` to disable


### PR DESCRIPTION
I'd like to be able to exempt more issues/PRs from stalebot.
Let's add these labels to do so.