### PR TITLE
Don't add /test/components/previews preview path unless the directory exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master
 
+* Don't add `/test/components/previews` to preview_paths if directory doesn't exist.
+
+    *Andy Holland*
+
 * Add `preview_controller` option to override the controller used for component previews.
 
     *Matt Swanson, Blake Williams, Juan Manuel Ramallo*

--- a/lib/view_component/engine.rb
+++ b/lib/view_component/engine.rb
@@ -17,7 +17,9 @@ module ViewComponent
       options.preview_controller ||= ViewComponent::Base.preview_controller
 
       if options.show_previews
-        options.preview_paths << "#{Rails.root}/test/components/previews" if defined?(Rails.root)
+        options.preview_paths << "#{Rails.root}/test/components/previews" if defined?(Rails.root) && Dir.exist?(
+          "#{Rails.root}/test/components/previews"
+        )
 
         if options.preview_path.present?
           ActiveSupport::Deprecation.warn(


### PR DESCRIPTION
This prevents a non-existent directory from being added to `ActiveSupport::Dependencies.autoload_paths` when show_previews is enabled, which causes the following seemingly unrelated issue:

```
** ERROR: directory is already being watched! **

Directory: [omitted]

is already being watched through: [omitted]

MORE INFO: https://github.com/guard/listen/wiki/Duplicate-directory-errors
[...]
```