### PR TITLE
add note about assert_selector visibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,10 @@ jobs:
             ruby_version: 2.4.10
           - rails_version: main
             ruby_version: 2.4.10
+          - rails_version: main
+            ruby_version: 2.5.8
+          - rails_version: main
+            ruby_version: 2.6.6
     steps:
     - uses: actions/checkout@master
     - name: Setup Ruby

--- a/docs/index.md
+++ b/docs/index.md
@@ -709,6 +709,8 @@ class ExampleComponentTest < ViewComponent::TestCase
 end
 ```
 
+_Note: `assert_selector` only matches on visible elements by default. To match on hidden elements, add `visible: false`._
+
 In the absence of `capybara`, assert against the return value of `render_inline`, which is an instance of `Nokogiri::HTML::DocumentFragment`:
 
 ```ruby

--- a/docs/index.md
+++ b/docs/index.md
@@ -709,7 +709,7 @@ class ExampleComponentTest < ViewComponent::TestCase
 end
 ```
 
-_Note: `assert_selector` only matches on visible elements by default. To match on hidden elements, add `visible: false`._
+_Note: `assert_selector` only matches on visible elements by default. To match on hidden elements, add `visible: false`. See the [Capybara documentation](https://rubydoc.info/github/jnicklas/capybara/Capybara/Node/Matchers) for more details._
 
 In the absence of `capybara`, assert against the return value of `render_inline`, which is an instance of `Nokogiri::HTML::DocumentFragment`:
 


### PR DESCRIPTION
This PR adds a small note about using `assert_selector` with hidden elements, as its behavior has bit a few developers enough to warrant a warning here.