### PR TITLE
[Docs] Add prominent link to GitHub page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,4 @@
-A framework for building reusable, testable & encapsulated view components in Ruby on Rails.
+A framework for building reusable, testable & encapsulated view components in Ruby on Rails. [View on GitHub →](https://github.com/github/view_component)
 
 ## Design philosophy
 


### PR DESCRIPTION
It would be really helpful if https://viewcomponent.org/ had a link to the GitHub project near the top of the page.