### PR TITLE
only run simplecov in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,7 @@ jobs:
         bundle update
         bundle exec rake
       env:
+        CI: true
         RAILS_VERSION: ${{ matrix.rails_version }}
     - name: Upload coverage results
       uses: actions/upload-artifact@master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
         bundle update
         bundle exec rake
       env:
-        CI: true
+        MEASURE_COVERAGE: true
         RAILS_VERSION: ${{ matrix.rails_version }}
     - name: Upload coverage results
       uses: actions/upload-artifact@master

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,7 +85,7 @@ GIT
 PATH
   remote: .
   specs:
-    view_component (2.18.1)
+    view_component (2.19.1)
       activesupport (>= 5.0.0, < 7.0)
 
 GEM

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,10 +2,12 @@
 require "simplecov"
 require "simplecov-console"
 
-SimpleCov.start do
-  command_name "rails#{ENV["RAILS_VERSION"]}-ruby#{ENV["RUBY_VERSION"]}" if ENV["RUBY_VERSION"]
+if ENV["CI"]
+  SimpleCov.start do
+    command_name "rails#{ENV["RAILS_VERSION"]}-ruby#{ENV["RUBY_VERSION"]}" if ENV["RUBY_VERSION"]
 
-  formatter SimpleCov::Formatter::Console
+    formatter SimpleCov::Formatter::Console
+  end
 end
 
 require "bundler/setup"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,7 +2,7 @@
 require "simplecov"
 require "simplecov-console"
 
-if ENV["CI"]
+if ENV["MEASURE_COVERAGE"]
   SimpleCov.start do
     command_name "rails#{ENV["RAILS_VERSION"]}-ruby#{ENV["RUBY_VERSION"]}" if ENV["RUBY_VERSION"]
 


### PR DESCRIPTION
### Summary

This PR changes our `simplecov` configuration to only run in CI, as our coverage is collated across our matrix of builds. It does so by checking for the `MEASURE_COVERAGE` environment variable, allowing coverage measurement to be flagged on locally if desired.