### PR TITLE
Add frozen_string_literal to Component template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master
 
+* Add `frozen_string_literal: true` to generated component template.
+
+    *Max Beizer*
+
 ## 2.22.1
 
 * Revert refactor that broke rendering for some users.

--- a/lib/rails/generators/component/templates/component.rb.tt
+++ b/lib/rails/generators/component/templates/component.rb.tt
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class <%= class_name %>Component < <%= parent_class %>
 <%- if initialize_signature -%>
   def initialize(<%= initialize_signature %>)


### PR DESCRIPTION
@joelhawksley how do you feel about this? I certainly can't think of a reason not to do. Perhaps not everyone adds this?

It's been around a while https://bugs.ruby-lang.org/issues/8976