### PR TITLE
lint markdown files

### DIFF
--- a/.github/lint/markdown.json
+++ b/.github/lint/markdown.json
@@ -1,0 +1,4 @@
+{
+  "default": true,
+  "line_length": false
+}

--- a/.github/lint/markdown.json
+++ b/.github/lint/markdown.json
@@ -1,5 +1,7 @@
 {
   "default": true,
   "line_length": false,
-  "ol-prefix": false
+  "ol-prefix": false,
+  "no-trailing-punctuation": false,
+  "no-inline-html": false
 }

--- a/.github/lint/markdown.json
+++ b/.github/lint/markdown.json
@@ -1,4 +1,5 @@
 {
   "default": true,
-  "line_length": false
+  "line_length": false,
+  "ol-prefix": false
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,7 @@ name: CI
 on: [push, pull_request]
 
 jobs:
-  lint-markdown:
-    name: Lint markdown files
+  markdown:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,14 @@ name: CI
 on: [push, pull_request]
 
 jobs:
+  lint-markdown:
+    name: Lint markdown files
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - uses: avto-dev/markdown-lint@v1
+      with:
+        args: '**/*.md'
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ jobs:
     - uses: actions/checkout@master
     - uses: avto-dev/markdown-lint@v1
       with:
+        config: '.github/lint/markdown.json'
         args: '**/*.md'
   lint:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -229,13 +229,13 @@
 
 * Move to `ViewComponent` namespace, removing all references to `ActionView`.
 
-    * The gem name is now `view_component`.
-    * ViewComponent previews are now accessed at `/rails/view_components`.
-    * ViewComponents can _only_ be rendered with the instance syntax: `render(MyComponent.new)`. Support for all other syntaxes has been removed.
-    * ActiveModel::Validations have been removed. ViewComponent generators no longer include validations.
-    * In Rails 6.1, no monkey patching is used.
-    * `to_component_class` has been removed.
-    * All gem configuration is now in `config.view_component`.
+  * The gem name is now `view_component`.
+  * ViewComponent previews are now accessed at `/rails/view_components`.
+  * ViewComponents can _only_ be rendered with the instance syntax: `render(MyComponent.new)`. Support for all other syntaxes has been removed.
+  * ActiveModel::Validations have been removed. ViewComponent generators no longer include validations.
+  * In Rails 6.1, no monkey patching is used.
+  * `to_component_class` has been removed.
+  * All gem configuration is now in `config.view_component`.
 
 ## v1.17.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# CHANGELOG
+
 ## master
 
 ## 2.18.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-# master
+## master
 
-# 2.18.2
+## 2.18.2
 
 * Raise an error if controller or view context is accessed during initialize as they are only available in render.
 
@@ -10,13 +10,13 @@
 
     *Joel Hawksley*
 
-# 2.18.1
+## 2.18.1
 
 * Fix bug where previews didn't work when monkey patch was disabled.
 
     *Mixer Gutierrez*
 
-# 2.18.0
+## 2.18.0
 
 * Fix auto-loading of previews (changes no longer require a server restart)
 
@@ -30,31 +30,31 @@
 
     *Brad Parker*
 
-# 2.17.1
+## 2.17.1
 
 * Fix bug where rendering Slot with empty block resulted in error.
 
     *Joel Hawksley*
 
-# 2.17.0
+## 2.17.0
 
 * Slots return stripped HTML, removing leading and trailing whitespace.
 
     *Jason Long, Joel Hawksley*
 
-# 2.16.0
+## 2.16.0
 
 * Add `--sidecar` option to the erb, haml and slim generators. Places the generated template in the sidecar directory.
 
     *Michael van Rooijen*
 
-# 2.15.0
+## 2.15.0
 
 * Add support for templates as ViewComponent::Preview examples.
 
     *Juan Manuel Ramallo
 
-# 2.14.1
+## 2.14.1
 
 * Allow using `render_inline` in test when the render monkey patch is disabled with `config.view_component.render_monkey_patch_enabled = false` in versions of Rails < 6.1.
 
@@ -71,7 +71,7 @@
 
     *Eileen M. Uchitelle*
 
-# 2.14.0
+## 2.14.0
 
 * Add `config.preview_paths` to support multiple locations of component preview files. Deprecate `config.preview_path`.
 
@@ -81,25 +81,25 @@
 
     *Richard Macklin*
 
-# 2.13.0
+## 2.13.0
 
 * Add the ability to disable the render monkey patch with `config.view_component.render_monkey_patch_enabled`. In versions of Rails < 6.1, add `render_component` and `render_component_to_string` methods which can be used for rendering components instead of `render`.
 
     *Johannes Engl*
 
-# 2.12.0
+## 2.12.0
 
 * Implement Slots as potential successor to Content Areas.
 
     *Jens Ljungblad, Brian Bugh, Jon Palmer, Joel Hawksley*
 
-# 2.11.1
+## 2.11.1
 
 * Fix kwarg warnings in Ruby 2.7.
 
     *Joel Hawksley*
 
-# 2.11.0
+## 2.11.0
 
 * Ensure Rails configuration is available within components.
 
@@ -109,25 +109,25 @@
 
     *Franco Sebregondi*
 
-# 2.10.0
+## 2.10.0
 
 * Raise an `ArgumentError` with a helpful message when Ruby cannot parse a component class.
 
     *Max Beizer*
 
-# 2.9.0
+## 2.9.0
 
 * Cache components per-request in development, preventing unnecessary recompilation during a single request.
 
     *Felipe Sateler*
 
-# 2.8.0
+## 2.8.0
 
 * Add `before_render`, deprecating `before_render_check`.
 
     *Joel Hawksley*
 
-# 2.7.0
+## 2.7.0
 
 * Add `rendered_component` method to `ViewComponent::TestHelpers` which exposes the raw output of the rendered component.
 
@@ -137,7 +137,7 @@
 
     *Jon Palmer*
 
-# 2.6.0
+## 2.6.0
 
 * Add `config.view_component.preview_route` to set the endpoint for component previews. By default `/rails/view_components` is used.
 
@@ -147,13 +147,13 @@
 
     *Joel Hawksley*
 
-# 2.5.1
+## 2.5.1
 
 * Compile component before rendering collection.
 
     *Rainer Borene*
 
-# v2.5.0
+## v2.5.0
 
 * Add counter variables when rendering collections.
 
@@ -163,7 +163,7 @@
 
     *Fabio Cantoni*
 
-# v2.4.0
+## v2.4.0
 
 * Add `#render_to_string` support.
 
@@ -181,7 +181,7 @@
 
     *Richard Macklin*
 
-# v2.3.0
+## v2.3.0
 
 * Allow using inline render method(s) defined on a parent.
 
@@ -195,19 +195,19 @@
 
     *Juan Manuel Ramallo*
 
-# v2.2.2
+## v2.2.2
 
 * Add `Base.format` for better compatibility with `ActionView::Template`.
 
     *Joel Hawksley*
 
-# v2.2.1
+## v2.2.1
 
 * Fix bug where template could not be found if `inherited` was redefined.
 
     *Joel Hawksley*
 
-# v2.2.0
+## v2.2.0
 
 * Add support for `config.action_view.annotate_template_file_names` (coming in Rails 6.1).
 
@@ -217,13 +217,13 @@
 
     *Vasiliy Ermolovich*
 
-# v2.1.0
+## v2.1.0
 
 * Support rendering collections (e.g., `render(MyComponent.with_collection(@items))`).
 
     *Tim Clem*
 
-# v2.0.0
+## v2.0.0
 
 * Move to `ViewComponent` namespace, removing all references to `ActionView`.
 
@@ -235,7 +235,7 @@
     * `to_component_class` has been removed.
     * All gem configuration is now in `config.view_component`.
 
-# v1.17.0
+## v1.17.0
 
 * Support Ruby 2.4 in CI.
 
@@ -249,7 +249,7 @@
 
     *Joel Hawksley*
 
-# v1.16.0
+## v1.16.0
 
 * Add `refute_component_rendered` test helper.
 
@@ -263,7 +263,7 @@
 
     *Rainer Borene*
 
-# v1.15.0
+## v1.15.0
 
 * Re-introduce ActionView::Component::TestHelpers.
 
@@ -287,19 +287,19 @@
 
     *Sean Doyle*
 
-# v1.14.1
+## v1.14.1
 
 * Fix bug where generator created invalid test code.
 
     *Joel Hawksley*
 
-# v1.14.0
+## v1.14.0
 
 * Rename ActionView::Component::Base to ViewComponent::Base
 
     *Joel Hawksley*
 
-# v1.13.0
+## v1.13.0
 
 * Allow components to be rendered inside controllers.
 
@@ -309,7 +309,7 @@
 
     *Blake Williams*
 
-# v1.12.0
+## v1.12.0
 
 * Revert: Remove initializer requirement for Ruby 2.7+
 
@@ -323,13 +323,13 @@
 
     *Joel Hawksley*
 
-# v1.11.1
+## v1.11.1
 
 * Relax Capybara requirement.
 
     *Joel Hawksley*
 
-# v1.11.0
+## v1.11.0
 
 * Add support for Capybara matchers.
 
@@ -339,25 +339,25 @@
 
     *Asger Behncke Jacobsen*
 
-# v1.10.0
+## v1.10.0
 
 * Deprecate all `render` syntaxes except for `render(MyComponent.new(foo: :bar))`
 
     *Joel Hawksley*
 
-# v1.9.0
+## v1.9.0
 
 * Remove initializer requirement for Ruby 2.7+
 
     *Dylan Clark*
 
-# v1.8.1
+## v1.8.1
 
 * Run validation checks before calling `#render?`.
 
     *Ash Wilson*
 
-# v1.8.0
+## v1.8.0
 
 * Remove the unneeded ComponentExamplesController and simplify preview rendering.
 
@@ -383,7 +383,7 @@
 
     *Sergey Malykh*
 
-# v1.7.0
+## v1.7.0
 
 * Simplify validation of templates and compilation.
 
@@ -393,7 +393,7 @@
 
     *Jon Palmer*
 
-# v1.6.2
+## v1.6.2
 
 * Fix Uninitialized Constant error.
 
@@ -407,7 +407,7 @@
 
     *Justin Coyne*
 
-# v1.6.1
+## v1.6.1
 
 * Allow Previews to have no layout.
 
@@ -433,7 +433,7 @@
 
     *Ryan Workman*
 
-# v1.6.0
+## v1.6.0
 
 * Avoid dropping elements in the render_inline test helper.
 
@@ -463,7 +463,7 @@
 
     *Vinicius Stock*
 
-# v1.5.3
+## v1.5.3
 
 * Add support for RSpec to generators.
 
@@ -473,19 +473,19 @@
 
     *Joel Hawksley*
 
-# v1.5.2
+## v1.5.2
 
 * Disable eager loading initializer.
 
     *Kasper Meyer*
 
-# v1.5.1
+## v1.5.1
 
 * Update railties class to work with Rails 6.
 
     *Juan Manuel Ramallo*
 
-# v1.5.0
+## v1.5.0
 
 Note: `actionview-component` is now loaded by requiring `actionview/component`, not `actionview/component/base`.
 
@@ -505,7 +505,7 @@ Note: `actionview-component` is now loaded by requiring `actionview/component`, 
 
     *Juan Manuel Ramallo*
 
-# v1.4.0
+## v1.4.0
 
 * Fix bug where components broke in application paths with periods.
 
@@ -527,7 +527,7 @@ Note: `actionview-component` is now loaded by requiring `actionview/component`, 
 
     *Elia Schito*
 
-# v1.3.6
+## v1.3.6
 
 * Allow template file names without format.
 
@@ -537,7 +537,7 @@ Note: `actionview-component` is now loaded by requiring `actionview/component`, 
 
     *Juan Manuel Ramallo*
 
-# v1.3.5
+## v1.3.5
 
 * Re-expose `controller` method.
 
@@ -551,7 +551,7 @@ Note: `actionview-component` is now loaded by requiring `actionview/component`, 
 
     *ars moriendi*
 
-# v1.3.4
+## v1.3.4
 
 * Template errors surface correct file and line number.
 
@@ -561,35 +561,35 @@ Note: `actionview-component` is now loaded by requiring `actionview/component`, 
 
     *Joel Hawksley*
 
-# v1.3.3
+## v1.3.3
 
 *   Do not raise error when sidecar files that are not templates exist.
 
     *Joel Hawksley*
 
-# v1.3.2
+## v1.3.2
 
 *   Support rendering views from inside component templates.
 
     *Patrick Sinclair*
 
-# v1.3.1
+## v1.3.1
 
 *   Fix bug where rendering nested content caused an error.
 
     *Joel Hawksley, Aaron Patterson*
 
-# v1.3.0
+## v1.3.0
 
 *   Components are rendered with enough controller context to support rendering of partials and forms.
 
     *Patrick Sinclair, Joel Hawksley, Aaron Patterson*
 
-# v1.2.1
+## v1.2.1
 
 *   `actionview-component` is now tested against Ruby 2.3/2.4 and Rails 5.0.0.
 
-# v1.2.0
+## v1.2.0
 
 *   The `render_component` test helper has been renamed to `render_inline`. `render_component` has been deprecated and will be removed in v2.0.0.
 
@@ -599,19 +599,19 @@ Note: `actionview-component` is now loaded by requiring `actionview/component`, 
 
     *Joel Hawksley*
 
-# v1.1.0
+## v1.1.0
 
 *   Components now inherit from ActionView::Component::Base
 
     *Joel Hawksley*
 
-# v1.0.1
+## v1.0.1
 
 *   Always recompile component templates outside production.
 
     *Joel Hawksley, John Hawthorn*
 
-# v1.0.0
+## v1.0.0
 
 This release extracts the `ActionView::Component` library from the GitHub application.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,7 +66,7 @@
 
     Fixes:
 
-    ```
+    ```console
     view_component/lib/view_component/slotable.rb:98: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
     view_component/test/app/components/slots_component.rb:18: warning: The called method `initialize' is defined here
     ```
@@ -565,51 +565,51 @@ Note: `actionview-component` is now loaded by requiring `actionview/component`, 
 
 ## v1.3.3
 
-*   Do not raise error when sidecar files that are not templates exist.
+* Do not raise error when sidecar files that are not templates exist.
 
     *Joel Hawksley*
 
 ## v1.3.2
 
-*   Support rendering views from inside component templates.
+* Support rendering views from inside component templates.
 
     *Patrick Sinclair*
 
 ## v1.3.1
 
-*   Fix bug where rendering nested content caused an error.
+* Fix bug where rendering nested content caused an error.
 
     *Joel Hawksley, Aaron Patterson*
 
 ## v1.3.0
 
-*   Components are rendered with enough controller context to support rendering of partials and forms.
+* Components are rendered with enough controller context to support rendering of partials and forms.
 
     *Patrick Sinclair, Joel Hawksley, Aaron Patterson*
 
 ## v1.2.1
 
-*   `actionview-component` is now tested against Ruby 2.3/2.4 and Rails 5.0.0.
+* `actionview-component` is now tested against Ruby 2.3/2.4 and Rails 5.0.0.
 
 ## v1.2.0
 
-*   The `render_component` test helper has been renamed to `render_inline`. `render_component` has been deprecated and will be removed in v2.0.0.
+* The `render_component` test helper has been renamed to `render_inline`. `render_component` has been deprecated and will be removed in v2.0.0.
 
     *Joel Hawksley*
 
-*   Components are now rendered with `render MyComponent, foo: :bar` syntax. The existing `render MyComponent.new(foo: :bar)` syntax has been deprecated and will be removed in v2.0.0.
+* Components are now rendered with `render MyComponent, foo: :bar` syntax. The existing `render MyComponent.new(foo: :bar)` syntax has been deprecated and will be removed in v2.0.0.
 
     *Joel Hawksley*
 
 ## v1.1.0
 
-*   Components now inherit from ActionView::Component::Base
+* Components now inherit from ActionView::Component::Base
 
     *Joel Hawksley*
 
 ## v1.0.1
 
-*   Always recompile component templates outside production.
+* Always recompile component templates outside production.
 
     *Joel Hawksley, John Hawthorn*
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -68,9 +68,9 @@ members of the project's leadership.
 ## Attribution
 
 This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
-available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+available at [https://www.contributor-covenant.org/version/1/4/code-of-conduct.html](https://www.contributor-covenant.org/version/1/4/code-of-conduct.html)
 
 [homepage]: https://www.contributor-covenant.org
 
 For answers to common questions about this code of conduct, see
-https://www.contributor-covenant.org/faq
+[https://www.contributor-covenant.org/faq](https://www.contributor-covenant.org/faq)

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ By default, slots can be rendered once per component. They provide an accessor w
 
 Slots declared with `collection: true` can be rendered multiple times. They provide an accessor with the pluralized name of the slot (`#rows`), which is an Array of `ViewComponent::Slot` instances.
 
-To learn more about the design of the Slots API, see https://github.com/github/view_component/pull/348 and https://github.com/github/view_component/discussions/325.
+To learn more about the design of the Slots API, see [#348](https://github.com/github/view_component/pull/348) and [#325](https://github.com/github/view_component/discussions/325).
 
 ##### Defining Slots
 
@@ -1023,7 +1023,7 @@ ViewComponent is far from a novel idea! Popular implementations of view componen
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/github/view_component. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct. We recommend reading the [contributing guide](./CONTRIBUTING.md) as well.
+This project is intended to be a safe, welcoming space for collaboration. Contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct. We recommend reading the [contributing guide](./CONTRIBUTING.md) as well.
 
 ## Contributors
 

--- a/README.md
+++ b/README.md
@@ -341,7 +341,7 @@ ViewComponents supports two options for defining view files.
 
 The simplest option is to place the view next to the Ruby component:
 
-```
+```console
 app/components
 ├── ...
 ├── test_component.rb
@@ -353,7 +353,7 @@ app/components
 
 As an alternative, views and other assets can be placed in a sidecar directory with the same name as the component, which can be useful for organizing views alongside other assets like Javascript and CSS.
 
-```
+```console
 app/components
 ├── ...
 ├── example_component.rb
@@ -366,7 +366,7 @@ app/components
 
 To generate a component with a sidecar directory, use the `--sidecar` flag:
 
-```
+```console
 bin/rails generate component Example title content --sidecar
       invoke  test_unit
       create  test/components/example_component_test.rb
@@ -380,7 +380,7 @@ It's also possible to place the Ruby component file inside the sidecar directory
 
 _Note: Avoid giving your containing folder the same name as your `.rb` file or there will be a conflict between Module and Class definitions_
 
-```
+```console
 app/components
 ├── ...
 ├── example
@@ -408,7 +408,7 @@ Traditionally, the logic for whether to render a view could go in either the com
 
 `app/components/confirm_email_component.html.erb`
 
-```
+```erb
 <% if user.requires_confirmation? %>
   <div class="alert">Please confirm your email address.</div>
 <% end %>
@@ -442,7 +442,7 @@ end
 
 `app/components/confirm_email_component.html.erb`
 
-```
+```erb
 <div class="banner">
   Please confirm your email address.
 </div>
@@ -856,7 +856,7 @@ In order to [avoid conflicts](https://github.com/github/view_component/issues/28
 
 With the monkey patch disabled, use `render_component` (or  `render_component_to_string`) instead:
 
-```
+```erb
 <%= render_component Component.new(message: "bar") %>
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
 # ViewComponent
+
 ViewComponent is a framework for building view components that are reusable, testable & encapsulated, in Ruby on Rails.
 
 ## Design philosophy
+
 ViewComponent is designed to integrate as seamlessly as possible [with Rails](https://rubyonrails.org/doctrine/), with the [least surprise](https://www.artima.com/intv/ruby4.html).
 
 ## Compatibility
+
 ViewComponent is [supported natively](https://edgeguides.rubyonrails.org/layouts_and_rendering.html#rendering-objects) in Rails 6.1, and compatible with Rails 5.0+ via an included [monkey patch](https://github.com/github/view_component/blob/master/lib/view_component/render_monkey_patch.rb).
 
 ViewComponent is tested for compatibility [with combinations of](https://github.com/github/view_component/blob/22e3d4ccce70d8f32c7375e5a5ccc3f70b22a703/.github/workflows/ruby_on_rails.yml#L10-L11) Ruby 2.4+ and Rails 5+.
@@ -96,6 +99,7 @@ bin/rails generate component Example title content --template-engine slim
 A ViewComponent is a Ruby file and corresponding template file with the same base name:
 
 `app/components/test_component.rb`:
+
 ```ruby
 class TestComponent < ViewComponent::Base
   def initialize(title:)
@@ -105,6 +109,7 @@ end
 ```
 
 `app/components/test_component.html.erb`:
+
 ```erb
 <span title="<%= @title %>"><%= content %></span>
 ```
@@ -130,6 +135,7 @@ Content passed to a ViewComponent as a block is captured and assigned to the `co
 ViewComponents can declare additional content areas. For example:
 
 `app/components/modal_component.rb`:
+
 ```ruby
 class ModalComponent < ViewComponent::Base
   with_content_areas :header, :body
@@ -137,6 +143,7 @@ end
 ```
 
 `app/components/modal_component.html.erb`:
+
 ```erb
 <div class="modal">
   <div class="header"><%= header %></div>
@@ -197,6 +204,7 @@ _Note: Slot classes must be subclasses of `ViewComponent::Slot`._
 ##### Example ViewComponent with Slots
 
 `# box_component.rb`
+
 ```ruby
 class BoxComponent < ViewComponent::Base
   include ViewComponent::Slotable
@@ -241,6 +249,7 @@ end
 ```
 
 `# box_component.html.erb`
+
 ```erb
 <div class="Box">
   <% if header %>
@@ -271,6 +280,7 @@ end
 ```
 
 `# index.html.erb`
+
 ```erb
 <%= render(BoxComponent.new) do |component| %>
   <% component.slot(:header, classes: "my-class-name") do %>
@@ -296,6 +306,7 @@ end
 ViewComponents can render without a template file, by defining a `call` method:
 
 `app/components/inline_component.rb`:
+
 ```ruby
 class InlineComponent < ViewComponent::Base
   def call
@@ -351,7 +362,6 @@ app/components
 |   ├── example_component.html.erb
 |   └── example_component.js
 ├── ...
-
 ```
 
 To generate a component with a sidecar directory, use the `--sidecar` flag:
@@ -397,6 +407,7 @@ Components can implement a `#render?` method to be called after initialization t
 Traditionally, the logic for whether to render a view could go in either the component template:
 
 `app/components/confirm_email_component.html.erb`
+
 ```
 <% if user.requires_confirmation? %>
   <div class="alert">Please confirm your email address.</div>
@@ -406,6 +417,7 @@ Traditionally, the logic for whether to render a view could go in either the com
 or the view that renders the component:
 
 `app/views/_banners.html.erb`
+
 ```erb
 <% if current_user.requires_confirmation? %>
   <%= render(ConfirmEmailComponent.new(user: current_user)) %>
@@ -415,6 +427,7 @@ or the view that renders the component:
 Using the `#render?` hook simplifies the view:
 
 `app/components/confirm_email_component.rb`
+
 ```ruby
 class ConfirmEmailComponent < ViewComponent::Base
   def initialize(user:)
@@ -428,6 +441,7 @@ end
 ```
 
 `app/components/confirm_email_component.html.erb`
+
 ```
 <div class="banner">
   Please confirm your email address.
@@ -435,6 +449,7 @@ end
 ```
 
 `app/views/_banners.html.erb`
+
 ```erb
 <%= render(ConfirmEmailComponent.new(user: current_user)) %>
 ```
@@ -446,6 +461,7 @@ _To assert that a component has not been rendered, use `refute_component_rendere
 Components can define a `before_render` method to be called before a component is rendered, when `helpers` is able to be used:
 
 `app/components/confirm_email_component.rb`
+
 ```ruby
 class MyComponent < ViewComponent::Base
   def before_render
@@ -459,11 +475,13 @@ end
 Use `with_collection` to render a ViewComponent with a collection:
 
 `app/view/products/index.html.erb`
+
 ``` erb
 <%= render(ProductComponent.with_collection(@products)) %>
 ```
 
 `app/components/product_component.rb`
+
 ``` ruby
 class ProductComponent < ViewComponent::Base
   def initialize(product:)
@@ -479,6 +497,7 @@ end
 Use `with_collection_parameter` to change the name of the collection parameter:
 
 `app/components/product_component.rb`
+
 ``` ruby
 class ProductComponent < ViewComponent::Base
   with_collection_parameter :item
@@ -494,11 +513,13 @@ end
 Additional arguments besides the collection are passed to each component instance:
 
 `app/view/products/index.html.erb`
+
 ``` erb
 <%= render(ProductComponent.with_collection(@products, notice: "hi")) %>
 ```
 
 `app/components/product_component.rb`
+
 ``` ruby
 class ProductComponent < ViewComponent::Base
   with_collection_parameter :item
@@ -511,6 +532,7 @@ end
 ```
 
 `app/components/product_component.html.erb`
+
 ``` erb
 <li>
   <h2><%= @item.name %></h2>
@@ -523,6 +545,7 @@ end
 ViewComponent defines a counter variable matching the parameter name above, followed by `_counter`. To access the variable, add it to `initialize` as an argument:
 
 `app/components/product_component.rb`
+
 ``` ruby
 class ProductComponent < ViewComponent::Base
   def initialize(product:, product_counter:)
@@ -533,6 +556,7 @@ end
 ```
 
 `app/components/product_component.html.erb`
+
 ``` erb
 <li>
   <%= @counter %> <%= @product.name %>
@@ -581,7 +605,7 @@ class UserComponent < ViewComponent::Base
 end
 ```
 
-### Testing
+### Writing tests
 
 Unit test components directly, using the `render_inline` test helper, asserting against the rendered output.
 
@@ -649,9 +673,11 @@ end
 ```
 
 ### Previewing Components
+
 `ViewComponent::Preview`, like `ActionMailer::Preview`, provides a way to preview components in isolation:
 
 `test/components/previews/test_component_preview.rb`
+
 ```ruby
 class TestComponentPreview < ViewComponent::Preview
   def with_default_title
@@ -679,6 +705,7 @@ and <http://localhost:3000/rails/view_components/test_component/with_content_blo
 It's also possible to set dynamic values from the params by setting them as arguments:
 
 `test/components/previews/test_component_preview.rb`
+
 ```ruby
 class TestComponentPreview < ViewComponent::Preview
   def with_dynamic_title(title: "Test component default")
@@ -696,6 +723,7 @@ and [`content_tag`](https://api.rubyonrails.org/classes/ActionView/Helpers/TagHe
 Previews use the application layout by default, but can use a specific layout with the `layout` option:
 
 `test/components/previews/test_component_preview.rb`
+
 ```ruby
 class TestComponentPreview < ViewComponent::Preview
   layout "admin"
@@ -707,6 +735,7 @@ end
 You can also set a custom layout to be used by default for previews as well as the preview index pages via the `default_preview_layout` configuration option:
 
 `config/application.rb`
+
 ```ruby
 # Set the default layout to app/views/layouts/component_preview.html.erb
 config.view_component.default_preview_layout = "component_preview"
@@ -715,6 +744,7 @@ config.view_component.default_preview_layout = "component_preview"
 Preview classes live in `test/components/previews`, which can be configured using the `preview_paths` option:
 
 `config/application.rb`
+
 ```ruby
 config.view_component.preview_paths << "#{Rails.root}/lib/component_previews"
 ```
@@ -722,6 +752,7 @@ config.view_component.preview_paths << "#{Rails.root}/lib/component_previews"
 Previews are served from <http://localhost:3000/rails/view_components> by default. To use a different endpoint, set the `preview_route` option:
 
 `config/application.rb`
+
 ```ruby
 config.view_component.preview_route = "/previews"
 ```
@@ -733,6 +764,7 @@ This example will make the previews available from <http://localhost:3000/previe
 Given a preview `test/components/previews/cell_component_preview.rb`, template files can be defined at `test/components/previews/cell_component_preview/`:
 
 `test/components/previews/cell_component_preview.rb`
+
 ```ruby
 class CellComponentPreview < ViewComponent::Preview
   def default
@@ -741,6 +773,7 @@ end
 ```
 
 `test/components/previews/cell_component_preview/default.html.erb`
+
 ```erb
 <table class="table">
   <tbody>
@@ -755,6 +788,7 @@ To use a different location for preview templates, pass the `template` argument:
 (the path should be relative to `config.view_component.preview_path`):
 
 `test/components/previews/cell_component_preview.rb`
+
 ```ruby
 class CellComponentPreview < ViewComponent::Preview
   def default
@@ -766,6 +800,7 @@ end
 Values from `params` can be accessed through `locals`:
 
 `test/components/previews/cell_component_preview.rb`
+
 ```ruby
 class CellComponentPreview < ViewComponent::Preview
   def default(title: "Default title", subtitle: "A subtitle")
@@ -784,6 +819,7 @@ Which enables passing in a value with <http://localhost:3000/rails/components/ce
 Component tests and previews assume the existence of an `ApplicationController` class, which be can be configured using the `test_controller` option:
 
 `config/application.rb`
+
 ```ruby
 config.view_component.test_controller = "BaseController"
 ```
@@ -793,6 +829,7 @@ config.view_component.test_controller = "BaseController"
 To use RSpec, add the following:
 
 `spec/rails_helper.rb`
+
 ```ruby
 require "view_component/test_helpers"
 
@@ -806,6 +843,7 @@ Specs created by the generator have access to test helpers like `render_inline`.
 To use component previews:
 
 `config/application.rb`
+
 ```ruby
 config.view_component.preview_paths << "#{Rails.root}/spec/components/previews"
 ```
@@ -856,6 +894,7 @@ One approach is to use Web Components, which contain all Javascript functionalit
 For example:
 
 `app/components/comment_component.rb`
+
 ```ruby
 class CommentComponent < ViewComponent::Base
   def initialize(comment:)
@@ -885,6 +924,7 @@ end
 ```
 
 `app/components/comment_component.html.erb`
+
 ```erb
 <my-comment comment-id="<%= comment.id %>">
   <time slot="posted" datetime="<%= comment.created_at.iso8601 %>"><%= comment.created_at.strftime("%b %-d") %></time>
@@ -898,6 +938,7 @@ end
 ```
 
 `app/components/comment_component.js`
+
 ```js
 class Comment extends HTMLElement {
   styles() {

--- a/docs/case-studies/jellyswitch.md
+++ b/docs/case-studies/jellyswitch.md
@@ -1,3 +1,5 @@
+# Jellyswitch
+
 Name: Dave Paola
 
 Github Handle: [@dpaola2](https://github.com/dpaola2)
@@ -28,7 +30,7 @@ class OnOffSwitch < ApplicationComponent
   private
 
   attr_reader :predicate, :path, :disabled, :label
-  
+
   def icon_class
     if predicate
       "fas fa-toggle-on"


### PR DESCRIPTION
### Summary

Add `markdownlint` to keep our markdown documents in tip-top shape, automatically!

### Other Information

Our README is getting pretty big, and I'd love to make it easier to keep it in good shape ❤️ 