### PR TITLE
Fix tiny typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ To define a collection slot, add `collection: true`:
 
 To define a slot with a custom Ruby class, pass `class_name`:
 
-`with_slot :body, class_name: 'BodySlot`
+`with_slot :body, class_name: 'BodySlot'`
 
 _Note: Slot classes must be subclasses of `ViewComponent::Slot`._
 


### PR DESCRIPTION
add missing `'` to a slot-example in README.

### Summary

Just a code-typo fix.
