### PR TITLE
Fix Ruby 2.6 variant warning

### DIFF
--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -132,7 +132,10 @@ module ViewComponent
 
     # For caching, such as #cache_if
     def format
-      @variant
+      # Ruby 2.6 throws a warning without checking `defined?`, 2.7 does not
+      if defined?(@variant)
+        @variant
+      end
     end
 
     # Assign the provided content to the content area accessor


### PR DESCRIPTION
This fixes a warning that is thrown in Ruby 2.6 but not 2.7.

Extracted from the slots v2 branch.
