### PR TITLE
Failing test for +link_to+ helper method

### DIFF
--- a/test/app/components/link_component.html.erb
+++ b/test/app/components/link_component.html.erb
@@ -1,0 +1,1 @@
+<%= link_to name, url_options, html_options %>

--- a/test/app/components/link_component.rb
+++ b/test/app/components/link_component.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class LinkComponent < ViewComponent::Base
+  attr_reader :name, :url_options, :html_options, :block
+
+  def initialize(name, url_options = nil, html_options = nil, &block)
+    @name = name
+    @url_options = url_options
+    @html_options = html_options
+    @block = block
+  end
+end

--- a/test/app/models/post.rb
+++ b/test/app/models/post.rb
@@ -2,6 +2,11 @@
 
 class Post
   include ActiveModel::Model
+  include ActiveModel::Conversion
 
-  attr_accessor :title
+  attr_accessor :id, :title
+
+  def persisted?
+    id.present?
+  end
 end

--- a/test/app/views/integration_examples/link_with_active_model.html.erb
+++ b/test/app/views/integration_examples/link_with_active_model.html.erb
@@ -1,0 +1,1 @@
+<%= render LinkComponent.new('A post', Post.new(id: 1)) %>

--- a/test/app/views/integration_examples/link_with_path.html.erb
+++ b/test/app/views/integration_examples/link_with_path.html.erb
@@ -1,0 +1,1 @@
+<%= render LinkComponent.new('With path', post_path(Post.new(id: 1))) %>

--- a/test/config/routes.rb
+++ b/test/config/routes.rb
@@ -18,4 +18,8 @@ Dummy::Application.routes.draw do
   get :render_component, to: "integration_examples#render_component"
   get :controller_inline_render_component, to: "integration_examples#controller_inline_render_component"
   get :controller_to_string_render_component, to: "integration_examples#controller_to_string_render_component"
+  get :link_with_active_model, to: "integration_examples#link_with_active_model"
+  get :link_with_path, to: "integration_examples#link_with_path"
+
+  resources :posts
 end

--- a/test/view_component/integration_test.rb
+++ b/test/view_component/integration_test.rb
@@ -493,4 +493,16 @@ class IntegrationTest < ActionDispatch::IntegrationTest
       assert_select "input[value=?]", "Send this form!"
     end
   end
+
+  def test_renders_link_component_with_active_model
+    get "/link_with_active_model"
+
+    assert_select "a[href='/posts/1']"
+  end
+
+  def test_renders_link_component_with_path
+    get "/link_with_path"
+
+    assert_select "a[href='/posts/1']"
+  end
 end


### PR DESCRIPTION
<!-- See https://github.com/github/view_component/blob/main/CONTRIBUTING.md#submitting-a-pull-request  -->

### Summary

I think this is a bug. 

This PR adds a failing test to track and fix the bug.

## Steps to reproduce
1. Create a component
2. Use an AR instance in a +link_to+ method inside the component's template
```
link_to 'Something', Post.first
```
3. Render the component in a view
4. Visit the view 

## Actual
```
Error:
ActionView::Template::Error: undefined method `merge' for #<Post:0x00007fd155be2200 @id=1>
    app/components/link_component.html.erb:1:in `call'
    (eval):3:in `render_template_for'
```

## Expected
The link is displayed correctly