### PR TITLE
Bump to version 2.23.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+## 2.23.0
+
 * Add `ActionView::SlotableV2`
   * `with_slot` becomes `renders_one`.
   * `with_slot collection: true` becomes `renders_many`.

--- a/lib/view_component/version.rb
+++ b/lib/view_component/version.rb
@@ -3,8 +3,8 @@
 module ViewComponent
   module VERSION
     MAJOR = 2
-    MINOR = 22
-    PATCH = 1
+    MINOR = 23
+    PATCH = 0
 
     STRING = [MAJOR, MINOR, PATCH].join(".")
   end


### PR DESCRIPTION
* Add `ActionView::SlotableV2`
  * `with_slot` becomes `renders_one`.
  * `with_slot collection: true` becomes `renders_many`.
  * Slot definitions now accept either a component class, component class name, or a lambda instead of a `class_name:` keyword argument.
  * Slots now support positional arguments.
  * Slots no longer use the `content` attribute to render content, instead relying on `to_s`. e.g. `<%= my_slot %>`.
  * Slot values are no longer set via the `slot` method, and instead use the name of the slot.

    *Blake Williams*

* Add `frozen_string_literal: true` to generated component template.

    *Max Beizer*

