### PR TITLE
Fix various warnings in test

### DIFF
--- a/test/app/components/product_reader_oops_component.rb
+++ b/test/app/components/product_reader_oops_component.rb
@@ -1,9 +1,14 @@
 # frozen_string_literal: true
 
-class ProductReaderOopsComponent < ViewComponent::Base
-  attr_reader :product,
-              :notice,
+# This code intentionally has a bug where there is an extra comma after the
+# :notice reader. `Kernel.silence_warnings` is in place to avoid Ruby emitting
+# warnings in test output.
+Kernel.silence_warnings do
+  class ProductReaderOopsComponent < ViewComponent::Base
+    attr_reader :product,
+                :notice,
 
-  def initialize(product_reader_oops:)
+    def initialize(product_reader_oops:)
+    end
   end
 end

--- a/test/view_component/integration_test.rb
+++ b/test/view_component/integration_test.rb
@@ -396,7 +396,7 @@ class IntegrationTest < ActionDispatch::IntegrationTest
       error = assert_raises ActionView::Template::Error do
         get "/render_component"
       end
-      assert_match /undefined method `render_component'/, error.message
+      assert_match(/undefined method `render_component'/, error.message)
     end
   end
 
@@ -481,7 +481,7 @@ class IntegrationTest < ActionDispatch::IntegrationTest
     error = assert_raises ViewComponent::PreviewTemplateError do
       get "/rails/view_components/inline_component/without_template"
     end
-    assert_match /preview template for example without_template does not exist/, error.message
+    assert_match(/preview template for example without_template does not exist/, error.message)
   end
 
   def test_renders_a_preview_template_using_haml_params_from_url_custom_template_and_locals


### PR DESCRIPTION
<!-- See https://github.com/github/view_component/blob/main/CONTRIBUTING.md#submitting-a-pull-request  -->

### Summary

When running `bundle exec rake` Ruby emits over a dozen lines of warnings which is pretty distracting.

This PR aims to clean up some if not all of those warnings.

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file. -->
