### PR TITLE
Add support for `--inline` flag when generating Slim and Haml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 * Do not generate template when using `--inline` flag.
 
     *Hans Lemuet*
+    
+* Add `--inline` option to the Haml and Slim generators
+
+    *Hans Lemuet*
 
 ## 2.25.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 * Do not generate template when using `--inline` flag.
 
     *Hans Lemuet*
-    
+
 * Add `--inline` option to the Haml and Slim generators
 
     *Hans Lemuet*

--- a/lib/rails/generators/haml/component_generator.rb
+++ b/lib/rails/generators/haml/component_generator.rb
@@ -7,9 +7,12 @@ module Haml
     class ComponentGenerator < Erb::Generators::ComponentGenerator
       source_root File.expand_path("templates", __dir__)
       class_option :sidecar, type: :boolean, default: false
+      # class_option :inline, type: :boolean, default: false
 
       def copy_view_file
-        template "component.html.haml", destination
+        unless options["inline"]
+          template "component.html.haml", destination
+        end
       end
 
       private

--- a/lib/rails/generators/haml/component_generator.rb
+++ b/lib/rails/generators/haml/component_generator.rb
@@ -7,10 +7,9 @@ module Haml
     class ComponentGenerator < Erb::Generators::ComponentGenerator
       source_root File.expand_path("templates", __dir__)
       class_option :sidecar, type: :boolean, default: false
-      # class_option :inline, type: :boolean, default: false
 
       def copy_view_file
-        unless options["inline"]
+        if !options["inline"]
           template "component.html.haml", destination
         end
       end

--- a/lib/rails/generators/slim/component_generator.rb
+++ b/lib/rails/generators/slim/component_generator.rb
@@ -7,9 +7,12 @@ module Slim
     class ComponentGenerator < Erb::Generators::ComponentGenerator
       source_root File.expand_path("templates", __dir__)
       class_option :sidecar, type: :boolean, default: false
+      # class_option :inline, type: :boolean, default: false
 
       def copy_view_file
-        template "component.html.slim", destination
+        unless options["inline"]
+          template "component.html.slim", destination
+        end
       end
 
       private

--- a/lib/rails/generators/slim/component_generator.rb
+++ b/lib/rails/generators/slim/component_generator.rb
@@ -7,10 +7,9 @@ module Slim
     class ComponentGenerator < Erb::Generators::ComponentGenerator
       source_root File.expand_path("templates", __dir__)
       class_option :sidecar, type: :boolean, default: false
-      # class_option :inline, type: :boolean, default: false
 
       def copy_view_file
-        unless options["inline"]
+        if !options["inline"]
           template "component.html.slim", destination
         end
       end

--- a/test/generators/haml_generator_test.rb
+++ b/test/generators/haml_generator_test.rb
@@ -13,7 +13,7 @@ class HamlGeneratorTest < Rails::Generators::TestCase
 
   arguments %w[user]
 
-  def test_component
+  def test_component_generator
     run_generator
 
     assert_file "app/components/user_component.html.haml" do |view|
@@ -21,7 +21,7 @@ class HamlGeneratorTest < Rails::Generators::TestCase
     end
   end
 
-  def test_component_with_sidecar
+  def test_component_generator_with_sidecar
     run_generator %w[user --sidecar]
 
     assert_file "app/components/user_component/user_component.html.haml" do |view|
@@ -39,5 +39,11 @@ class HamlGeneratorTest < Rails::Generators::TestCase
     run_generator %w[admins/user --sidecar]
 
     assert_file "app/components/admins/user_component/user_component.html.haml"
+  end
+
+  def test_component_with_inline
+    run_generator %w[user name --inline]
+
+    assert_no_file "app/components/user_component.html.haml"
   end
 end

--- a/test/generators/slim_generator_test.rb
+++ b/test/generators/slim_generator_test.rb
@@ -13,7 +13,7 @@ class SlimGeneratorTest < Rails::Generators::TestCase
 
   arguments %w[user]
 
-  def test_component
+  def test_component_generator
     run_generator
 
     assert_file "app/components/user_component.html.slim" do |view|
@@ -21,7 +21,7 @@ class SlimGeneratorTest < Rails::Generators::TestCase
     end
   end
 
-  def test_component_with_sidecar
+  def test_component_generator_with_sidecar
     run_generator %w[user --sidecar]
 
     assert_file "app/components/user_component/user_component.html.slim" do |view|
@@ -39,5 +39,11 @@ class SlimGeneratorTest < Rails::Generators::TestCase
     run_generator %w[admins/user --sidecar]
 
     assert_file "app/components/admins/user_component/user_component.html.slim"
+  end
+
+  def test_component_with_inline
+    run_generator %w[user name --inline]
+
+    assert_no_file "app/components/user_component.html.slim"
   end
 end


### PR DESCRIPTION
### Summary

In order to have feature parity for all supported templating languages, this add `--inline` support to Slim and Haml generators.

Close #625 
