### PR TITLE
Extract template compiler from base

### DIFF
--- a/lib/view_component.rb
+++ b/lib/view_component.rb
@@ -6,6 +6,7 @@ module ViewComponent
   extend ActiveSupport::Autoload
 
   autoload :Base
+  autoload :Compiler
   autoload :Preview
   autoload :PreviewTemplateError
   autoload :TestHelpers

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -225,8 +225,6 @@ module ViewComponent
       # Do as much work as possible in this step, as doing so reduces the amount
       # of work done each time a component is rendered.
       def compile(raise_errors: false)
-        return if compiled?
-
         template_compiler.compile(raise_errors: raise_errors)
       end
 

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -227,61 +227,11 @@ module ViewComponent
       def compile(raise_errors: false)
         return if compiled?
 
-        if template_errors.present?
-          raise ViewComponent::TemplateError.new(template_errors) if raise_errors
-          return false
-        end
+        template_compiler.compile(raise_errors: raise_errors)
+      end
 
-        if instance_methods(false).include?(:before_render_check)
-          ActiveSupport::Deprecation.warn(
-            "`before_render_check` will be removed in v3.0.0. Use `before_render` instead."
-          )
-        end
-
-        # Remove any existing singleton methods,
-        # as Ruby warns when redefining a method.
-        remove_possible_singleton_method(:variants)
-        remove_possible_singleton_method(:collection_parameter)
-        remove_possible_singleton_method(:collection_counter_parameter)
-        remove_possible_singleton_method(:counter_argument_present?)
-
-        define_singleton_method(:variants) do
-          templates.map { |template| template[:variant] } + variants_from_inline_calls(inline_calls)
-        end
-
-        define_singleton_method(:collection_parameter) do
-          if provided_collection_parameter
-            provided_collection_parameter
-          else
-            name.demodulize.underscore.chomp("_component").to_sym
-          end
-        end
-
-        define_singleton_method(:collection_counter_parameter) do
-          "#{collection_parameter}_counter".to_sym
-        end
-
-        define_singleton_method(:counter_argument_present?) do
-          instance_method(:initialize).parameters.map(&:second).include?(collection_counter_parameter)
-        end
-
-        validate_collection_parameter! if raise_errors
-
-        templates.each do |template|
-          # Remove existing compiled template methods,
-          # as Ruby warns when redefining a method.
-          method_name = call_method_name(template[:variant])
-          undef_method(method_name.to_sym) if instance_methods.include?(method_name.to_sym)
-
-          class_eval <<-RUBY, template[:path], -1
-            def #{method_name}
-              @output_buffer = ActionView::OutputBuffer.new
-              #{compiled_template(template[:path])}
-            end
-          RUBY
-        end
-
-        CompileCache.register self
+      def template_compiler
+        @_template_compiler ||= Compiler.new(self)
       end
 
       # we'll eventually want to update this to support other types
@@ -346,111 +296,6 @@ module ViewComponent
         @provided_collection_parameter ||= nil
       end
 
-      def compiled_template(file_path)
-        handler = ActionView::Template.handler_for_extension(File.extname(file_path).gsub(".", ""))
-        template = File.read(file_path)
-
-        if handler.method(:call).parameters.length > 1
-          handler.call(self, template)
-        else
-          handler.call(OpenStruct.new(source: template, identifier: identifier, type: type))
-        end
-      end
-
-      def inline_calls
-        @inline_calls ||=
-          begin
-            # Fetch only ViewComponent ancestor classes to limit the scope of
-            # finding inline calls
-            view_component_ancestors =
-              ancestors.take_while { |ancestor| ancestor != ViewComponent::Base } - included_modules
-
-            view_component_ancestors.flat_map { |ancestor| ancestor.instance_methods(false).grep(/^call/) }.uniq
-          end
-      end
-
-      def inline_calls_defined_on_self
-        @inline_calls_defined_on_self ||= instance_methods(false).grep(/^call/)
-      end
-
-      def matching_views_in_source_location
-        return [] unless source_location
-
-        location_without_extension = source_location.chomp(File.extname(source_location))
-
-        extensions = ActionView::Template.template_handler_extensions.join(",")
-
-        # view files in the same directory as the component
-        sidecar_files = Dir["#{location_without_extension}.*{#{extensions}}"]
-
-        # view files in a directory named like the component
-        directory = File.dirname(source_location)
-        filename = File.basename(source_location, ".rb")
-        component_name = name.demodulize.underscore
-
-        sidecar_directory_files = Dir["#{directory}/#{component_name}/#{filename}.*{#{extensions}}"]
-
-        (sidecar_files - [source_location] + sidecar_directory_files)
-      end
-
-      def templates
-        @templates ||=
-          matching_views_in_source_location.each_with_object([]) do |path, memo|
-            pieces = File.basename(path).split(".")
-
-            memo << {
-              path: path,
-              variant: pieces.second.split("+").second&.to_sym,
-              handler: pieces.last
-            }
-          end
-      end
-
-      def template_errors
-        @template_errors ||=
-          begin
-            errors = []
-
-            if (templates + inline_calls).empty?
-              errors << "Could not find a template file or inline render method for #{self}."
-            end
-
-            if templates.count { |template| template[:variant].nil? } > 1
-              errors << "More than one template found for #{self}. There can only be one default template file per component."
-            end
-
-            invalid_variants = templates
-                                  .group_by { |template| template[:variant] }
-                                  .map { |variant, grouped| variant if grouped.length > 1 }
-                                  .compact
-                                  .sort
-
-            unless invalid_variants.empty?
-              errors << "More than one template found for #{'variant'.pluralize(invalid_variants.count)} #{invalid_variants.map { |v| "'#{v}'" }.to_sentence} in #{self}. There can only be one template file per variant."
-            end
-
-            if templates.find { |template| template[:variant].nil? } && inline_calls_defined_on_self.include?(:call)
-              errors << "Template file and inline render method found for #{self}. There can only be a template file or inline render method per component."
-            end
-
-            duplicate_template_file_and_inline_variant_calls =
-              templates.pluck(:variant) & variants_from_inline_calls(inline_calls_defined_on_self)
-
-            unless duplicate_template_file_and_inline_variant_calls.empty?
-              count = duplicate_template_file_and_inline_variant_calls.count
-
-              errors << "Template #{'file'.pluralize(count)} and inline render #{'method'.pluralize(count)} found for #{'variant'.pluralize(count)} #{duplicate_template_file_and_inline_variant_calls.map { |v| "'#{v}'" }.to_sentence} in #{self}. There can only be a template file or inline render method per variant."
-            end
-
-            errors
-          end
-      end
-
-      def variants_from_inline_calls(calls)
-        calls.reject { |call| call == :call }.map do |variant_call|
-          variant_call.to_s.sub("call_", "").to_sym
-        end
-      end
     end
 
     ActiveSupport.run_load_hooks(:view_component, self)

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -217,7 +217,7 @@ module ViewComponent
       end
 
       def compiled?
-        CompileCache.compiled?(self)
+        template_compiler.compiled?
       end
 
       # Compile templates to instance methods, assuming they haven't been compiled already.

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -77,7 +77,7 @@ module ViewComponent
       before_render
 
       if render?
-        send(self.class.call_method_name(@variant))
+        render_template_for(@variant)
       else
         ""
       end
@@ -206,14 +206,6 @@ module ViewComponent
         child.slots = self.slots.clone
 
         super
-      end
-
-      def call_method_name(variant)
-        if variant.present? && variants.include?(variant)
-          "call_#{variant}"
-        else
-          "call"
-        end
       end
 
       def compiled?

--- a/lib/view_component/compiler.rb
+++ b/lib/view_component/compiler.rb
@@ -1,0 +1,177 @@
+# frozen_string_literal: true
+
+module ViewComponent
+  class Compiler
+    def initialize(component_class)
+      @component_class = component_class
+    end
+
+    def compile(raise_errors: false)
+      if template_errors.present?
+        raise ViewComponent::TemplateError.new(template_errors) if raise_errors
+        return false
+      end
+
+      if component_class.instance_methods(false).include?(:before_render_check)
+        ActiveSupport::Deprecation.warn(
+          "`before_render_check` will be removed in v3.0.0. Use `before_render` instead."
+        )
+      end
+
+      # Remove any existing singleton methods,
+      # as Ruby warns when redefining a method.
+      component_class.remove_possible_singleton_method(:variants)
+      component_class.remove_possible_singleton_method(:collection_parameter)
+      component_class.remove_possible_singleton_method(:collection_counter_parameter)
+      component_class.remove_possible_singleton_method(:counter_argument_present?)
+
+
+      template_variants = templates.map { |template| template[:variant] } + variants_from_inline_calls(inline_calls)
+      component_class.define_singleton_method(:variants) do
+        template_variants
+      end
+
+      component_class.define_singleton_method(:collection_parameter) do
+        if provided_collection_parameter
+          provided_collection_parameter
+        else
+          name.demodulize.underscore.chomp("_component").to_sym
+        end
+      end
+
+      component_class.define_singleton_method(:collection_counter_parameter) do
+        "#{collection_parameter}_counter".to_sym
+      end
+
+      component_class.define_singleton_method(:counter_argument_present?) do
+        instance_method(:initialize).parameters.map(&:second).include?(collection_counter_parameter)
+      end
+
+      component_class.validate_collection_parameter! if raise_errors
+
+      templates.each do |template|
+        # Remove existing compiled template methods,
+        # as Ruby warns when redefining a method.
+        method_name = component_class.call_method_name(template[:variant])
+        component_class.undef_method(method_name.to_sym) if component_class.instance_methods.include?(method_name.to_sym)
+
+        component_class.class_eval <<-RUBY, template[:path], -1
+          def #{method_name}
+            @output_buffer = ActionView::OutputBuffer.new
+            #{compiled_template(template[:path])}
+          end
+        RUBY
+      end
+
+      CompileCache.register(component_class)
+    end
+
+    private
+
+    attr_reader :component_class
+
+    def template_errors
+      @_template_errors ||= begin
+        errors = []
+
+        if (templates + inline_calls).empty?
+          errors << "Could not find a template file or inline render method for #{component_class}."
+        end
+
+        if templates.count { |template| template[:variant].nil? } > 1
+          errors << "More than one template found for #{component_class}. There can only be one default template file per component."
+        end
+
+        invalid_variants = templates
+          .group_by { |template| template[:variant] }
+          .map { |variant, grouped| variant if grouped.length > 1 }
+          .compact
+          .sort
+
+        unless invalid_variants.empty?
+          errors << "More than one template found for #{'variant'.pluralize(invalid_variants.count)} #{invalid_variants.map { |v| "'#{v}'" }.to_sentence} in #{component_class}. There can only be one template file per variant."
+        end
+
+        if templates.find { |template| template[:variant].nil? } && inline_calls_defined_on_self.include?(:call)
+          errors << "Template file and inline render method found for #{component_class}. There can only be a template file or inline render method per component."
+        end
+
+        duplicate_template_file_and_inline_variant_calls =
+          templates.pluck(:variant) & variants_from_inline_calls(inline_calls_defined_on_self)
+
+        unless duplicate_template_file_and_inline_variant_calls.empty?
+          count = duplicate_template_file_and_inline_variant_calls.count
+
+          errors << "Template #{'file'.pluralize(count)} and inline render #{'method'.pluralize(count)} found for #{'variant'.pluralize(count)} #{duplicate_template_file_and_inline_variant_calls.map { |v| "'#{v}'" }.to_sentence} in #{component_class}. There can only be a template file or inline render method per variant."
+        end
+
+        errors
+      end
+    end
+
+    def templates
+      @templates ||= matching_views_in_source_location.each_with_object([]) do |path, memo|
+        pieces = File.basename(path).split(".")
+
+        memo << {
+          path: path,
+          variant: pieces.second.split("+").second&.to_sym,
+          handler: pieces.last
+        }
+      end
+    end
+
+    def matching_views_in_source_location
+      source_location = component_class.source_location
+      return [] unless source_location
+
+      location_without_extension = source_location.chomp(File.extname(source_location))
+
+      extensions = ActionView::Template.template_handler_extensions.join(",")
+
+      # view files in the same directory as the component
+      sidecar_files = Dir["#{location_without_extension}.*{#{extensions}}"]
+
+      # view files in a directory named like the component
+      directory = File.dirname(source_location)
+      filename = File.basename(source_location, ".rb")
+      component_name = component_class.name.demodulize.underscore
+
+      sidecar_directory_files = Dir["#{directory}/#{component_name}/#{filename}.*{#{extensions}}"]
+
+      (sidecar_files - [source_location] + sidecar_directory_files)
+    end
+
+    def inline_calls
+      @inline_calls ||= begin
+        # Fetch only ViewComponent ancestor classes to limit the scope of
+        # finding inline calls
+        view_component_ancestors =
+          component_class.ancestors.take_while { |ancestor| ancestor != ViewComponent::Base } - component_class.included_modules
+
+        view_component_ancestors.flat_map { |ancestor| ancestor.instance_methods(false).grep(/^call/) }.uniq
+      end
+    end
+
+    def inline_calls_defined_on_self
+      @inline_calls_defined_on_self ||= component_class.instance_methods(false).grep(/^call/)
+    end
+
+    def variants_from_inline_calls(calls)
+      calls.reject { |call| call == :call }.map do |variant_call|
+        variant_call.to_s.sub("call_", "").to_sym
+      end
+    end
+
+    def compiled_template(file_path)
+      handler = ActionView::Template.handler_for_extension(File.extname(file_path).gsub(".", ""))
+      template = File.read(file_path)
+
+      if handler.method(:call).parameters.length > 1
+        handler.call(component_class, template)
+      else
+        handler.call(OpenStruct.new(source: template, identifier: identifier, type: component_class.type))
+      end
+    end
+  end
+end

--- a/lib/view_component/compiler.rb
+++ b/lib/view_component/compiler.rb
@@ -197,7 +197,7 @@ module ViewComponent
       if handler.method(:call).parameters.length > 1
         handler.call(component_class, template)
       else
-        handler.call(OpenStruct.new(source: template, identifier: source_location, type: component_class.type))
+        handler.call(OpenStruct.new(source: template, identifier: component_class.identifier, type: component_class.type))
       end
     end
 

--- a/lib/view_component/compiler.rb
+++ b/lib/view_component/compiler.rb
@@ -6,6 +6,10 @@ module ViewComponent
       @component_class = component_class
     end
 
+    def compiled?
+      CompileCache.compiled?(component_class)
+    end
+
     def compile(raise_errors: false)
       if template_errors.present?
         raise ViewComponent::TemplateError.new(template_errors) if raise_errors

--- a/lib/view_component/compiler.rb
+++ b/lib/view_component/compiler.rb
@@ -190,6 +190,7 @@ module ViewComponent
       end
     end
 
+    # :nocov:
     def compiled_template(file_path)
       handler = ActionView::Template.handler_for_extension(File.extname(file_path).gsub(".", ""))
       template = File.read(file_path)
@@ -200,6 +201,7 @@ module ViewComponent
         handler.call(OpenStruct.new(source: template, identifier: component_class.identifier, type: component_class.type))
       end
     end
+    # :nocov:
 
     def call_method_name(variant)
       if variant.present? && variants.include?(variant)

--- a/lib/view_component/compiler.rb
+++ b/lib/view_component/compiler.rb
@@ -52,7 +52,7 @@ module ViewComponent
         # Remove existing compiled template methods,
         # as Ruby warns when redefining a method.
         method_name = call_method_name(template[:variant])
-        component_class.undef_method(method_name.to_sym) if component_class.instance_methods.include?(method_name.to_sym)
+        component_class.send(:undef_method, method_name.to_sym) if component_class.instance_methods.include?(method_name.to_sym)
 
         component_class.class_eval <<-RUBY, template[:path], -1
           def #{method_name}

--- a/lib/view_component/compiler.rb
+++ b/lib/view_component/compiler.rb
@@ -197,7 +197,7 @@ module ViewComponent
       if handler.method(:call).parameters.length > 1
         handler.call(component_class, template)
       else
-        handler.call(OpenStruct.new(source: template, identifier: identifier, type: component_class.type))
+        handler.call(OpenStruct.new(source: template, identifier: source_location, type: component_class.type))
       end
     end
 

--- a/lib/view_component/compiler.rb
+++ b/lib/view_component/compiler.rb
@@ -11,6 +11,8 @@ module ViewComponent
     end
 
     def compile(raise_errors: false)
+      return if compiled?
+
       if template_errors.present?
         raise ViewComponent::TemplateError.new(template_errors) if raise_errors
         return false

--- a/lib/view_component/compiler.rb
+++ b/lib/view_component/compiler.rb
@@ -72,7 +72,7 @@ module ViewComponent
     attr_reader :component_class
 
     def define_render_template_for
-      component_class.undef_method(:render_template_for) if component_class.instance_methods.include?(:render_template_for)
+      component_class.send(:undef_method, :render_template_for) if component_class.instance_methods.include?(:render_template_for)
 
       variant_elsifs = variants.compact.uniq.map do |variant|
         "elsif variant.to_sym == :#{variant}\n    #{call_method_name(variant)}"

--- a/test/view_component/base_test.rb
+++ b/test/view_component/base_test.rb
@@ -3,28 +3,29 @@
 require "test_helper"
 
 class ViewComponent::Base::UnitTest < Minitest::Test
-  def test_templates_parses_all_types_of_paths
-    file_path = [
-      "/Users/fake.user/path/to.templates/component/test_component.html+phone.erb",
-      "/_underscore-dash./component/test_component.html+desktop.slim",
-      "/tilda~/component/test_component.html.haml"
-    ]
-    expected = [
-      {variant: :phone, handler: "erb"},
-      {variant: :desktop, handler: "slim"},
-      {variant: nil, handler: "haml"}
-    ]
-
-    ViewComponent::Base.stub(:matching_views_in_source_location, file_path) do
-      templates = ViewComponent::Base.send(:templates)
-
-      templates.each_with_index do |template, index|
-        assert_equal(template[:path], file_path[index])
-        assert_equal(template[:variant], expected[index][:variant])
-        assert_equal(template[:handler], expected[index][:handler])
-      end
-    end
-  end
+  # TODO revisit
+  # def test_templates_parses_all_types_of_paths
+  #   file_path = [
+  #     "/Users/fake.user/path/to.templates/component/test_component.html+phone.erb",
+  #     "/_underscore-dash./component/test_component.html+desktop.slim",
+  #     "/tilda~/component/test_component.html.haml"
+  #   ]
+  #   expected = [
+  #     {variant: :phone, handler: "erb"},
+  #     {variant: :desktop, handler: "slim"},
+  #     {variant: nil, handler: "haml"}
+  #   ]
+  #
+  #   ViewComponent::Base.stub(:matching_views_in_source_location, file_path) do
+  #     templates = ViewComponent::Base.send(:templates)
+  #
+  #     templates.each_with_index do |template, index|
+  #       assert_equal(template[:path], file_path[index])
+  #       assert_equal(template[:variant], expected[index][:variant])
+  #       assert_equal(template[:handler], expected[index][:handler])
+  #     end
+  #   end
+  # end
 
   def test_calling_helpers_outside_render_raises
     component = ViewComponent::Base.new

--- a/test/view_component/base_test.rb
+++ b/test/view_component/base_test.rb
@@ -3,29 +3,29 @@
 require "test_helper"
 
 class ViewComponent::Base::UnitTest < Minitest::Test
-  # TODO revisit
-  # def test_templates_parses_all_types_of_paths
-  #   file_path = [
-  #     "/Users/fake.user/path/to.templates/component/test_component.html+phone.erb",
-  #     "/_underscore-dash./component/test_component.html+desktop.slim",
-  #     "/tilda~/component/test_component.html.haml"
-  #   ]
-  #   expected = [
-  #     {variant: :phone, handler: "erb"},
-  #     {variant: :desktop, handler: "slim"},
-  #     {variant: nil, handler: "haml"}
-  #   ]
-  #
-  #   ViewComponent::Base.stub(:matching_views_in_source_location, file_path) do
-  #     templates = ViewComponent::Base.send(:templates)
-  #
-  #     templates.each_with_index do |template, index|
-  #       assert_equal(template[:path], file_path[index])
-  #       assert_equal(template[:variant], expected[index][:variant])
-  #       assert_equal(template[:handler], expected[index][:handler])
-  #     end
-  #   end
-  # end
+  def test_templates_parses_all_types_of_paths
+    file_path = [
+      "/Users/fake.user/path/to.templates/component/test_component.html+phone.erb",
+      "/_underscore-dash./component/test_component.html+desktop.slim",
+      "/tilda~/component/test_component.html.haml"
+    ]
+    expected = [
+      {variant: :phone, handler: "erb"},
+      {variant: :desktop, handler: "slim"},
+      {variant: nil, handler: "haml"}
+    ]
+
+    compiler = ViewComponent::Compiler.new(ViewComponent::Base)
+    compiler.stub(:matching_views_in_source_location, file_path) do
+      templates = compiler.send(:templates)
+
+      templates.each_with_index do |template, index|
+        assert_equal(template[:path], file_path[index])
+        assert_equal(template[:variant], expected[index][:variant])
+        assert_equal(template[:handler], expected[index][:handler])
+      end
+    end
+  end
 
   def test_calling_helpers_outside_render_raises
     component = ViewComponent::Base.new


### PR DESCRIPTION
### Summary

This extracts the template compiling logic from the base class to help reduce
`ViewComponent::Base`s public API. This should hopefully make it easier to
modify the template compilation logic by separating it from the base class
logic.

### Other Information

There may be a breaking change or two hidden in this PR, such as
`ViewComponent::Base` no longer having `variants` defined on it. I don't think
that many components would have relied on that method being callable, but worth
discussing if it should be supported.

