### PR TITLE
Always use current view context for helpers

### DIFF
--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -102,11 +102,7 @@ module ViewComponent
     # If trying to render a partial or template inside a component,
     # pass the render call to the parent view_context.
     def render(options = {}, args = {}, &block)
-      if options.is_a?(String) || (options.is_a?(Hash) && options.has_key?(:partial))
-        view_context.render(options, args, &block)
-      else
-        super
-      end
+      view_context.render(options, args, &block)
     end
 
     def controller
@@ -117,7 +113,7 @@ module ViewComponent
     # Provides a proxy to access helper methods from the context of the current controller
     def helpers
       raise ViewContextCalledBeforeRenderError, "`helpers` can only be called at render time." if view_context.nil?
-      @helpers ||= controller.view_context
+      @helpers ||= view_context
     end
 
     # Exposes .virutal_path as an instance method


### PR DESCRIPTION
This changes `render` to always delegate to the current `view_context` for rendering. This allows us to use `view_context` for helpers instead of going through `view_context.controller` and instantiating a new view context.

This should help improve performance when rendering components that use helpers.

