### PR TITLE
Only warn of deprecation if the Rails.env is not test

### DIFF
--- a/lib/view_component.rb
+++ b/lib/view_component.rb
@@ -7,6 +7,7 @@ module ViewComponent
 
   autoload :Base
   autoload :Compiler
+  autoload :Deprecation
   autoload :Preview
   autoload :PreviewTemplateError
   autoload :TestHelpers

--- a/lib/view_component/compiler.rb
+++ b/lib/view_component/compiler.rb
@@ -21,7 +21,7 @@ module ViewComponent
       if component_class.instance_methods(false).include?(:before_render_check)
         ActiveSupport::Deprecation.warn(
           "`before_render_check` will be removed in v3.0.0. Use `before_render` instead."
-        )
+        ) unless Rails.env.test?
       end
 
       # Remove any existing singleton methods,

--- a/lib/view_component/compiler.rb
+++ b/lib/view_component/compiler.rb
@@ -21,7 +21,7 @@ module ViewComponent
       if component_class.instance_methods(false).include?(:before_render_check)
         ActiveSupport::Deprecation.warn(
           "`before_render_check` will be removed in v3.0.0. Use `before_render` instead."
-        ) unless Rails.env.test?
+        ) unless ENV["VIEW_COMPONENT_ENV"] == "test"
       end
 
       # Remove any existing singleton methods,

--- a/lib/view_component/compiler.rb
+++ b/lib/view_component/compiler.rb
@@ -19,9 +19,9 @@ module ViewComponent
       end
 
       if component_class.instance_methods(false).include?(:before_render_check)
-        ActiveSupport::Deprecation.warn(
+        ViewComponent::Deprecation.warn(
           "`before_render_check` will be removed in v3.0.0. Use `before_render` instead."
-        ) unless ENV["VIEW_COMPONENT_ENV"] == "test"
+        )
       end
 
       # Remove any existing singleton methods,

--- a/lib/view_component/deprecation.rb
+++ b/lib/view_component/deprecation.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module ViewComponent
+  # ViewComponent should warn consumers when they are using a deprecated method.
+  # In local development, however, those deprecation warnings are distracting.
+  # This class wraps the deprecation warning functionality in some basic logic
+  # so the deprecation warnings are only shown to consumers.
+  class Deprecation
+    def self.warn(message)
+      new.warn(message)
+    end
+
+    def initialize
+      @deprecation_class = if local_test_env?
+                             NoopDeprecation
+                           else
+                             ActiveSupport::Deprecation
+                           end
+    end
+
+    def warn(message)
+      @deprecation_class.warn(message)
+    end
+
+    private
+
+    def local_test_env?
+      ENV["VIEW_COMPONENT_ENV"] == "test"
+    end
+  end
+
+  class NoopDeprecation
+    def self.warn(_); end
+  end
+end

--- a/lib/view_component/deprecation.rb
+++ b/lib/view_component/deprecation.rb
@@ -12,10 +12,10 @@ module ViewComponent
 
     def initialize
       @deprecation_class = if local_test_env?
-                             NoopDeprecation
-                           else
-                             ActiveSupport::Deprecation
-                           end
+        NoopDeprecation
+      else
+        ActiveSupport::Deprecation
+      end
     end
 
     def warn(message)

--- a/lib/view_component/engine.rb
+++ b/lib/view_component/engine.rb
@@ -22,9 +22,9 @@ module ViewComponent
         )
 
         if options.preview_path.present?
-          ActiveSupport::Deprecation.warn(
+          ViewComponent::Deprecation.warn(
             "`preview_path` will be removed in v3.0.0. Use `preview_paths` instead."
-          ) unless ENV["VIEW_COMPONENT_ENV"] == "test"
+          )
           options.preview_paths << options.preview_path
         end
       end

--- a/lib/view_component/engine.rb
+++ b/lib/view_component/engine.rb
@@ -24,7 +24,7 @@ module ViewComponent
         if options.preview_path.present?
           ActiveSupport::Deprecation.warn(
             "`preview_path` will be removed in v3.0.0. Use `preview_paths` instead."
-          ) unless Rails.env.test?
+          ) unless ENV["VIEW_COMPONENT_ENV"] == "test"
           options.preview_paths << options.preview_path
         end
       end

--- a/lib/view_component/engine.rb
+++ b/lib/view_component/engine.rb
@@ -24,7 +24,7 @@ module ViewComponent
         if options.preview_path.present?
           ActiveSupport::Deprecation.warn(
             "`preview_path` will be removed in v3.0.0. Use `preview_paths` instead."
-          )
+          ) unless Rails.env.test?
           options.preview_paths << options.preview_path
         end
       end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -17,6 +17,7 @@ require "minitest/autorun"
 
 # Configure Rails Envinronment
 ENV["RAILS_ENV"] = "test"
+ENV["VIEW_COMPONENT_ENV"] = "test"
 
 require File.expand_path("../config/environment.rb", __FILE__)
 require "rails/test_help"


### PR DESCRIPTION
<!-- See https://github.com/github/view_component/blob/main/CONTRIBUTING.md#submitting-a-pull-request  -->

### Summary

related to #585  

### First pass

I split this one off from the other PR since it may involve more thought/discussion. Is there any reason to show these warnings in test? For development purposes, no. Would library consumers not see this warning with this change? I don't think they will and that may be a bad idea.

Still thinking about it.

### Second pass

I think this is a better approach. This uses an env var set up in `test_helper` to determine whether we are testing the library or a consumer is running tests against their app. If we are running VC tests, then swallow the warning.

In https://github.com/github/view_component/pull/586/commits/cddc367714294a6381c5f8826d303bdf415abd7e decided to introduce a new class to wrap the warning logic. One benefit here is that we could potentially capture those warnings and write tests against the, essentially asserting that various code paths will warn consumers. If you like this approach I can extend it a bit more and fix up the code coverage.

I thought I'd propose it and if you don't like it then we can go back to the simpler https://github.com/github/view_component/pull/586/commits/927c088cd3e5f7b8b5cfd500eca6c208e95e5438

cc @joelhawksley 


### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file. -->
