### PR TITLE
Fix test helper issue by using the monkey patch value in render_inline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## main
 
+* Fix bug where render_inline helper didn't work when monkey patch was enabled.
+
+    *Josiah Campbell*
+
 * Add `--preview` generator option to create an associated preview file.
 
   *Bob Maerten*

--- a/docs/index.md
+++ b/docs/index.md
@@ -1222,3 +1222,8 @@ ViewComponent is built by:
 |:---:|:---:|:---:|:---:|:---:|
 |@mixergtz|@jules2689|@g13ydson|@swanson|@bobmaerten|
 |Medellin, Colombia|Toronto, Canada|João Pessoa, Brazil|Indianapolis, IN|Valenciennes, France|
+
+|<img src="https://avatars.githubusercontent.com/jocmp?s=256" alt="jocmp" width="128" />|
+|:---:|
+|@jocmp|
+| Grand Rapids, MI |

--- a/lib/view_component/test_helpers.rb
+++ b/lib/view_component/test_helpers.rb
@@ -25,7 +25,7 @@ module ViewComponent
 
     def render_inline(component, **args, &block)
       @rendered_component =
-        if Rails.version.to_f >= 6.1
+        if Base.render_monkey_patch_enabled || Rails.version.to_f >= 6.1
           controller.view_context.render(component, args, &block)
         else
           controller.view_context.render_component(component, &block)

--- a/test/view_component/view_component_test.rb
+++ b/test/view_component/view_component_test.rb
@@ -570,4 +570,12 @@ class ViewComponentTest < ViewComponent::TestCase
     assert_predicate InheritedInlineComponent, :compiled?
     assert_selector("input[type='text'][name='name']")
   end
+
+  def test_render_inline_with_public_render_api
+    with_render_monkey_patch_config(true) do
+      render_inline(MyComponent.new)
+
+      assert_selector("div", text: "hello,world!")
+    end
+  end
 end


### PR DESCRIPTION
### Summary

In Rails < 6.1, if there is already a render_component method defined on
the controller, then the render_inline method will not send the message correctly.

```ruby
module MyExistingHelper
  # public methods...
  private
    def render_component
      puts "I wish I didn't conflict with view_component!"
    end
end
```

Then the following output will occur using Rspec:

```
  1) MyComponent renders
     Failure/Error: component = render_inline(described_class.new(attr: "myval")).css("h2").to_html

     NoMethodError:
       private method `render_component' called for #<#<Class:0x00007ff80cd48080>:0x00007ff80cd195c8>
       Did you mean?  ...
```

Instead, this change fixes the name conflict by using the same predicate found in the preview template ([Permalink](https://github.com/github/view_component/blob/062f9bbf8dbdb05f3a695d1b5393bad0c4503c24/app/views/view_components/preview.html.erb#L1)), which checks if the render monkey patch is enabled or falls back to the initial check if Rails >= 6.1

Previous related change relating to previews: [Previews with render_component fail when render_monkey_patch_enabled is set to false #433](https://github.com/github/view_component/pull/433)