### PR TITLE
add assert_text example

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -633,6 +633,8 @@ class MyComponentTest < ViewComponent::TestCase
     render_inline(TestComponent.new(title: "my title")) { "Hello, World!" }
 
     assert_selector("span[title='my title']", text: "Hello, World!")
+    # or, to just assert against the text:
+    assert_text("Hello, World!")
   end
 end
 ```


### PR DESCRIPTION
cc @jasonrudolph

Per @jasonrudolph, this PR adds an example of using `assert_text` to the docs.