### PR TITLE
Revert "Always use current view context for helpers"

### DIFF
--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -102,7 +102,11 @@ module ViewComponent
     # If trying to render a partial or template inside a component,
     # pass the render call to the parent view_context.
     def render(options = {}, args = {}, &block)
-      view_context.render(options, args, &block)
+      if options.is_a?(String) || (options.is_a?(Hash) && options.has_key?(:partial))
+        view_context.render(options, args, &block)
+      else
+        super
+      end
     end
 
     def controller
@@ -113,7 +117,7 @@ module ViewComponent
     # Provides a proxy to access helper methods from the context of the current controller
     def helpers
       raise ViewContextCalledBeforeRenderError, "`helpers` can only be called at render time." if view_context.nil?
-      @helpers ||= view_context
+      @helpers ||= controller.view_context
     end
 
     # Exposes .virutal_path as an instance method


### PR DESCRIPTION
Reverts github/view_component#519

In testing v2.22.0 with `primer_view_components`, this change caused the entire test suite to fail due to captured content being rendered out of place. 

Let's revert it so we can ship a stable build while we investigate further.