### PR TITLE
Remove no-cov from compiled_template call

### DIFF
--- a/lib/view_component/compiler.rb
+++ b/lib/view_component/compiler.rb
@@ -205,7 +205,6 @@ module ViewComponent
       end
     end
 
-    # :nocov:
     def compiled_template(file_path)
       handler = ActionView::Template.handler_for_extension(File.extname(file_path).gsub(".", ""))
       template = File.read(file_path)
@@ -216,7 +215,6 @@ module ViewComponent
         handler.call(OpenStruct.new(source: template, identifier: component_class.identifier, type: component_class.type))
       end
     end
-    # :nocov:
 
     def call_method_name(variant)
       if variant.present? && variants.include?(variant)


### PR DESCRIPTION
<!-- See https://github.com/github/view_component/blob/main/CONTRIBUTING.md#submitting-a-pull-request  -->

### Summary

While pairing with @joelhawksley , he noticed that there was a `nocov` block and we decided to try to remove it and fix the coverage gap. Looks like CI passes without it so 🔥 .


### Other Information

