### PR TITLE
add test case for rendering component only if content is provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ## main
 
-## 2.23.3
+## 2.24.0
+
+* Add test case for checking presence of `content` in `#render?`.
+
+    *Joel Hawksley*
 
 * Rename `master` branch to `main`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## main
 
-## 2.24.0
 
 * Add test case for checking presence of `content` in `#render?`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## main
 
-
 * Add test case for checking presence of `content` in `#render?`.
 
     *Joel Hawksley*

--- a/test/app/components/conditional_content_component.rb
+++ b/test/app/components/conditional_content_component.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class ConditionalContentComponent < ViewComponent::Base
+  def render?
+    content.present?
+  end
+
+  def call
+    content
+  end
+end

--- a/test/view_component/view_component_test.rb
+++ b/test/view_component/view_component_test.rb
@@ -329,6 +329,18 @@ class ViewComponentTest < ViewComponent::TestCase
     assert_no_text("component was rendered")
   end
 
+  def test_conditional_rendering_if_content_provided
+    render_inline(ConditionalContentComponent.new)
+
+    refute_component_rendered
+
+    render_inline(ConditionalContentComponent.new) do
+      "Content"
+    end
+
+    assert_text("Content")
+  end
+
   def test_render_check
     render_inline(RenderCheckComponent.new)
 


### PR DESCRIPTION
In #558 / #559, @virolea is proposing changes to how capturing content and `render?` work together. 

After reading the proposed changes, I realized that we have a conflicting use case in the GitHub.com codebase, where we have components that check for the presence of `content` in `render?`.

While I'm open to the proposed changes, I felt the need to document our current usage of this API so as to not accidentally introduce a breaking change.