### PR TITLE
Update doc link on benchmarks

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -46,7 +46,7 @@ ViewComponents use a standard Ruby initializer that clearly defines what is need
 
 #### Performance
 
-Based on our [benchmarks](performance/benchmark.rb), ViewComponents are ~10x faster than partials.
+Based on our [benchmarks](../performance/benchmark.rb), ViewComponents are ~10x faster than partials.
 
 #### Standards
 


### PR DESCRIPTION
Updates the `docs/index.md` to point to the correct link for the `benchmarks.rb`