### PR TITLE
Bump to v2.18.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # master
 
+# 2.18.2
+
 * Raise an error if controller or view context is accessed during initialize as they are only available in render.
 
     *Julian Nadeau*

--- a/lib/view_component/version.rb
+++ b/lib/view_component/version.rb
@@ -4,7 +4,7 @@ module ViewComponent
   module VERSION
     MAJOR = 2
     MINOR = 18
-    PATCH = 1
+    PATCH = 2
 
     STRING = [MAJOR, MINOR, PATCH].join(".")
   end


### PR DESCRIPTION
Bumps the version to 2.18.2

## Changes

* Raise an error if controller or view context is accessed during initialize as they are only available in render.

    *Julian Nadeau*

* Collate test coverage across CI builds, ensuring 100% test coverage.

    *Joel Hawksley*
