### PR TITLE
Remove warning when slot does not receive a content block

### DIFF
--- a/lib/view_component/slot_v2.rb
+++ b/lib/view_component/slot_v2.rb
@@ -28,7 +28,11 @@ module ViewComponent
       @content = view_context.capture do
         if defined?(@_component_instance)
           # render_in is faster than `parent.render`
-          @_component_instance.render_in(view_context, &@_content_block)
+          if defined?(@_content_block)
+            @_component_instance.render_in(view_context, &@_content_block)
+          else
+            @_component_instance.render_in(view_context)
+          end
         elsif defined?(@_content)
           @_content
         elsif defined?(@_content_block)

--- a/test/app/components/slots_v2_without_content_block_component.html.erb
+++ b/test/app/components/slots_v2_without_content_block_component.html.erb
@@ -1,0 +1,3 @@
+<div class="title">
+  <%= title %>
+</div>

--- a/test/app/components/slots_v2_without_content_block_component.rb
+++ b/test/app/components/slots_v2_without_content_block_component.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class SlotsV2WithoutContentBlockComponent < ViewComponent::Base
+  include ViewComponent::SlotableV2
+
+  renders_one :title, "MyTitleComponent"
+
+  class MyTitleComponent < ViewComponent::Base
+    def initialize(title:)
+      @title = title
+    end
+
+    def call
+      content_tag :h1, @title
+    end
+  end
+end

--- a/test/view_component/slotable_v2_test.rb
+++ b/test/view_component/slotable_v2_test.rb
@@ -241,4 +241,12 @@ class SlotsV2sTest < ViewComponent::TestCase
 
     assert_selector("h1", text: "This is my title!")
   end
+
+  def test_slots_without_render_block
+    render_inline(SlotsV2WithoutContentBlockComponent.new) do |component|
+      component.title(title: "This is my title!")
+    end
+
+    assert_selector("h1", text: "This is my title!")
+  end
 end


### PR DESCRIPTION
### Summary

When a slot was called without a content block, it raised a warning `warning: instance variable @_content_block not initialized`

This PR removes that warning by only passing the content_block to the slot if it is defined.

| Before | After |
|--------|--------|
| ![image](https://user-images.githubusercontent.com/11280312/108881934-74991d80-75c9-11eb-9eb2-961cc07a7c41.png) | ![image](https://user-images.githubusercontent.com/11280312/108881957-7b279500-75c9-11eb-9f74-1cc78d757c16.png) | 
