### PR TITLE
Fix broken link to slots v1 docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -171,7 +171,7 @@ Returning:
 
 #### Slots (experimental)
 
-_Slots are currently under development as the successor to Content Areas. The Slot APIs should be considered unfinished (it's already in its second iteration, [see the original API](/slots-v1).) and subject to breaking changes in non-major releases of ViewComponent._
+_Slots are currently under development as the successor to Content Areas. The Slot APIs should be considered unfinished (it's already in its second iteration, [see the original API](/slots_v1).) and subject to breaking changes in non-major releases of ViewComponent._
 
 Slots enable multiple blocks of content to be passed to a single ViewComponent, improving the ergonomics of complex components.
 


### PR DESCRIPTION
<!-- See https://github.com/github/view_component/blob/main/CONTRIBUTING.md#submitting-a-pull-request  -->

### Summary

Link to the original slots v1 api docs was a 404. Hopefully this fixes it 🍔 
