### PR TITLE
Extend documentation for using Stimulus within sidecar directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master
 
+* Extend documentation for using Stimulus within sidecar directories.
+
+    *Ciprian Redinciuc*
+
 * Fix uninitialized constant error from `with_collection` when `eager_load` is disabled.
 
     *Josh Gross*

--- a/README.md
+++ b/README.md
@@ -992,6 +992,30 @@ application.load(
 
 This enables the creation of files such as `app/components/widget_controller.js`, where the controller identifier matches the `data-controller` attribute in the component's HTML template.
 
+If you place your Stimulus controller inside a sidecar directory, please be aware that when referencing your Stimulus controller [each forward slash in a namespaced controller file’s path becomes two dashes in its identifier](
+https://stimulusjs.org/handbook/installing#controller-filenames-map-to-identifiers).
+
+```console
+app/components
+├── ...
+├── example
+|   ├── component.rb
+|   ├── component.css
+|   ├── component.html.erb
+|   └── component_controller.js
+├── ...
+
+```
+
+In the example above, the `component_controller.js` Stimulus identifier becomes: `example--component`:
+
+```erb
+<div data-controller="example--component">
+  <input type="text">
+  <button data-action="click->example--component#greet">Greet</button>
+</div>
+```
+
 ## Frequently Asked Questions
 
 ### Can I use other templating languages besides ERB?

--- a/README.md
+++ b/README.md
@@ -992,8 +992,8 @@ application.load(
 
 This enables the creation of files such as `app/components/widget_controller.js`, where the controller identifier matches the `data-controller` attribute in the component's HTML template.
 
-If you place your Stimulus controller inside a sidecar directory, please be aware that when referencing your Stimulus controller [each forward slash in a namespaced controller file’s path becomes two dashes in its identifier](
-https://stimulusjs.org/handbook/installing#controller-filenames-map-to-identifiers).
+When placing a Stimulus controller inside a sidecar directory, be aware that when referencing the controller [each forward slash in a namespaced controller file’s path becomes two dashes in its identifier](
+https://stimulusjs.org/handbook/installing#controller-filenames-map-to-identifiers):
 
 ```console
 app/components
@@ -1004,10 +1004,9 @@ app/components
 |   ├── component.html.erb
 |   └── component_controller.js
 ├── ...
-
 ```
 
-In the example above, the `component_controller.js` Stimulus identifier becomes: `example--component`:
+`component_controller.js`'s Stimulus identifier becomes: `example--component`:
 
 ```erb
 <div data-controller="example--component">


### PR DESCRIPTION

### Summary

Extends the documentation for using Stimulus within view_component sidecar directories.
When using sidecar directories for your components, you might overlook the fact that Stimulus maps namespaced controllers using two dashes in its stimulus controller identifier.

