### PR TITLE
Fix uninitialized constant error from with_collection when eager_load is disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # master
 
+* Fix uninitialized constant error from with_collection when eager_load is disabled
+
+    *Josh Gross*
+
 # 2.18.2
 
 * Raise an error if controller or view context is accessed during initialize as they are only available in render.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # master
 
-* Fix uninitialized constant error from with_collection when eager_load is disabled
+* Fix uninitialized constant error from `with_collection` when `eager_load` is disabled.
 
     *Josh Gross*
 

--- a/lib/view_component/collection.rb
+++ b/lib/view_component/collection.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_dependency "action_view/renderer/collection_renderer" if Rails.version.to_f >= 6.1
+
 module ViewComponent
   class Collection
     def render_in(view_context, &block)

--- a/lib/view_component/collection.rb
+++ b/lib/view_component/collection.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_dependency "action_view/renderer/collection_renderer" if Rails.version.to_f >= 6.1
+require "action_view/renderer/collection_renderer" if Rails.version.to_f >= 6.1
 
 module ViewComponent
   class Collection


### PR DESCRIPTION
Fixes https://github.com/github/view_component/issues/461


### Summary

When eager_load is disabled on Rails 6.1, `with_collection` will fail with the error `uninitialized constant ActionView::PartialIteration`. This was caused by Rails 6.1 moving ActionView::PartialIteration to `lib/action_view/renderer/collection_renderer.rb` which broke the autoloading
Since eager_load is typically enabled in production and tests, this error did was not reproducible in CI.

