### PR TITLE
docs(adr): add 001 Record Architecture Decisions

### DIFF
--- a/adr/0001-record-architecture-decisions.md
+++ b/adr/0001-record-architecture-decisions.md
@@ -1,0 +1,19 @@
+# 1. Record architecture decisions
+
+Date: 2021-02-19
+
+## Status
+
+Accepted
+
+## Context
+
+We need to record the architectural decisions made on this project.
+
+## Decision
+
+We will use Architecture Decision Records, as [described by Michael Nygard](https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions).
+
+## Consequences
+
+See Michael Nygard's article, linked above. For a lightweight ADR toolset, see Nat Pryce's [adr-tools](https://github.com/npryce/adr-tools).


### PR DESCRIPTION
### Summary

This adds a basic document that describes how we might make architectural decisions, and record such decisions for future reference.