### PR TITLE
Fixing deprecation warnings from Rails

### DIFF
--- a/lib/view_component/preview.rb
+++ b/lib/view_component/preview.rb
@@ -83,7 +83,7 @@ module ViewComponent # :nodoc:
         Pathname.new(path)
                 .relative_path_from(Pathname.new(preview_path))
                 .to_s
-                .sub(/\..*$/, '')
+                .sub(/\..*$/, "")
       end
 
       private

--- a/lib/view_component/preview.rb
+++ b/lib/view_component/preview.rb
@@ -80,7 +80,10 @@ module ViewComponent # :nodoc:
         end
 
         path = Dir["#{preview_path}/#{preview_name}_preview/#{example}.html.*"].first
-        Pathname.new(path).relative_path_from(Pathname.new(preview_path)).to_s
+        Pathname.new(path)
+                .relative_path_from(Pathname.new(preview_path))
+                .to_s
+                .sub(/\..*$/, '')
       end
 
       private


### PR DESCRIPTION
### Summary
Fixes a deprecation warning from Rails.

Previews [using templates](https://github.com/github/view_component#preview-templates) were passing a pathname with extensions causing
Rails to trigger a deprecation warning.

This PR fixes those deprecation warnings by removing the extensions from
the pathname of the template rendered in the controller.

The regex used can be read as:
1. `\.` an escaped dot character
2. `.*` anything after the previous dot
3. `$`  it must be at the end of the string

More info about the deprecation here https://github.com/rails/rails/commit/dd9991bac598bb5da312278a749cf85e19b027cc
