### PR TITLE
Fix duplicate filenames in template search

### DIFF
--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -393,14 +393,14 @@ module ViewComponent
         extensions = ActionView::Template.template_handler_extensions.join(",")
 
         # view files in the same directory as the component
-        sidecar_files = Dir["#{location_without_extension}.*{#{extensions}}"]
+        sidecar_files = Dir["#{location_without_extension}.*{#{extensions}}"].uniq
 
         # view files in a directory named like the component
         directory = File.dirname(source_location)
         filename = File.basename(source_location, ".rb")
         component_name = name.demodulize.underscore
 
-        sidecar_directory_files = Dir["#{directory}/#{component_name}/#{filename}.*{#{extensions}}"]
+        sidecar_directory_files = Dir["#{directory}/#{component_name}/#{filename}.*{#{extensions}}"].uniq
 
         (sidecar_files - [source_location] + sidecar_directory_files)
       end


### PR DESCRIPTION
### Summary

Within a codebase which has `.rb` added as a template handler (eg via `ActionView::Template.register_template_handler(:rb, :source.to_proc)`), `#matching_views_in_source_location` wrongly returns duplicate filepaths for erb view component templates, because "rb" is a sbstring of "erb", and the lookup uses a naive `Dir` glob algo with the registered template extensions.

Fix this by doing `.uniq` after each search

With the current behavior, the above scenario ultimately results in a bogus "There can only be one default template file per component" being raised at render-time