### PR TITLE
Update index.md

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -397,7 +397,7 @@ And render them `with_variant`:
 # output: <%= link_to "Phone", phone_path %>
 ```
 
-_*Note*: `call_*` methods must be public._
+_**Note**: `call_*` methods must be public._
 
 ### Template Inheritance
 


### PR DESCRIPTION
This PR:
  - Fixes the **bold** markdown syntax

Why?
  - We were missing an asterisk

![image](https://user-images.githubusercontent.com/4008677/103822563-65243c00-503e-11eb-97f3-c14cbc796752.png)
