### PR TITLE
Call `.after_compile` class method after a component is compiled.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## main
 
-* Call `.after_compile` class method after a component is compiled.
+* Experimental: call `._after_compile` class method after a component is compiled.
 
     *Joel Hawksley*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## main
 
+* Call `.after_compile` class method after a component is compiled.
+
+    *Joel Hawksley*
+
 * Fix bug where SlotV2 was rendered as an HTML string when using Slim.
 
     *Manuel Puyol*

--- a/docs/index.md
+++ b/docs/index.md
@@ -554,6 +554,12 @@ class ExampleComponent < ViewComponent::Base
 end
 ```
 
+### `.after_compile`
+
+ViewComponents can define an `after_compile` class method that will be called after the component is compiled.
+
+`.after_compile` is called at request time if `Rails.application.config.eager_load` is `false`, or at application boot if it set to `true`.
+
 ### Rendering collections
 
 Use `with_collection` to render a ViewComponent with a collection:

--- a/docs/index.md
+++ b/docs/index.md
@@ -540,9 +540,9 @@ end
 
 _To assert that a component has not been rendered, use `refute_component_rendered` from `ViewComponent::TestHelpers`._
 
-### `before_render`
+### `#before_render`
 
-Components can define a `before_render` method to be called before a component is rendered, when `helpers` is able to be used:
+ViewComponents can define a `before_render` method to be called before a component is rendered, when `helpers` is able to be used:
 
 `app/components/example_component.rb`
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -554,12 +554,6 @@ class ExampleComponent < ViewComponent::Base
 end
 ```
 
-### `.after_compile`
-
-ViewComponents can define an `after_compile` class method that will be called after the component is compiled.
-
-`.after_compile` is called at request time if `Rails.application.config.eager_load` is `false`, or at application boot if set to `true`.
-
 ### Rendering collections
 
 Use `with_collection` to render a ViewComponent with a collection:

--- a/docs/index.md
+++ b/docs/index.md
@@ -558,7 +558,7 @@ end
 
 ViewComponents can define an `after_compile` class method that will be called after the component is compiled.
 
-`.after_compile` is called at request time if `Rails.application.config.eager_load` is `false`, or at application boot if it set to `true`.
+`.after_compile` is called at request time if `Rails.application.config.eager_load` is `false`, or at application boot if set to `true`.
 
 ### Rendering collections
 

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -23,10 +23,11 @@ module ViewComponent
     class_attribute :content_areas
     self.content_areas = [] # class_attribute:default doesn't work until Rails 5.2
 
+    # EXPERIMENTAL: This API is experimental and may be removed at any time.
     # Hook for allowing components to do work as part of the compilation process.
     #
     # For example, one might compile component-specific assets at this point.
-    def self.after_compile
+    def self._after_compile
       # noop
     end
 

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -23,6 +23,13 @@ module ViewComponent
     class_attribute :content_areas
     self.content_areas = [] # class_attribute:default doesn't work until Rails 5.2
 
+    # Hook for allowing components to do work as part of the compilation process.
+    #
+    # For example, one might compile component-specific assets at this point.
+    def self.after_compile
+      # noop
+    end
+
     # Entrypoint for rendering components.
     #
     # view_context: ActionView context from calling view

--- a/lib/view_component/compiler.rb
+++ b/lib/view_component/compiler.rb
@@ -67,7 +67,7 @@ module ViewComponent
 
       define_render_template_for
 
-      component_class.after_compile
+      component_class._after_compile
 
       CompileCache.register(component_class)
     end

--- a/lib/view_component/compiler.rb
+++ b/lib/view_component/compiler.rb
@@ -67,6 +67,8 @@ module ViewComponent
 
       define_render_template_for
 
+      component_class.after_compile
+
       CompileCache.register(component_class)
     end
 

--- a/test/app/components/after_compile_component.rb
+++ b/test/app/components/after_compile_component.rb
@@ -3,7 +3,7 @@
 class AfterCompileComponent < ViewComponent::Base
   @@compiled_value = ""
 
-  def self.after_compile
+  def self._after_compile
     @@compiled_value = "Hello, World!"
   end
 

--- a/test/app/components/after_compile_component.rb
+++ b/test/app/components/after_compile_component.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class AfterCompileComponent < ViewComponent::Base
+  @@compiled_value = ""
+
+  def self.after_compile
+    @@compiled_value = "Hello World!"
+  end
+
+  def self.compiled_value
+    @@compiled_value
+  end
+
+  def call
+    @@compiled_value
+  end
+end

--- a/test/app/components/after_compile_component.rb
+++ b/test/app/components/after_compile_component.rb
@@ -4,7 +4,7 @@ class AfterCompileComponent < ViewComponent::Base
   @@compiled_value = ""
 
   def self.after_compile
-    @@compiled_value = "Hello World!"
+    @@compiled_value = "Hello, World!"
   end
 
   def self.compiled_value

--- a/test/view_component/view_component_test.rb
+++ b/test/view_component/view_component_test.rb
@@ -627,4 +627,12 @@ class ViewComponentTest < ViewComponent::TestCase
     assert_predicate InheritedInlineComponent, :compiled?
     assert_selector("input[type='text'][name='name']")
   end
+
+  def test_after_compile
+    assert_equal AfterCompileComponent.compiled_value, "Hello, World!"
+
+    render_inline(AfterCompileComponent.new)
+
+    assert_text "Hello, World!"
+  end
 end


### PR DESCRIPTION
### Summary

This PR introduces the `after_compile` hook, allowing for components to define logic that should be executed when the component is compiled.

### Other Information

The compilation step is a critical part of the ViewComponent architecture that has previously been more or less invisible to the developer. I'm hoping that this hook is the first step towards allowing developers to leverage this powerful feature in new and exciting ways. 