### PR TITLE
Add note for defining `call_*` methods publicly to docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -397,6 +397,8 @@ And render them `with_variant`:
 # output: <%= link_to "Phone", phone_path %>
 ```
 
+_*Note*: These `call_*` methods must be public._
+
 ### Template Inheritance
 
 Components that subclass another component inherit the parent component's

--- a/docs/index.md
+++ b/docs/index.md
@@ -397,7 +397,7 @@ And render them `with_variant`:
 # output: <%= link_to "Phone", phone_path %>
 ```
 
-_*Note*: These `call_*` methods must be public._
+_*Note*: `call_*` methods must be public._
 
 ### Template Inheritance
 


### PR DESCRIPTION
This PR:
  - Adds a note about how the `call_*` methods must be defined

Why?
  - Lots of the methods that we define in components are private. This makes sure that we specifically note that they must be defined publicly.