### PR TITLE
docs/index.md: Fix benchmarks link

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -48,7 +48,7 @@ ViewComponents use a standard Ruby initializer that clearly defines what is need
 
 #### Performance
 
-Based on our [benchmarks](../performance/benchmark.rb), ViewComponents are ~10x faster than partials.
+Based on our [benchmarks](https://github.com/github/view_component/blob/main/performance/benchmark.rb), ViewComponents are ~10x faster than partials.
 
 #### Standards
 


### PR DESCRIPTION
### Summary

The benchmarks link on the GitHub Pages site at https://viewcomponent.org doesn't work as expected. It goes to https://viewcomponent.org/performance/benchmark.rb which 404s.

This branch makes the link go to the blob on the `main` branch instead: 

https://github.com/github/view_component/blob/main/performance/benchmark.rb

### Other Information

This seems like the simplest solution, but open to others if there's a preferred approach.
