### PR TITLE
Add test to highlight content block performance

### DIFF
--- a/test/app/components/sleep_component.rb
+++ b/test/app/components/sleep_component.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class SleepComponent < ViewComponent::Base
+  def initialize(seconds:)
+    @seconds = seconds
+  end
+
+  def call
+    sleep @seconds
+    "sleep!"
+  end
+end

--- a/test/view_component/view_component_test.rb
+++ b/test/view_component/view_component_test.rb
@@ -570,4 +570,16 @@ class ViewComponentTest < ViewComponent::TestCase
     assert_predicate InheritedInlineComponent, :compiled?
     assert_selector("input[type='text'][name='name']")
   end
+
+  def test_does_not_render_passed_in_content_if_render_is_false
+    start_time = Time.now
+
+    render_inline ConditionalRenderComponent.new(should_render: false) do |c|
+      c.render SleepComponent.new(seconds: 5)
+    end
+
+    total = Time.now - start_time
+
+    assert total < 1
+  end
 end


### PR DESCRIPTION
This adds a test to highlight the performance impact of capturing the
block passed to `render` before `render?` is called.

The core issue is that even if a component's `render?` method returns
false, we have already evaluated the block content even though it won't
be rendered on the page.

