### PR TITLE
Add optional preview to generators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## main
 
+* Add `--preview` option to the generator. Generates associated preview file.
+
+  *Bob Maerten*
+
 ## 2.24.0
 
 * Add `--inline` option to the erb generator. Prevents default erb template from being created and creates a component with a call method.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1212,7 +1212,8 @@ ViewComponent is built by:
 |@johannesengl|@czj|@mrrooijen|@bradparker|@mattbrictson|
 |Berlin, Germany|Paris, France|The Netherlands|Brisbane, Australia|San Francisco|
 
-|<img src="https://avatars.githubusercontent.com/mixergtz?s=256" alt="mixergtz" width="128" />|<img src="https://avatars.githubusercontent.com/jules2689?s=256" alt="jules2689" width="128" />|<img src="https://avatars.githubusercontent.com/g13ydson?s=256" alt="g13ydson" width="128" />|<img src="https://avatars.githubusercontent.com/swanson?s=256" alt="swanson" width="128" />|
-|:---:|:---:|:---:|:---:|
-|@mixergtz|@jules2689|@g13ydson|@swanson|
-|Medellin, Colombia|Toronto, Canada|João Pessoa, Brazil|Indianapolis, IN|
+|<img src="https://avatars.githubusercontent.com/mixergtz?s=256" alt="mixergtz" width="128" />|<img src="https://avatars.githubusercontent.com/jules2689?s=256" alt="jules2689" width="128" />|<img src="https://avatars.githubusercontent.com/g13ydson?s=256" alt="g13ydson" width="128" />|<img src="https://avatars.githubusercontent.com/swanson?s=256" alt="swanson" width="128" />|<img src="https://avatars.githubusercontent.com/bobmaerten?s=256" alt="bobmaerten" width="128" />|
+|:---:|:---:|:---:|:---:|:---:|
+|@mixergtz|@jules2689|@g13ydson|@swanson|@bobmaerten|
+|Medellin, Colombia|Toronto, Canada|João Pessoa, Brazil|Indianapolis, IN|Valenciennes, France|
+

--- a/lib/rails/generators/component/component_generator.rb
+++ b/lib/rails/generators/component/component_generator.rb
@@ -15,6 +15,10 @@ module Rails
 
       hook_for :test_framework
 
+      hook_for :preview, type: :boolean do |instance, preview|
+        instance.invoke preview, [instance.name, instance.attributes.map(&:name)]
+      end
+
       hook_for :template_engine do |instance, template_engine|
         instance.invoke template_engine, [instance.name]
       end

--- a/lib/rails/generators/preview/component_generator.rb
+++ b/lib/rails/generators/preview/component_generator.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Preview
+  module Generators
+    class ComponentGenerator < ::Rails::Generators::NamedBase
+      source_root File.expand_path("templates", __dir__)
+
+      argument :attributes, type: :array, default: [], banner: "attribute"
+      check_class_collision suffix: "ComponentPreview"
+
+      def create_preview_file
+        template "component_preview.rb", File.join("test/components/previews", class_path, "#{file_name}_component_preview.rb")
+      end
+
+      private
+
+      def file_name
+        @_file_name ||= super.sub(/_component\z/i, "")
+      end
+
+      def initialize_signature
+        return if attributes.blank?
+
+        attributes.map { |attr| %(#{attr.name}: "#{attr.name}") }.join(", ")
+      end
+    end
+  end
+end

--- a/lib/rails/generators/preview/templates/component_preview.rb.tt
+++ b/lib/rails/generators/preview/templates/component_preview.rb.tt
@@ -1,0 +1,11 @@
+require "test_helper"
+
+class <%= class_name %>ComponentPreview < ViewComponent::Preview
+  def with_useful_content
+  <%- if initialize_signature -%>
+    render(<%= class_name %>Component.new(<%= initialize_signature %>))
+  <%- else -%>
+    render(<%= class_name %>Component.new)
+  <%- end -%>
+  end
+end

--- a/test/generators/component_generator_test.rb
+++ b/test/generators/component_generator_test.rb
@@ -22,6 +22,15 @@ class ComponentGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_component_tests
+    run_generator %w[user --test-framework test_unit]
+
+    assert_file "test/components/user_component_test.rb" do |component|
+      assert_match(/class UserComponentTest < /, component)
+      assert_match(/def test_component_renders_something_useful/, component)
+    end
+  end
+
   def test_component_preview
     run_generator %w[user --preview]
 
@@ -63,6 +72,15 @@ class ComponentGeneratorTest < Rails::Generators::TestCase
     run_generator %w[admins/user]
 
     assert_file "app/components/admins/user_component.rb", /class Admins::UserComponent < /
+  end
+
+  def test_component_tests_with_namespace
+    run_generator %w[admins/user --test-framework test_unit]
+
+    assert_file "test/components/admins/user_component_test.rb" do |component|
+      assert_match(/class Admins::UserComponentTest < /, component)
+      assert_match(/def test_component_renders_something_useful/, component)
+    end
   end
 
   def test_component_preview_with_namespace

--- a/test/generators/component_generator_test.rb
+++ b/test/generators/component_generator_test.rb
@@ -22,12 +22,30 @@ class ComponentGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_component_preview
+    run_generator %w[user --preview]
+
+    assert_file "test/components/previews/user_component_preview.rb" do |component|
+      assert_match(/class UserComponentPreview < /, component)
+      assert_match(/render\(UserComponent.new\)/, component)
+    end
+  end
+
   def test_component_with_arguments
     run_generator %w[user name]
 
     assert_file "app/components/user_component.rb" do |component|
       assert_match(/class UserComponent < /, component)
       assert_match(/def initialize\(name:\)/, component)
+    end
+  end
+
+  def test_component_preview_with_arguments
+    run_generator %w[user name --preview]
+
+    assert_file "test/components/previews/user_component_preview.rb" do |component|
+      assert_match(/class UserComponentPreview < /, component)
+      assert_match(/render\(UserComponent.new\(name: "name"\)\)/, component)
     end
   end
 
@@ -45,6 +63,15 @@ class ComponentGeneratorTest < Rails::Generators::TestCase
     run_generator %w[admins/user]
 
     assert_file "app/components/admins/user_component.rb", /class Admins::UserComponent < /
+  end
+
+  def test_component_preview_with_namespace
+    run_generator %w[admins/user --preview]
+
+    assert_file "test/components/previews/admins/user_component_preview.rb" do |component|
+      assert_match(/class Admins::UserComponentPreview < /, component)
+      assert_match(/render\(Admins::UserComponent.new\)/, component)
+    end
   end
 
   def test_invoking_erb_template_engine


### PR DESCRIPTION
### Summary

Enable passing `--preview` to generators to automatically generate preview file.
Closes #584

### Other Information

I found missing test cases on generator tests, but I found them in integration test. Remove them if you find it acts as double.