### PR TITLE
Sidecar translations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## main
 
+* Add `ViewComponent::I18n` for sidecar translations
+
+    *Elia Schito*
+
 * Allow customization of the controller used in component tests.
 
     *Alex Robbin*

--- a/docs/index.md
+++ b/docs/index.md
@@ -1179,6 +1179,51 @@ app/components
 </div>
 ```
 
+##### Translations
+
+In order to support `I18n` translations scoped to the component you can add a dynamic translations loader:
+
+`config/locale/components.rb`
+
+```ruby
+require "view_component/i18n"
+ViewComponent::I18n.load
+```
+
+and setup reloading support for development:
+
+`config/application.rb`
+
+```ruby
+config.after_initialize do |app|
+  require "view_component/i18n"
+  ViewComponent::I18n.initialize_i18n(app)
+end
+
+config.before_eager_load do |app|
+  require "view_component/i18n"
+  ViewComponent::I18n.initialize_i18n(app)
+end
+```
+
+This allows for adding a "sidecar" YAML file that will define translations scoped to the component:
+
+`app/components/example_component.yml`
+
+```yml
+en:
+  # This key will be expanded to `en.example_component.hello`
+  hello: "Hello world!"
+```
+
+The translations will then be available with a leading "dot":
+
+`app/components/example_component.html.erb`
+
+```erb
+<p><%= t(".hello") %></p>
+```
+
 ## Known issues
 
 ### form_for compatibility

--- a/lib/view_component/i18n.rb
+++ b/lib/view_component/i18n.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require "yaml"
+require "pathname"
+
+module ViewComponent
+  module I18n
+    # Expects a component to have a file with the same basename and
+    # the .yml extension, holding translations scoped to the component's path.
+    #
+    # A component YML should look like this:
+    #
+    #   en:
+    #     hello: "Hello World!"
+    #
+    # And inside the component will be possible to call
+    #
+    #   t(".hello") # => "Hello World!"
+    #
+    # Internally the scope will be expanded using the template's path.
+    # As an example, the translation above from within
+    # `app/components/example/greeting_component.html.erb` will result in
+    # an internal I18n key like this:
+    #
+    #   en:
+    #     example:
+    #       greeting_component:
+    #         hello: "Hello World!"
+    #
+    #
+    def self.load(components_root: "#{Rails.root}/app/components", glob: "**/*component.{yml,yaml}")
+      Dir["#{components_root}/#{glob}"].each.with_object({}) do |path, translations|
+        relative_path = Pathname(path).relative_path_from(Pathname(components_root)).to_s
+        component_translations = YAML.load_file(path, fallback: {})
+        scopes = relative_path.sub(/\.ya?ml/, "").split("/")
+
+        component_translations.to_h.each do |locale, scoped_translations|
+          translations[locale] ||= {}
+          scopes.reduce(translations[locale]) do |nested_translations, scope|
+            nested_translations[scope] ||= {}
+          end
+          translations[locale].dig(*scopes).merge! scoped_translations
+        end
+      end
+    end
+
+    @i18n_initialized = false
+
+    # Install the sidecar translations reloader
+    def self.initialize_i18n(app = Rails.application, components_root: "#{Rails.root}/app/components")
+      return if @i18n_initialized
+
+      @i18n_initialized = true
+
+      reloader = app.config.file_watcher.new [], components_root => [".yml", ".yaml"] do
+        ::I18n.reload!
+      end
+
+      app.reloaders << reloader
+      app.reloader.to_run do
+        reloader.execute_if_updated { require_unload_lock! }
+      end
+
+      reloader.execute
+    end
+  end
+end

--- a/test/app/components/translations_component.html.erb
+++ b/test/app/components/translations_component.html.erb
@@ -1,4 +1,5 @@
 <div>
   <h1><%= t('.title') %></h1>
   <h2><%= t('translations_component.subtitle') %></h2>
+  <p><%= t('.body') %></p>
 </div>

--- a/test/app/components/translations_component.yml
+++ b/test/app/components/translations_component.yml
@@ -1,0 +1,2 @@
+en:
+  body: Even more lorem!

--- a/test/config/application.rb
+++ b/test/config/application.rb
@@ -14,6 +14,11 @@ require "slim"
 module Dummy
   class Application < Rails::Application
     config.action_controller.asset_host = "http://assets.example.com"
+
+    config.after_initialize do |app|
+      require "view_component/i18n"
+      ViewComponent::I18n.initialize_i18n(app)
+    end
   end
 end
 

--- a/test/config/locales/components.rb
+++ b/test/config/locales/components.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+require "view_component/i18n"
+
+ViewComponent::I18n.load

--- a/test/view_component/i18n_test.rb
+++ b/test/view_component/i18n_test.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "fileutils"
+
+class ViewComponent::I18nTest < ViewComponent::TestCase
+  def setup
+    FileUtils.mkdir_p "#{components_root}/greeting"
+
+    File.write "#{components_root}/greeting/component.yml", <<~YAML
+      en:
+        hello: Hello!
+    YAML
+
+    File.write "#{components_root}/widget_component.yml", <<~YAML
+      en:
+        title: I'm a widget!
+        sub:
+          key: foobar
+    YAML
+  end
+
+  def test_multiple_translation_files
+    translations = ViewComponent::I18n.load components_root: components_root, glob: "**/*component.yml"
+
+    assert_equal({
+      "en" => {
+        "greeting" => {
+          "component" => {"hello" => "Hello!"}
+        },
+        "widget_component" => {
+          "title" => "I'm a widget!",
+          "sub" => { "key" => "foobar" }
+        }
+      }
+    }, translations)
+  end
+
+  def test_a_custom_glob
+    translations = ViewComponent::I18n.load components_root: components_root, glob: "**/*_component.yml"
+
+    assert_equal({
+      "en" => {
+        "widget_component" => {
+          "title" => "I'm a widget!",
+          "sub" => { "key" => "foobar" }
+        }
+      }
+    }, translations)
+  end
+
+  private
+
+  def components_root
+    @components_root ||= Dir.mktmpdir
+  end
+end

--- a/test/view_component/view_component_test.rb
+++ b/test/view_component/view_component_test.rb
@@ -348,6 +348,7 @@ class ViewComponentTest < ViewComponent::TestCase
 
     assert_selector("h1", text: I18n.t("translations_component.title"))
     assert_selector("h2", text: I18n.t("translations_component.subtitle"))
+    assert_selector("p", text: I18n.t("translations_component.body"))
   end
 
   def test_renders_component_with_rb_in_its_name


### PR DESCRIPTION
<!-- See https://github.com/github/view_component/blob/master/CONTRIBUTING.md#submitting-a-pull-request  -->

### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

Having sidecar translations is mentioned in multiple places in the project and the two apps using components I'm aware of are both doing it. Locally we solved with a less refined version of the attached code.

### Other Information

This builds on the work started in #74.

Expects a component to have a file with the same basename and the `.yml` extension, holding translations scoped to the component's path.

A component YML should look like this:

```yml
  en:
    hello: "Hello World!"
```

And inside the component will be possible to call

```erb
<%=  t(".hello") %>
```

Internally the scope will be expanded using the template's path.
As an example, the translation above from within `app/components/greeting/component.html.erb` will result in an internal `I18n` key like this:

```yml
  en:
    greeting:
      component:
        hello: "Hello World!"
```


---

_This PR is sponsored by @nebulab_