### PR TITLE
Generate preview at overriden path if one exists when using `--preview` flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## main
 
+* Generate preview at overridden path if one exists when using `--preview` flag.
+
+    *Nishiki Liu*
+
 * Do not generate template when using `--inline` flag.
 
     *Hans Lemuet*

--- a/docs/index.md
+++ b/docs/index.md
@@ -1247,3 +1247,8 @@ ViewComponent is built by:
 |:---:|:---:|:---:|:---:|:---:|
 |@mixergtz|@jules2689|@g13ydson|@swanson|@bobmaerten|
 |Medellin, Colombia|Toronto, Canada|João Pessoa, Brazil|Indianapolis, IN|Valenciennes, France|
+
+|<img src="https://avatars.githubusercontent.com/nshki?s=256" alt="nshki" width="128" />|
+|:---:|
+|@nshki|
+|Los Angeles, CA|

--- a/lib/rails/generators/preview/component_generator.rb
+++ b/lib/rails/generators/preview/component_generator.rb
@@ -9,6 +9,8 @@ module Preview
 
       def create_preview_file
         preview_paths = Rails.application.config.view_component.preview_paths
+        return if preview_paths.count > 1
+
         path_prefix = preview_paths.one? ? preview_paths.first : "test/components/previews"
         template "component_preview.rb", File.join(path_prefix, class_path, "#{file_name}_component_preview.rb")
       end

--- a/lib/rails/generators/preview/component_generator.rb
+++ b/lib/rails/generators/preview/component_generator.rb
@@ -8,7 +8,9 @@ module Preview
       check_class_collision suffix: "ComponentPreview"
 
       def create_preview_file
-        template "component_preview.rb", File.join("test/components/previews", class_path, "#{file_name}_component_preview.rb")
+        preview_paths = Rails.application.config.view_component.preview_paths
+        path_prefix = preview_paths.one? ? preview_paths.first : "test/components/previews"
+        template "component_preview.rb", File.join(path_prefix, class_path, "#{file_name}_component_preview.rb")
       end
 
       private

--- a/test/generators/component_generator_test.rb
+++ b/test/generators/component_generator_test.rb
@@ -32,11 +32,13 @@ class ComponentGeneratorTest < Rails::Generators::TestCase
   end
 
   def test_component_preview
-    run_generator %w[user --preview]
+    with_preview_paths([]) do
+      run_generator %w[user --preview]
 
-    assert_file "test/components/previews/user_component_preview.rb" do |component|
-      assert_match(/class UserComponentPreview < /, component)
-      assert_match(/render\(UserComponent.new\)/, component)
+      assert_file "test/components/previews/user_component_preview.rb" do |component|
+        assert_match(/class UserComponentPreview < /, component)
+        assert_match(/render\(UserComponent.new\)/, component)
+      end
     end
   end
 
@@ -55,10 +57,9 @@ class ComponentGeneratorTest < Rails::Generators::TestCase
     with_preview_paths(%w[spec/components/previews some/other/directory]) do
       run_generator %w[user --preview]
 
-      assert_file "test/components/previews/user_component_preview.rb" do |component|
-        assert_match(/class UserComponentPreview < /, component)
-        assert_match(/render\(UserComponent.new\)/, component)
-      end
+      assert_no_file "test/components/previews/user_component_preview.rb"
+      assert_no_file "spec/components/previews/user_component_preview.rb"
+      assert_no_file "some/other/directory/user_component_preview.rb"
     end
   end
 
@@ -98,11 +99,13 @@ class ComponentGeneratorTest < Rails::Generators::TestCase
   end
 
   def test_component_preview_with_namespace
-    run_generator %w[admins/user --preview]
+    with_preview_paths([]) do
+      run_generator %w[admins/user --preview]
 
-    assert_file "test/components/previews/admins/user_component_preview.rb" do |component|
-      assert_match(/class Admins::UserComponentPreview < /, component)
-      assert_match(/render\(Admins::UserComponent.new\)/, component)
+      assert_file "test/components/previews/admins/user_component_preview.rb" do |component|
+        assert_match(/class Admins::UserComponentPreview < /, component)
+        assert_match(/render\(Admins::UserComponent.new\)/, component)
+      end
     end
   end
 

--- a/test/generators/component_generator_test.rb
+++ b/test/generators/component_generator_test.rb
@@ -40,6 +40,28 @@ class ComponentGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_component_preview_with_one_overridden_preview_path
+    with_preview_paths(%w[spec/components/previews]) do
+      run_generator %w[user --preview]
+
+      assert_file "spec/components/previews/user_component_preview.rb" do |component|
+        assert_match(/class UserComponentPreview < /, component)
+        assert_match(/render\(UserComponent.new\)/, component)
+      end
+    end
+  end
+
+  def test_component_preview_with_two_overridden_preview_paths
+    with_preview_paths(%w[spec/components/previews some/other/directory]) do
+      run_generator %w[user --preview]
+
+      assert_file "test/components/previews/user_component_preview.rb" do |component|
+        assert_match(/class UserComponentPreview < /, component)
+        assert_match(/render\(UserComponent.new\)/, component)
+      end
+    end
+  end
+
   def test_component_with_arguments
     run_generator %w[user name]
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -21,6 +21,18 @@ ENV["RAILS_ENV"] = "test"
 require File.expand_path("../config/environment.rb", __FILE__)
 require "rails/test_help"
 
+# Sets custom preview paths in tests.
+#
+# @param new_value [Array<String>] List of preview paths
+# @yield Test code to run
+# @return [void]
+def with_preview_paths(new_value)
+  old_value = Rails.application.config.view_component.preview_paths
+  Rails.application.config.view_component.preview_paths = new_value
+  yield
+  Rails.application.config.view_component.preview_paths = old_value
+end
+
 def with_preview_route(new_value)
   old_value = Rails.application.config.view_component.preview_route
   Rails.application.config.view_component.preview_route = new_value


### PR DESCRIPTION
<!-- See https://github.com/github/view_component/blob/main/CONTRIBUTING.md#submitting-a-pull-request  -->

### Summary

First of all, I want to thank you all for this lovely gem. We have recently started adopting it over at Litmus and we are thrilled with what it enables our team with.

Something minor that we've noticed is that when generating components with the `--preview` flag, the preview file isn't placed in a custom preview path directory that we've defined.

e.g. With the following configuration:

```ruby
# config/application.rb

module MyProjectName
  class Application < Rails::Application
    # Initialize configuration defaults for originally generated Rails version.
    config.load_defaults 6.0

    # Settings in config/environments/* take precedence over those specified here.
    # Application configuration can go into files in config/initializers
    # -- all .rb files in that directory are automatically loaded after loading
    # the framework and any gems in your application.

    config.view_component.preview_paths << Rails.root.join("spec", "components", "previews")
  end
end
```

,,,we'd love for the file to be placed in `spec/components/previews/` when running something like:

```
$ bin/rails generate component Test --preview
```

I realized that the `preview_paths` config option could possibly have more than one path, so this PR only places the file in an overridden path if and only if one exists.

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file. -->
