### PR TITLE
Rename `master` branch to `main`.

### DIFF
--- a/.github/pull-request-template.md
+++ b/.github/pull-request-template.md
@@ -1,4 +1,4 @@
-<!-- See https://github.com/github/view_component/blob/master/CONTRIBUTING.md#submitting-a-pull-request  -->
+<!-- See https://github.com/github/view_component/blob/main/CONTRIBUTING.md#submitting-a-pull-request  -->
 
 ### Summary
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # CHANGELOG
 
-## master
+## main
+
+## 2.23.3
+
+* Rename `master` branch to `main`.
+
+    *Joel Hawksley*
 
 ## 2.23.2
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,6 @@ If you are the current maintainer of this gem:
 1. Make a PR to github/view_component.
 1. Merge github/view_component PR
 1. Create a GitHub [release](https://github.com/github/view_component/releases/new) with the pushed tag and populate it with a list of the changes from `CHANGELOG.md`.
-1. Get latest changes from default branch: `git pull origin master`
+1. Get latest changes from default branch: `git pull origin main`
 1. Build a local gem: `gem build view_component.gemspec`
 1. Push to rubygems.org -- `gem push view_component-VERSION.gem`

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,7 @@ ViewComponent is designed to integrate as seamlessly as possible [with Rails](ht
 
 ## Compatibility
 
-ViewComponent is [supported natively](https://edgeguides.rubyonrails.org/layouts_and_rendering.html#rendering-objects) in Rails 6.1, and compatible with Rails 5.0+ via an included [monkey patch](https://github.com/github/view_component/blob/master/lib/view_component/render_monkey_patch.rb).
+ViewComponent is [supported natively](https://edgeguides.rubyonrails.org/layouts_and_rendering.html#rendering-objects) in Rails 6.1, and compatible with Rails 5.0+ via an included [monkey patch](https://github.com/github/view_component/blob/main/lib/view_component/render_monkey_patch.rb).
 
 ViewComponent is tested for compatibility [with combinations of](https://github.com/github/view_component/blob/22e3d4ccce70d8f32c7375e5a5ccc3f70b22a703/.github/workflows/ruby_on_rails.yml#L10-L11) Ruby 2.4+ and Rails 5+.
 


### PR DESCRIPTION
In the interest of using `welcoming and inclusive language` (see [CONTRIBUTING](https://github.com/github/view_component/blob/main/CODE_OF_CONDUCT.md#our-standards)), this PR updates our docs to reference `main` instead of `master`, as I've renamed our default branch as such ❤️ 