### PR TITLE
Validate component arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
   *Bob Maerten*
 
-* Add argument validation to avoid `content` override
+* Add argument validation to avoid `content` override.
 
     *Manuel Puyol*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
   *Bob Maerten*
 
+* Add argument validation to avoid `content` override
+
+    *Manuel Puyol*
+
 ## 2.24.0
 
 * Add `--inline` option to the erb generator. Prevents default erb template from being created and creates a component with a call method.

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -304,9 +304,7 @@ module ViewComponent
           "public ViewComponent method."
         end
 
-        raise ArgumentError.new(
-
-        )
+        raise ArgumentError.new message
       end
 
       private

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -15,7 +15,7 @@ module ViewComponent
 
     ViewContextCalledBeforeRenderError = Class.new(StandardError)
 
-    BLACKLISTED_PARAMETERS = %i[content].freeze
+    DENYLISTED_PARAMETERS = %i[content].freeze
 
     # For CSRF authenticity tokens in forms
     delegate :form_authenticity_token, :protect_against_forgery?, :config, to: :helpers
@@ -287,7 +287,7 @@ module ViewComponent
       # invalid parameters that could override the framework's
       # methods.
       def validate_initialization_parameters!
-        invalid_parameters = initialize_parameter_names & BLACKLISTED_PARAMETERS
+        invalid_parameters = initialize_parameter_names & DENYLISTED_PARAMETERS
 
         return unless invalid_parameters.any?
 

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -292,8 +292,9 @@ module ViewComponent
         return unless invalid_parameters.any?
 
         raise ArgumentError.new(
-          "#{self} initializer must not have " \
-          "`#{invalid_parameters.join(", ")}` as parameters."
+          "#{self} initializer cannot contain " \
+          "`#{invalid_parameters.join(", ")}` since it will override " \
+          "public ViewComponent methods."
         )
       end
 

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -15,7 +15,7 @@ module ViewComponent
 
     ViewContextCalledBeforeRenderError = Class.new(StandardError)
 
-    DENYLISTED_PARAMETERS = %i[content].freeze
+    RESERVED_PARAMETER = :content
 
     # For CSRF authenticity tokens in forms
     delegate :form_authenticity_token, :protect_against_forgery?, :config, to: :helpers
@@ -287,24 +287,13 @@ module ViewComponent
       # invalid parameters that could override the framework's
       # methods.
       def validate_initialization_parameters!
-        invalid_parameters = initialize_parameter_names & DENYLISTED_PARAMETERS
+        return unless initialize_parameter_names.include?(RESERVED_PARAMETER)
 
-        return unless invalid_parameters.any?
-
-        multiple_parameters = invalid_parameters.size > 1
-        parameter_list = invalid_parameters.join(", ")
-
-        message = if multiple_parameters
+        raise ArgumentError.new(
           "#{self} initializer cannot contain " \
-          "`#{parameter_list}` since they will override " \
-          "public ViewComponent methods."
-        else
-          "#{self} initializer cannot contain " \
-          "`#{parameter_list}` since it will override a " \
+          "`#{RESERVED_PARAMETER}` since it will override a " \
           "public ViewComponent method."
-        end
-
-        raise ArgumentError.new message
+        )
       end
 
       private

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -291,10 +291,21 @@ module ViewComponent
 
         return unless invalid_parameters.any?
 
-        raise ArgumentError.new(
+        multiple_parameters = invalid_parameters.size > 1
+        parameter_list = invalid_parameters.join(", ")
+
+        message = if multiple_parameters
           "#{self} initializer cannot contain " \
-          "`#{invalid_parameters.join(", ")}` since it will override " \
+          "`#{parameter_list}` since they will override " \
           "public ViewComponent methods."
+        else
+          "#{self} initializer cannot contain " \
+          "`#{parameter_list}` since it will override a " \
+          "public ViewComponent method."
+        end
+
+        raise ArgumentError.new(
+
         )
       end
 

--- a/lib/view_component/compiler.rb
+++ b/lib/view_component/compiler.rb
@@ -46,7 +46,10 @@ module ViewComponent
         instance_method(:initialize).parameters.map(&:second).include?(collection_counter_parameter)
       end
 
-      component_class.validate_collection_parameter! if raise_errors
+      if raise_errors
+        component_class.validate_initialization_parameters!
+        component_class.validate_collection_parameter!
+      end
 
       templates.each do |template|
         # Remove existing compiled template methods,

--- a/test/app/components/invalid_named_parameters_component.erb
+++ b/test/app/components/invalid_named_parameters_component.erb
@@ -1,0 +1,1 @@
+<h1>Hello World</h1>

--- a/test/app/components/invalid_named_parameters_component.rb
+++ b/test/app/components/invalid_named_parameters_component.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class InvalidNamedParametersComponent < ViewComponent::Base
+  def initialize(content:); end
+end

--- a/test/app/components/invalid_parameters_component.erb
+++ b/test/app/components/invalid_parameters_component.erb
@@ -1,0 +1,1 @@
+<h1>Hello World</h1>

--- a/test/app/components/invalid_parameters_component.rb
+++ b/test/app/components/invalid_parameters_component.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class InvalidParametersComponent < ViewComponent::Base
+  def initialize(content); end
+end

--- a/test/view_component/view_component_test.rb
+++ b/test/view_component/view_component_test.rb
@@ -536,6 +536,21 @@ class ViewComponentTest < ViewComponent::TestCase
     assert_match(/MissingDefaultCollectionParameterComponent initializer must accept `missing_default_collection_parameter` collection parameter/, exception.message)
   end
 
+  def test_component_with_invalid_parameter_names
+    begin
+      old_cache = ViewComponent::CompileCache.cache
+      ViewComponent::CompileCache.cache = Set.new
+
+      exception = assert_raises ArgumentError do
+        InvalidParametersComponent.compile(raise_errors: true)
+      end
+
+      assert_match(/InvalidParametersComponent initializer cannot contain `content` since it will override public ViewComponent methods/, exception.message)
+    ensure
+      ViewComponent::CompileCache.cache = old_cache
+    end
+  end
+
   def test_collection_component_with_trailing_comma_attr_reader
     exception = assert_raises ArgumentError do
       render_inline(

--- a/test/view_component/view_component_test.rb
+++ b/test/view_component/view_component_test.rb
@@ -545,7 +545,7 @@ class ViewComponentTest < ViewComponent::TestCase
         InvalidParametersComponent.compile(raise_errors: true)
       end
 
-      assert_match(/InvalidParametersComponent initializer cannot contain `content` since it will override public ViewComponent methods/, exception.message)
+      assert_match(/InvalidParametersComponent initializer cannot contain `content` since it will override public ViewComponent method/, exception.message)
     ensure
       ViewComponent::CompileCache.cache = old_cache
     end

--- a/test/view_component/view_component_test.rb
+++ b/test/view_component/view_component_test.rb
@@ -551,6 +551,21 @@ class ViewComponentTest < ViewComponent::TestCase
     end
   end
 
+  def test_component_with_invalid_named_parameter_names
+    begin
+      old_cache = ViewComponent::CompileCache.cache
+      ViewComponent::CompileCache.cache = Set.new
+
+      exception = assert_raises ArgumentError do
+        InvalidNamedParametersComponent.compile(raise_errors: true)
+      end
+
+      assert_match(/InvalidNamedParametersComponent initializer cannot contain `content` since it will override public ViewComponent methods/, exception.message)
+    ensure
+      ViewComponent::CompileCache.cache = old_cache
+    end
+  end
+
   def test_collection_component_with_trailing_comma_attr_reader
     exception = assert_raises ArgumentError do
       render_inline(

--- a/test/view_component/view_component_test.rb
+++ b/test/view_component/view_component_test.rb
@@ -545,7 +545,7 @@ class ViewComponentTest < ViewComponent::TestCase
         InvalidParametersComponent.compile(raise_errors: true)
       end
 
-      assert_match(/InvalidParametersComponent initializer cannot contain `content` since it will override public ViewComponent method/, exception.message)
+      assert_match(/InvalidParametersComponent initializer cannot contain `content` since it will override a public ViewComponent method/, exception.message)
     ensure
       ViewComponent::CompileCache.cache = old_cache
     end
@@ -560,7 +560,7 @@ class ViewComponentTest < ViewComponent::TestCase
         InvalidNamedParametersComponent.compile(raise_errors: true)
       end
 
-      assert_match(/InvalidNamedParametersComponent initializer cannot contain `content` since it will override public ViewComponent methods/, exception.message)
+      assert_match(/InvalidNamedParametersComponent initializer cannot contain `content` since it will override a public ViewComponent method/, exception.message)
     ensure
       ViewComponent::CompileCache.cache = old_cache
     end


### PR DESCRIPTION
### Summary

Closes https://github.com/github/view_component/issues/580

Adds a validation on compile time that checks if any blacklisted arguments are used on the component `initialize`. At the moment, the only invalid argument name is `content` but it can be expanded