### PR TITLE
Default to original view_context for anything that is not a ViewComponent

### DIFF
--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -101,7 +101,7 @@ module ViewComponent
 
     # use original view_context if we're not rendering a component
     def render(options = {}, args = {}, &block)
-      if options.is_a? self.class
+      if options.is_a? ViewComponent::Base
         super
       else
         view_context.render(options, args, &block)

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -99,7 +99,11 @@ module ViewComponent
 
     def initialize(*); end
 
-    # use original view_context if we're not rendering a component
+    # Re-use original view_context if we're not rendering a component.
+    #
+    # This prevents an exception when rendering a partial inside of a component that has also been rendered outside
+    # of the component. This is due to the partials compiled template method existing in the parent `view_context`,
+    #  and not the component's `view_context`.
     def render(options = {}, args = {}, &block)
       if options.is_a? ViewComponent::Base
         super

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -99,13 +99,12 @@ module ViewComponent
 
     def initialize(*); end
 
-    # If trying to render a partial or template inside a component,
-    # pass the render call to the parent view_context.
+    # use original view_context if we're not rendering a component
     def render(options = {}, args = {}, &block)
-      if options.is_a?(String) || (options.is_a?(Hash) && options.has_key?(:partial))
-        view_context.render(options, args, &block)
-      else
+      if options.is_a? self.class
         super
+      else
+        view_context.render(options, args, &block)
       end
     end
 
@@ -291,7 +290,6 @@ module ViewComponent
       def provided_collection_parameter
         @provided_collection_parameter ||= nil
       end
-
     end
 
     ActiveSupport.run_load_hooks(:view_component, self)

--- a/test/app/components/partial_component.html.erb
+++ b/test/app/components/partial_component.html.erb
@@ -1,2 +1,3 @@
 <%= render partial: "test_partial" %>
 <%= render "test_partial" %>
+<%= render OpenStruct.new(to_partial_path: "test_partial") %>

--- a/test/view_component/view_component_test.rb
+++ b/test/view_component/view_component_test.rb
@@ -132,7 +132,7 @@ class ViewComponentTest < ViewComponent::TestCase
   def test_renders_partial_template
     render_inline(PartialComponent.new)
 
-    assert_text("hello,partial world!", count: 2)
+    assert_text("hello,partial world!", count: 3)
   end
 
   def test_renders_content_for_template
@@ -240,7 +240,6 @@ class ViewComponentTest < ViewComponent::TestCase
         "This is the footer"
       end
     end
-
 
     assert_selector(".card.mt-4")
 
@@ -389,7 +388,6 @@ class ViewComponentTest < ViewComponent::TestCase
   end
 
   def test_template_changes_are_not_reflected_if_cache_is_not_cleared
-
     render_inline(MyComponent.new)
 
     assert_text("hello,world!")


### PR DESCRIPTION
Rendering partials inside a component, with an object as argument, fails in specific cases:

`render some_object`

What happens is, we fall into the else case here because the argument is an object.

https://github.com/github/view_component/blob/bbe48fc73ff85c1565f92575be6460aef474269c/lib/view_component/base.rb#L104-L110

This tries to render the partial, but within the context of the component. This works, but not if the server already rendered that partial in normal context. In that case, the template is found, but the compiled template method is defined on the original context as seen here:

https://github.com/rails/rails/blob/6f9d4a000b4394bb13daacb30003bc4010a60d23/actionview/lib/action_view/template.rb#L151-L158
```ruby
    def render(view, locals, buffer = ActionView::OutputBuffer.new, add_to_stack: true, &block)
      instrument_render_template do
        compile!(view)
        view._run(method_name, self, locals, buffer, add_to_stack: add_to_stack, &block)
      end
    rescue => e
      handle_render_error(view, e)
    end
```

and here:  https://github.com/rails/rails/blob/6f9d4a000b4394bb13daacb30003bc4010a60d23/actionview/lib/action_view/template.rb#L280-L282

This results in an error like: 

`undefined method `_app_views_nodes__toc_html_haml__3805333848491569737_66100' for #CollectionsComponent:0x00007fe40e066720`

So the method is defined, but not within the current view_context (being the component). What I suppose is to make sure we use the original view context in all cases where we're not rendering other view_components.

(The problem occurs the other way round too: if rendered first within the component, it results in the above error if when trying to render within the normal view context.)