### PR TITLE
use def test_method_name syntax for tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -627,7 +627,7 @@ Capybara matchers are available if the gem is installed:
 require "view_component/test_case"
 
 class MyComponentTest < ViewComponent::TestCase
-  test "render component" do
+  def test_render_component
     render_inline(TestComponent.new(title: "my title")) { "Hello, World!" }
 
     assert_selector("span[title='my title']", text: "Hello, World!")
@@ -638,7 +638,7 @@ end
 In the absence of `capybara`, assert against the return value of `render_inline`, which is an instance of `Nokogiri::HTML::DocumentFragment`:
 
 ```ruby
-test "render component" do
+def test_render_component
   result = render_inline(TestComponent.new(title: "my title")) { "Hello, World!" }
 
   assert_includes result.css("span[title='my title']").to_html, "Hello, World!"
@@ -648,7 +648,7 @@ end
 Alternatively, assert against the raw output of the component, which is exposed as `rendered_component`:
 
 ```ruby
-test "render component" do
+def test_render_component
   render_inline(TestComponent.new(title: "my title")) { "Hello, World!" }
 
   assert_includes rendered_component, "Hello, World!"
@@ -658,7 +658,7 @@ end
 To test components that use `with_content_areas`:
 
 ```ruby
-test "renders content_areas template with content " do
+def test_renders_content_areas_template_with_content
   render_inline(ContentAreasComponent.new(footer: "Bye!")) do |component|
     component.with(:title, "Hello!")
     component.with(:body) { "Have a nice day." }
@@ -675,7 +675,7 @@ end
 Use the `with_variant` helper to test specific variants:
 
 ```ruby
-test "render component for tablet" do
+def test_render_component_for_tablet
   with_variant :tablet do
     render_inline(TestComponent.new(title: "my title")) { "Hello, tablets!" }
 

--- a/lib/rails/generators/test_unit/templates/component_test.rb.tt
+++ b/lib/rails/generators/test_unit/templates/component_test.rb.tt
@@ -1,7 +1,7 @@
 require "test_helper"
 
 class <%= class_name %>ComponentTest < ViewComponent::TestCase
-  test "component renders something useful" do
+  def test_component_renders_something_useful
     # assert_equal(
     #   %(<span>Hello, components!</span>),
     #   render_inline(<%= class_name %>Component.new(message: "Hello, components!")).css("span").to_html

--- a/test/view_component/default_preview_layout_integration_test.rb
+++ b/test/view_component/default_preview_layout_integration_test.rb
@@ -3,21 +3,21 @@
 require "test_helper"
 
 class DefaultPreviewLayoutIntegrationTest < ActionDispatch::IntegrationTest
-  test "preview index renders custom application layout if configured" do
+  def test_preview_index_renders_custom_application_layout_if_configured
     with_default_preview_layout("admin") do
       get "/rails/view_components"
       assert_select "title", "ViewComponent - Admin - Test"
     end
   end
 
-  test "preview index of a component renders custom application layout if configured" do
+  def test_preview_index_of_a_component_renders_custom_application_layout_if_configured
     with_default_preview_layout("admin") do
       get "/rails/view_components/preview_component"
       assert_select "title", "ViewComponent - Admin - Test"
     end
   end
 
-  test "component preview renders custom application layout if configured" do
+  def test_component_preview_renders_custom_application_layout_if_configured
     with_default_preview_layout("admin") do
       get "/rails/view_components/preview_component/default"
       assert_select "title", "ViewComponent - Admin - Test"
@@ -25,7 +25,7 @@ class DefaultPreviewLayoutIntegrationTest < ActionDispatch::IntegrationTest
     end
   end
 
-  test "component preview renders standard Rails layout if configured false" do
+  def test_component_preview_renders_standard_rails_layout_if_configured_false
     with_default_preview_layout(false) do
       get "/rails/view_components/preview_component/default"
 
@@ -34,7 +34,7 @@ class DefaultPreviewLayoutIntegrationTest < ActionDispatch::IntegrationTest
     end
   end
 
-  test "preview renders without layout even if default layout is configured" do
+  def test_preview_renders_without_layout_even_if_default_layout_is_configured
     with_default_preview_layout("admin") do
       get "/rails/view_components/no_layout/default"
       assert_select("div", "hello,world!")

--- a/test/view_component/integration_test.rb
+++ b/test/view_component/integration_test.rb
@@ -3,7 +3,7 @@
 require "test_helper"
 
 class IntegrationTest < ActionDispatch::IntegrationTest
-  test "rendering component in a view" do
+  def test_rendering_component_in_a_view
     get "/"
     assert_response :success
 
@@ -11,7 +11,7 @@ class IntegrationTest < ActionDispatch::IntegrationTest
   end
 
   if Rails.version.to_f >= 6.1
-    test "rendering component with template annotations enabled" do
+    def test_rendering_component_with_template_annotations_enabled
       get "/"
       assert_response :success
 
@@ -21,7 +21,7 @@ class IntegrationTest < ActionDispatch::IntegrationTest
     end
   end
 
-  test "rendering component in a controller" do
+  def test_rendering_component_in_a_controller
     get "/controller_inline_baseline"
 
     assert_select("div", "bar")
@@ -38,7 +38,7 @@ class IntegrationTest < ActionDispatch::IntegrationTest
     assert_includes inline_response, baseline_response
   end
 
-  test "template changes are not reflected on new request when cache_template_loading is true" do
+  def test_template_changes_are_not_reflected_on_new_request_when_cache_template_loading_is_true
     # cache_template_loading is set to true on the initializer
 
     get "/controller_inline"
@@ -56,7 +56,7 @@ class IntegrationTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
-  test "template changes are reflected on new request when cache_template_loading is false" do
+  def test_template_changes_are_reflected_on_new_request_when_cache_template_loading_is_false
     begin
       old_cache = ViewComponent::CompileCache.cache
       ViewComponent::CompileCache.cache = Set.new
@@ -81,7 +81,7 @@ class IntegrationTest < ActionDispatch::IntegrationTest
     end
   end
 
-  test "rendering component in a controller using #render_to_string" do
+  def test_rendering_component_in_a_controller_using_render_to_string
     get "/controller_inline_baseline"
 
     assert_select("div", "bar")
@@ -98,7 +98,7 @@ class IntegrationTest < ActionDispatch::IntegrationTest
     assert_includes to_string_response, baseline_response
   end
 
-  test "rendering component with content" do
+  def test_rendering_component_with_content
     get "/content"
     assert_response :success
     assert_select "div.State--green"
@@ -106,7 +106,7 @@ class IntegrationTest < ActionDispatch::IntegrationTest
     assert_includes response.body, "Open"
   end
 
-  test "rendering component with content_for" do
+  def test_rendering_component_with_content_for
     get "/content_areas"
     assert_response :success
 
@@ -115,26 +115,26 @@ class IntegrationTest < ActionDispatch::IntegrationTest
     assert_select(".footer h3", "Bye!")
   end
 
-  test "rendering component with a partial" do
+  def test_rendering_component_with_a_partial
     get "/partial"
     assert_response :success
 
     assert_select("div", "hello,partial world!", count: 2)
   end
 
-  test "rendering component without variant" do
+  def test_rendering_component_without_variant
     get "/variants"
     assert_response :success
     assert_includes response.body, "Default"
   end
 
-  test "rendering component with tablet variant" do
+  def test_rendering_component_with_tablet_variant
     get "/variants?variant=tablet"
     assert_response :success
     assert_includes response.body, "Tablet"
   end
 
-  test "rendering component several times with different variants" do
+  def test_rendering_component_several_times_with_different_variants
     get "/variants?variant=tablet"
     assert_response :success
     assert_includes response.body, "Tablet"
@@ -156,7 +156,7 @@ class IntegrationTest < ActionDispatch::IntegrationTest
     assert_includes response.body, "Phone"
   end
 
-  test "rendering component with caching" do
+  def test_rendering_component_with_caching
     Rails.cache.clear
     ActionController::Base.perform_caching = true
 
@@ -172,7 +172,7 @@ class IntegrationTest < ActionDispatch::IntegrationTest
     Rails.cache.clear
   end
 
-  test "optional rendering component depending on request context" do
+  def test_optional_rendering_component_depending_on_request_context
     get "/render_check"
     assert_response :success
     assert_includes response.body, "Rendered"
@@ -184,19 +184,19 @@ class IntegrationTest < ActionDispatch::IntegrationTest
     refute_includes response.body, "Rendered"
   end
 
-  test "renders component preview" do
+  def test_renders_component_preview
     get "/rails/view_components/my_component/default"
 
     assert_includes response.body, "<div>hello,world!</div>"
   end
 
-  test "renders preview component default preview" do
+  def test_renders_preview_component_default_preview
     get "/rails/view_components/preview_component/default"
 
     assert_includes response.body, "Click me!"
   end
 
-  test "renders preview component default preview ignoring params" do
+  def test_renders_preview_component_default_preview_ignoring_params
     get "/rails/view_components/preview_component/default?cta=CTA+from+params"
 
     assert_includes response.body, "Click me!"
@@ -204,46 +204,46 @@ class IntegrationTest < ActionDispatch::IntegrationTest
     refute_includes response.body, "CTA from params"
   end
 
-  test "renders preview component with_cta preview" do
+  def test_renders_preview_component_with_cta_preview
     get "/rails/view_components/preview_component/without_cta"
 
     assert_includes response.body, "More lorem..."
   end
 
-  test "renders preview component with content preview" do
+  def test_renders_preview_component_with_content_preview
     get "/rails/view_components/preview_component/with_content"
 
     assert_includes response.body, "some content"
   end
 
-  test "renders preview component with tag helper-generated content preview" do
+  def test_renders_preview_component_with_tag_helper_generated_content_preview
     get "/rails/view_components/preview_component/with_tag_helper_in_content"
 
     assert_includes response.body, "<span>some content</span>"
   end
 
-  test "renders preview component with params preview with default values" do
+  def test_renders_preview_component_with_params_preview_with_default_values
     get "/rails/view_components/preview_component/with_params"
 
     assert_includes response.body, "Default CTA"
     assert_includes response.body, "Default title"
   end
 
-  test "renders preview component with params preview with one param" do
+  def test_renders_preview_component_with_params_preview_with_one_param
     get "/rails/view_components/preview_component/with_params?cta=CTA+from+params"
 
     assert_includes response.body, "CTA from params"
     assert_includes response.body, "Default title"
   end
 
-  test "renders preview component with params preview with multiple params" do
+  def test_renders_preview_component_with_params_preview_with_multiple_params
     get "/rails/view_components/preview_component/with_params?cta=CTA+from+params&title=Title+from+params"
 
     assert_includes response.body, "CTA from params"
     assert_includes response.body, "Title from params"
   end
 
-  test "renders preview component with params preview ignoring unsupported params" do
+  def test_renders_preview_component_with_params_preview_ignoring_unsupported_params
     get "/rails/view_components/preview_component/with_params?cta=CTA+from+params&label=Label+from+params"
 
     assert_includes response.body, "CTA from params"
@@ -252,57 +252,57 @@ class IntegrationTest < ActionDispatch::IntegrationTest
     refute_includes response.body, "Label from params"
   end
 
-  test "renders badge component open preview" do
+  def test_renders_badge_component_open_preview
     get "/rails/view_components/issues/badge_component/open"
 
     assert_includes response.body, "Open"
   end
 
-  test "renders badge component closed preview" do
+  def test_renders_badge_component_closed_preview
     get "/rails/view_components/issues/badge_component/closed"
 
     assert_includes response.body, "Closed"
   end
 
-  test "test preview renders" do
+  def test_preview_renders
     get "/rails/view_components/preview_component/default"
 
     assert_select(".preview-component .btn", "Click me!")
   end
 
-  test "test preview renders with layout" do
+  def test_preview_renders_with_layout
     get "/rails/view_components/my_component/default"
 
     assert_includes response.body, "ViewComponent - Admin - Test"
     assert_select("div", "hello,world!")
   end
 
-  test "test preview renders without layout" do
+  def test_preview_renders_without_layout
     get "/rails/view_components/no_layout/default"
 
     assert_select("div", "hello,world!")
     refute_includes response.body, "ViewComponent - Test"
   end
 
-  test "test preview renders application's layout by default" do
+  def test_preview_renders_application_s_layout_by_default
     get "/rails/view_components/preview_component/default"
 
     assert_select "title", "ViewComponent - Test"
   end
 
-  test "test preview index renders rails application layout by default" do
+  def test_preview_index_renders_rails_application_layout_by_default
     get "/rails/view_components"
 
     assert_select "title", "Component Previews"
   end
 
-  test "test preview index of a component renders rails application layout by default" do
+  def test_preview_index_of_a_component_renders_rails_application_layout_by_default
     get "/rails/view_components/preview_component"
 
     assert_select "title", "Component Previews for preview_component"
   end
 
-  test "test preview related views are being rendered correctly" do
+  def test_preview_related_views_are_being_rendered_correctly
     get "/rails/view_components"
     assert_select "title", "Component Previews"
 
@@ -313,12 +313,12 @@ class IntegrationTest < ActionDispatch::IntegrationTest
     assert_select "title", "Component Previews for preview_component"
   end
 
-  test "test preview from multiple preview_paths" do
+  def test_preview_from_multiple_preview_paths
     get "/rails/view_components/my_component_lib/default"
     assert_select("div", "hello,world!")
   end
 
-  test "renders collections" do
+  def test_renders_collections
     get "/products"
 
     assert_select("h1", text: "Products for sale")
@@ -330,7 +330,7 @@ class IntegrationTest < ActionDispatch::IntegrationTest
     assert_select("p", text: "Mints counter: 2")
   end
 
-  test "renders the previews in the configured route" do
+  def test_renders_the_previews_in_the_configured_route
     with_preview_route("/previews") do
       get "/previews"
       assert_select "title", "Component Previews"
@@ -343,7 +343,7 @@ class IntegrationTest < ActionDispatch::IntegrationTest
     end
   end
 
-  test "renders singular and collection slots with arguments" do
+  def test_renders_singular_and_collection_slots_with_arguments
     get "/slots"
 
     assert_select(".card.mt-4")
@@ -367,14 +367,14 @@ class IntegrationTest < ActionDispatch::IntegrationTest
     assert_equal(title_node, expected_title_html)
   end
 
-  test "renders empty slot without error" do
+  def test_renders_empty_slot_without_error
     get "/empty_slot"
 
     assert_response :success
   end
 
   if Rails.version.to_f >= 6.1
-    test "rendering component using the render_component helper raises an error" do
+    def test_rendering_component_using_the_render_component_helper_raises_an_error
       error = assert_raises ActionView::Template::Error do
         get "/render_component"
       end
@@ -383,22 +383,22 @@ class IntegrationTest < ActionDispatch::IntegrationTest
   end
 
   if Rails.version.to_f < 6.1
-    test "rendering component using #render_component" do
+    def test_rendering_component_using_render_component
       get "/render_component"
       assert_includes response.body, "bar"
     end
 
-    test "rendering component in a controller using #render_component" do
+    def test_rendering_component_in_a_controller_using_render_component
       get "/controller_inline_render_component"
       assert_includes response.body, "bar"
     end
 
-    test "rendering component in a controller using #render_component_to_string" do
+    def test_rendering_component_in_a_controller_using_render_component_to_string
       get "/controller_to_string_render_component"
       assert_includes response.body, "bar"
     end
 
-    test "rendering component in preview using #render_component and monkey patch disabled" do
+    def test_rendering_component_in_preview_using_render_component_and_monkey_patch_disabled
       with_render_monkey_patch_config(false) do
         get "/rails/view_components/monkey_patch_disabled_component/default"
         assert_includes response.body, "<div>hello,world!</div>"
@@ -406,7 +406,7 @@ class IntegrationTest < ActionDispatch::IntegrationTest
     end
   end
 
-  test "renders the inline component preview examples with default behaviour and with their own templates" do
+  def test_renders_the_inline_component_preview_examples_with_default_behaviour_and_with_their_own_templates
     get "/rails/view_components/inline_component/default"
     assert_select "input" do
       assert_select "[name=?]", "name"
@@ -425,7 +425,7 @@ class IntegrationTest < ActionDispatch::IntegrationTest
     end
   end
 
-  test "renders the preview example with its own template and a layout" do
+  def test_renders_the_preview_example_with_its_own_template_and_a_layout
     get "/rails/view_components/my_component/inside_banner"
     assert_includes response.body, "ViewComponent - Admin - Test"
     assert_select ".banner" do
@@ -433,7 +433,7 @@ class IntegrationTest < ActionDispatch::IntegrationTest
     end
   end
 
-  test "renders an inline component preview using URL params and a template" do
+  def test_renders_an_inline_component_preview_using_url_params_and_a_template
     get "/rails/view_components/inline_component/with_params?form_title=This is a test form"
     assert_select "form" do
       assert_select "p", "This is a test form"
@@ -441,32 +441,32 @@ class IntegrationTest < ActionDispatch::IntegrationTest
     end
   end
 
-  test "renders the inline component using a non standard-located template" do
+  def test_renders_the_inline_component_using_a_non_standard_located_template
     get "/rails/view_components/inline_component/with_non_standard_template"
     assert_select "h1", "This is not a standard place to have a preview template"
     assert_select "input[name=?]", "name"
   end
 
-  test "renders an inline component preview using a HAML template" do
+  def test_renders_an_inline_component_preview_using_a_haml_template
     get "/rails/view_components/inline_component/with_haml"
     assert_select "h1", "Some HAML here"
     assert_select "input[name=?]", "name"
   end
 
-  test "returns 404 when preview does not exist" do
+  def test_returns_404_when_preview_does_not_exist
     assert_raises AbstractController::ActionNotFound do
       get "/rails/view_components/missing_preview"
     end
   end
 
-  test "raises an error if the template is not present and the render_with_template method is used in the example" do
+  def test_raises_an_error_if_the_template_is_not_present_and_the_render_with_template_method_is_used_in_the_example
     error = assert_raises ViewComponent::PreviewTemplateError do
       get "/rails/view_components/inline_component/without_template"
     end
     assert_match /preview template for example without_template does not exist/, error.message
   end
 
-  test "renders a preview template using HAML, params from URL, custom template and locals" do
+  def test_renders_a_preview_template_using_haml_params_from_url_custom_template_and_locals
     get "/rails/view_components/inline_component/with_several_options?form_title=Title from params"
 
     assert_select "form" do

--- a/test/view_component/test_unit_generator_test.rb
+++ b/test/view_component/test_unit_generator_test.rb
@@ -15,7 +15,7 @@ class ViewComponent::TestUnitGeneratorTest < ::Rails::Generators::TestCase
     File.delete File.expand_path("../../tmp/test/components/dummy_component_test.rb", __FILE__)
   end
 
-  test "generates component" do
+  def test_generates_component
     assert_file "../tmp/test/components/dummy_component_test.rb" do |content|
       assert_match(/render_inline\(DummyComponent.new\(message: "Hello, components!"\)\).css\("span"\).to_html/, content)
     end


### PR DESCRIPTION
### Summary

This PR standardizes our test syntax to use method names.