### PR TITLE
Add `before_render` DSL method

### DIFF
--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -179,8 +179,16 @@ module ViewComponent
     class << self
       attr_accessor :source_location, :virtual_path
 
-      def before_render(&block)
-        set_callback :render, :before, block
+      def before_render(method_name = nil, &block)
+        if block_given?
+          set_callback :render, :before, block
+        else
+          set_callback :render, :before, method_name
+        end
+      end
+
+      def skip_before_render(method_name)
+        skip_callback :render, method_name
       end
 
       # Render a component collection.

--- a/test/app/components/before_conditional_render_component.html.erb
+++ b/test/app/components/before_conditional_render_component.html.erb
@@ -1,0 +1,1 @@
+<div>component was rendered</div>

--- a/test/app/components/before_conditional_render_component.rb
+++ b/test/app/components/before_conditional_render_component.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class BeforeConditionalRenderComponent < ViewComponent::Base
+  before_render do
+    throw :abort unless @should_render
+  end
+
+  def initialize(should_render:)
+    @should_render = should_render
+  end
+end

--- a/test/app/components/before_render_symbol_component.html.erb
+++ b/test/app/components/before_render_symbol_component.html.erb
@@ -1,0 +1,1 @@
+<div>component was rendered</div>

--- a/test/app/components/before_render_symbol_component.rb
+++ b/test/app/components/before_render_symbol_component.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class BeforeRenderSymbolComponent < ViewComponent::Base
+  before_render :ensure_should_render
+
+  def initialize(should_render:)
+    @should_render = should_render
+  end
+
+  private
+
+  def ensure_should_render
+    throw :abort unless @should_render
+  end
+end

--- a/test/app/components/skip_before_render_component.rb
+++ b/test/app/components/skip_before_render_component.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class SkipBeforeRenderComponent < BeforeRenderSymbolComponent
+  skip_before_render :ensure_should_render
+end

--- a/test/view_component/view_component_test.rb
+++ b/test/view_component/view_component_test.rb
@@ -664,4 +664,16 @@ class ViewComponentTest < ViewComponent::TestCase
     assert_predicate InheritedInlineComponent, :compiled?
     assert_selector("input[type='text'][name='name']")
   end
+
+  def test_does_not_render_if_before_render_returns_false
+    render_inline(BeforeConditionalRenderComponent.new(should_render: false))
+
+    refute_component_rendered
+  end
+
+  def test_renders_if_before_render_returns_true
+    render_inline(BeforeConditionalRenderComponent.new(should_render: true))
+
+    assert_text("component was rendered")
+  end
 end

--- a/test/view_component/view_component_test.rb
+++ b/test/view_component/view_component_test.rb
@@ -665,7 +665,7 @@ class ViewComponentTest < ViewComponent::TestCase
     assert_selector("input[type='text'][name='name']")
   end
 
-  def test_does_not_render_if_before_render_returns_false
+  def test_does_not_render_if_before_render_raises_abort
     render_inline(BeforeConditionalRenderComponent.new(should_render: false))
 
     refute_component_rendered
@@ -673,6 +673,25 @@ class ViewComponentTest < ViewComponent::TestCase
 
   def test_renders_if_before_render_returns_true
     render_inline(BeforeConditionalRenderComponent.new(should_render: true))
+
+    assert_text("component was rendered")
+  end
+
+  def test_does_not_render_if_symbol_before_render_raises_abort
+    render_inline(BeforeRenderSymbolComponent.new(should_render: false))
+
+    refute_component_rendered
+  end
+
+  def test_renders_if_symbol_before_render_returns_true
+    render_inline(BeforeRenderSymbolComponent.new(should_render: true))
+
+    assert_text("component was rendered")
+  end
+
+  def test_skip_before_render_does_not_call_method
+    component = SkipBeforeRenderComponent.new(should_render: false)
+    render_inline(component)
 
     assert_text("component was rendered")
   end


### PR DESCRIPTION
This adds a new DSL method, `before_render` that allows components to
define a block that is called before rendering. This block uses
`ActiveSupport::Callbacks` under the hood, so it can prevent a component
from rendering via `throw :abort`.

* Include `ActiveSupport::Callbacks` in `ViewComponent::Base`
* Define callbacks for `render`
* Add public `before_render` method to `ViewComponent::Base` that allows
  components to define a method that is called before rendering and
  prevent `render` from executing, allowing us to eventually replace
  `render?` and `#before_render`.
