### PR TITLE
Lazily evaluate content instead of eagerly evaluating it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## main
 
+* Lazily evaluate component `content` in `render?`, preventing the `content` block from being evaluated when `render?` returns false.
+
 ## 2.25.1
 
 * Experimental: call `._after_compile` class method after a component is compiled.

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -78,6 +78,7 @@ module ViewComponent
       old_current_template = @current_template
       @current_template = self
 
+      @_content_evaluated = false
       @_render_in_block = block
 
       before_render
@@ -181,10 +182,15 @@ module ViewComponent
 
     def content
       return @_content if defined?(@_content)
+      @_content_evaluated = true
 
       if @view_context && @_render_in_block
         @_content = view_context.capture(self, &@_render_in_block)
       end
+    end
+
+    def content_evaluated?
+      @_content_evaluated
     end
 
     # The controller used for testing components.

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -184,8 +184,8 @@ module ViewComponent
       return @_content if defined?(@_content)
       @_content_evaluated = true
 
-      if @view_context && @_render_in_block
-        @_content = view_context.capture(self, &@_render_in_block)
+      @_content = if @view_context && @_render_in_block
+        view_context.capture(self, &@_render_in_block)
       end
     end
 

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -84,7 +84,6 @@ module ViewComponent
       before_render
 
       if render?
-        content # eager load content to preload things like slots
         render_template_for(@variant)
       else
         ""
@@ -270,7 +269,14 @@ module ViewComponent
         if areas.include?(:content)
           raise ArgumentError.new ":content is a reserved content area name. Please use another name, such as ':body'"
         end
-        attr_reader(*areas)
+
+        areas.each do |area|
+          define_method area.to_sym do
+            content unless content_evaluated? # ensure content is loaded so content_areas will be defined
+            instance_variable_get(:"@#{area}") if instance_variable_defined?(:"@#{area}")
+          end
+        end
+
         self.content_areas = areas
       end
 

--- a/lib/view_component/slotable.rb
+++ b/lib/view_component/slotable.rb
@@ -51,11 +51,17 @@ module ViewComponent
           if collection
             class_eval <<-RUBY
               def #{accessor_name}
+                content unless content_evaluated? # ensure content is loaded so slots will be defined
                 #{instance_variable_name} ||= []
               end
             RUBY
           else
-            attr_reader accessor_name
+            class_eval <<-RUBY
+              def #{accessor_name}
+                content unless content_evaluated? # ensure content is loaded so slots will be defined
+                #{instance_variable_name} if defined?(#{instance_variable_name})
+              end
+            RUBY
           end
 
           # Default class_name to ViewComponent::Slot

--- a/lib/view_component/slotable_v2.rb
+++ b/lib/view_component/slotable_v2.rb
@@ -69,6 +69,7 @@ module ViewComponent
 
         define_method slot_name do |*args, **kwargs, &block|
           if args.empty? && kwargs.empty? && block.nil?
+            content unless content_evaluated? # ensure content is loaded so slots will be defined
             get_slot(slot_name)
           else
             set_slot(slot_name, *args, **kwargs, &block)
@@ -131,6 +132,7 @@ module ViewComponent
         # argument to each slot constructor
         define_method slot_name do |collection_args = nil, &block|
           if collection_args.nil? && block.nil?
+            content unless content_evaluated? # ensure content is loaded so slots will be defined
             get_slot(slot_name)
           else
             collection_args.each do |args|

--- a/lib/view_component/slotable_v2.rb
+++ b/lib/view_component/slotable_v2.rb
@@ -69,7 +69,6 @@ module ViewComponent
 
         define_method slot_name do |*args, **kwargs, &block|
           if args.empty? && kwargs.empty? && block.nil?
-            content unless content_evaluated? # ensure content is loaded so slots will be defined
             get_slot(slot_name)
           else
             set_slot(slot_name, *args, **kwargs, &block)
@@ -132,7 +131,6 @@ module ViewComponent
         # argument to each slot constructor
         define_method slot_name do |collection_args = nil, &block|
           if collection_args.nil? && block.nil?
-            content unless content_evaluated? # ensure content is loaded so slots will be defined
             get_slot(slot_name)
           else
             collection_args.each do |args|
@@ -185,6 +183,8 @@ module ViewComponent
     end
 
     def get_slot(slot_name)
+      content unless content_evaluated? # ensure content is loaded so slots will be defined
+
       slot = self.class.registered_slots[slot_name]
       @_set_slots ||= {}
 

--- a/test/app/components/content_areas_predicate_component.rb
+++ b/test/app/components/content_areas_predicate_component.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class ContentAreasPredicateComponent < ViewComponent::Base
+  with_content_areas :title
+
+  def initialize(title: nil, footer: nil)
+    @title = title
+    @footer = footer
+  end
+
+  def render?
+    title.present?
+  end
+
+  def call
+    content_tag :div do
+      content_tag :h1, title
+    end
+  end
+end

--- a/test/app/components/sleep_component.rb
+++ b/test/app/components/sleep_component.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class SleepComponent < ViewComponent::Base
+  def initialize(seconds:)
+    @seconds = seconds
+  end
+
+  def call
+    sleep @seconds
+    "sleep!"
+  end
+end

--- a/test/app/components/slots_v2_render_predicate_component.rb
+++ b/test/app/components/slots_v2_render_predicate_component.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class SlotsV2RenderPredicateComponent < ViewComponent::Base
+  include ViewComponent::SlotableV2
+
+  renders_one :title, "PredicateTitleComponent"
+
+  def render?
+    title.present?
+  end
+
+  def call
+    content_tag :div do
+      title.to_s
+    end
+  end
+
+  class PredicateTitleComponent < ViewComponent::Base
+    def call
+      content_tag :h1, content
+    end
+  end
+end

--- a/test/app/components/title_component.html.erb
+++ b/test/app/components/title_component.html.erb
@@ -1,3 +1,3 @@
 <div>
-  <h1><%= content %></h1>
+  <h1><%= body %></h1>
 </div>

--- a/test/app/components/title_component.rb
+++ b/test/app/components/title_component.rb
@@ -3,5 +3,5 @@
 class TitleComponent < ViewComponent::Base
   include ViewComponent::SlotableV2
 
-  renders_one :content
+  renders_one :body
 end

--- a/test/app/components/title_wrapper_component.html.erb
+++ b/test/app/components/title_wrapper_component.html.erb
@@ -1,5 +1,5 @@
 <%= render TitleComponent.new do |c| %>
-  <%= c.content do %>
-    <%= @content %>
+  <%= c.body do %>
+    <%= @title %>
   <% end %>
 <% end %>

--- a/test/app/components/title_wrapper_component.rb
+++ b/test/app/components/title_wrapper_component.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class TitleWrapperComponent < ViewComponent::Base
-  def initialize(content:)
-    @content = content
+  def initialize(title:)
+    @title = title
   end
 end

--- a/test/view_component/slotable_v2_test.rb
+++ b/test/view_component/slotable_v2_test.rb
@@ -196,7 +196,7 @@ class SlotsV2sTest < ViewComponent::TestCase
   end
 
   def test_renders_nested_content_in_order
-    render_inline TitleWrapperComponent.new(content: "Hello world!")
+    render_inline TitleWrapperComponent.new(title: "Hello world!")
 
     assert_selector("h1", text: /Hello world/)
     assert_text(/Hello world/, count: 1)

--- a/test/view_component/slotable_v2_test.rb
+++ b/test/view_component/slotable_v2_test.rb
@@ -231,4 +231,14 @@ class SlotsV2sTest < ViewComponent::TestCase
     assert_selector(".greeting", text: "Hello, John Doe")
     assert_selector(".greeting", text: "Hello, Jane Doe")
   end
+
+  def test_slots_accessible_in_render_predicate
+    render_inline(SlotsV2RenderPredicateComponent.new) do |component|
+      component.title do
+        "This is my title!"
+      end
+    end
+
+    assert_selector("h1", text: "This is my title!")
+  end
 end

--- a/test/view_component/view_component_test.rb
+++ b/test/view_component/view_component_test.rb
@@ -635,4 +635,16 @@ class ViewComponentTest < ViewComponent::TestCase
 
     assert_text "Hello, World!"
   end
+
+  def test_does_not_render_passed_in_content_if_render_is_false
+    start_time = Time.now
+
+    render_inline ConditionalRenderComponent.new(should_render: false) do |c|
+      c.render SleepComponent.new(seconds: 5)
+    end
+
+    total = Time.now - start_time
+
+    assert total < 1
+  end
 end

--- a/test/view_component/view_component_test.rb
+++ b/test/view_component/view_component_test.rb
@@ -237,6 +237,16 @@ class ViewComponentTest < ViewComponent::TestCase
     assert_includes exception.message, ":content is a reserved content area name"
   end
 
+  def test_with_content_areas_render_predicate
+    render_inline(ContentAreasPredicateComponent.new) do |c|
+      c.with :title do
+        "hello world"
+      end
+    end
+
+    assert_selector("h1", text: "hello world")
+  end
+
   def test_renders_helper_method_through_proxy
     render_inline(HelpersProxyComponent.new)
 


### PR DESCRIPTION
This changes `content` to load only when a component's `render?`
predicate method returns true. The `render?` method can still access
`content`, which will cause it to be evaluated.

~This shouldn't be a breaking change for components themselves, but
attempting to access a slot in `before_render` or `render?` may no
longer work.~

This is an alternative approach to https://github.com/github/view_component/pull/559 (but doesn't remove the value of the conversation happening there, imo) and may at least partially close https://github.com/github/view_component/issues/558
