### PR TITLE
Fix out-of-order rendering issue with slots v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master
 
+* Fixed out-of-order rendering bug in `ActionView::SlotableV2`
+
+    *Blake Williams*
+
 ## 2.23.0
 
 * Add `ActionView::SlotableV2`

--- a/lib/view_component/slot_v2.rb
+++ b/lib/view_component/slot_v2.rb
@@ -22,16 +22,16 @@ module ViewComponent
     # If there is no slot renderable, we evaluate the block passed to
     # the slot and return it.
     def to_s
-      if defined?(@_component_instance)
-        # render_in is faster than `parent.render`
-        @_component_instance.render_in(
-          @parent.send(:view_context),
-          &@_content_block
-        )
-      elsif defined?(@_content)
-        @_content
-      elsif defined?(@_content_block)
-        @_content_block.call
+      view_context = @parent.send(:view_context)
+      view_context.capture do
+        if defined?(@_component_instance)
+          # render_in is faster than `parent.render`
+          @_component_instance.render_in(view_context, &@_content_block)
+        elsif defined?(@_content)
+          @_content
+        elsif defined?(@_content_block)
+          @_content_block.call
+        end
       end
     end
 
@@ -59,7 +59,7 @@ module ViewComponent
     end
 
     def respond_to_missing?(symbol, include_all = false)
-      @_component_instance.respond_to?(symbol, include_all)
+      defined?(@_component_instance) && @_component_instance.respond_to?(symbol, include_all)
     end
   end
 end

--- a/test/app/components/title_component.html.erb
+++ b/test/app/components/title_component.html.erb
@@ -1,0 +1,3 @@
+<div>
+  <h1><%= content %></h1>
+</div>

--- a/test/app/components/title_component.rb
+++ b/test/app/components/title_component.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class TitleComponent < ViewComponent::Base
+  include ViewComponent::SlotableV2
+
+  renders_one :content
+end

--- a/test/app/components/title_wrapper_component.html.erb
+++ b/test/app/components/title_wrapper_component.html.erb
@@ -1,0 +1,5 @@
+<%= render TitleComponent.new do |c| %>
+  <%= c.content do %>
+    <%= @content %>
+  <% end %>
+<% end %>

--- a/test/app/components/title_wrapper_component.rb
+++ b/test/app/components/title_wrapper_component.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class TitleWrapperComponent < ViewComponent::Base
+  def initialize(content:)
+    @content = content
+  end
+end

--- a/test/view_component/slotable_v2_test.rb
+++ b/test/view_component/slotable_v2_test.rb
@@ -183,6 +183,13 @@ class SlotsV2sTest < ViewComponent::TestCase
     assert_selector(".item.normal", count: 2)
   end
 
+  def test_renders_nested_content_in_order
+    render_inline TitleWrapperComponent.new(content: "Hello world!")
+
+    assert_selector("h1", text: /Hello world/)
+    assert_text(/Hello world/, count: 1)
+  end
+
   # In a previous implementation of slots,
   # the list of slots registered to a component
   # was accidentally assigned to all components!


### PR DESCRIPTION
This resolves an issue where slots could be rendered out-of-order,
with similar results as the form object issue.

This resolves the issue by wrapping the component in a `capture` to
ensure no output is written to the output buffer at the wrong time.

Fixes https://github.com/github/view_component/issues/548
