### PR TITLE
Add breaking test with default args slot call

### DIFF
--- a/test/app/components/slots_v2_with_default_args_component.html.erb
+++ b/test/app/components/slots_v2_with_default_args_component.html.erb
@@ -1,0 +1,3 @@
+<div class="container">
+  <%= icon %>
+</div>

--- a/test/app/components/slots_v2_with_default_args_component.rb
+++ b/test/app/components/slots_v2_with_default_args_component.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class SlotsV2WithDefaultArgsComponent < ViewComponent::Base
+  include ViewComponent::SlotableV2
+
+  renders_one :icon, ->(icon: "my-icon") { image_tag(icon) }
+end

--- a/test/view_component/slotable_v2_test.rb
+++ b/test/view_component/slotable_v2_test.rb
@@ -231,4 +231,14 @@ class SlotsV2sTest < ViewComponent::TestCase
     assert_selector(".greeting", text: "Hello, John Doe")
     assert_selector(".greeting", text: "Hello, Jane Doe")
   end
+
+  def test_renders_slots_with_default_args
+    render_inline(SlotsV2WithDefaultArgsComponent.new) do |component|
+      component.icon
+    end
+
+    assert_selector(".container") do
+      assert_selector("img")
+    end
+  end
 end

--- a/test/view_component/slotable_v2_test.rb
+++ b/test/view_component/slotable_v2_test.rb
@@ -241,4 +241,14 @@ class SlotsV2sTest < ViewComponent::TestCase
       assert_selector("img")
     end
   end
+
+  def test_renders_slots_when_passing_args
+    render_inline(SlotsV2WithDefaultArgsComponent.new) do |component|
+      component.icon(icon: "other-icon")
+    end
+
+    assert_selector(".container") do
+      assert_selector("img")
+    end
+  end
 end


### PR DESCRIPTION
Related to https://github.com/github/view_component/issues/637

### Summary

This PR adds a failing test for SlotsV2 calls without providing any args (expected to use defaults). It also adds a test showing the slot being rendered if arguments are provided


