### PR TITLE
Don't call compile in collections

### DIFF
--- a/lib/view_component/collection.rb
+++ b/lib/view_component/collection.rb
@@ -10,7 +10,6 @@ module ViewComponent
     def render_in(view_context, &block)
       iterator = ActionView::PartialIteration.new(@collection.size)
 
-      component.compile(raise_errors: true)
       component.validate_collection_parameter!(validate_default: true)
 
       @collection.map do |item|


### PR DESCRIPTION
This removes a call to `ViewComponent::Base#compile` from
`ViewComponent::Collection` since components should already be compiled
when their `render_in` method is called.

This saves us a decent amount of time when rendering a large number of
components.
