### PR TITLE
Decouple collection parameters from compilation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## main
 
+* Fix bug that raises when trying to use a collection before the component has been compiled.
+
+    *Blake Williams*
+
 ## 2.26.0
 
 * Lazily evaluate component `content` in `render?`, preventing the `content` block from being evaluated when `render?` returns false.

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -324,6 +324,22 @@ module ViewComponent
         )
       end
 
+      def collection_parameter
+        if provided_collection_parameter
+          provided_collection_parameter
+        else
+          name && name.demodulize.underscore.chomp("_component").to_sym
+        end
+      end
+
+      def collection_counter_parameter
+        "#{collection_parameter}_counter".to_sym
+      end
+
+      def counter_argument_present?
+        instance_method(:initialize).parameters.map(&:second).include?(collection_counter_parameter)
+      end
+
       private
 
       def initialize_parameter_names

--- a/lib/view_component/compiler.rb
+++ b/lib/view_component/compiler.rb
@@ -24,28 +24,6 @@ module ViewComponent
         )
       end
 
-      # Remove any existing singleton methods,
-      # as Ruby warns when redefining a method.
-      component_class.remove_possible_singleton_method(:collection_parameter)
-      component_class.remove_possible_singleton_method(:collection_counter_parameter)
-      component_class.remove_possible_singleton_method(:counter_argument_present?)
-
-      component_class.define_singleton_method(:collection_parameter) do
-        if provided_collection_parameter
-          provided_collection_parameter
-        else
-          name.demodulize.underscore.chomp("_component").to_sym
-        end
-      end
-
-      component_class.define_singleton_method(:collection_counter_parameter) do
-        "#{collection_parameter}_counter".to_sym
-      end
-
-      component_class.define_singleton_method(:counter_argument_present?) do
-        instance_method(:initialize).parameters.map(&:second).include?(collection_counter_parameter)
-      end
-
       if raise_errors
         component_class.validate_initialization_parameters!
         component_class.validate_collection_parameter!

--- a/test/view_component/view_component_test.rb
+++ b/test/view_component/view_component_test.rb
@@ -657,4 +657,30 @@ class ViewComponentTest < ViewComponent::TestCase
 
     assert total < 1
   end
+
+  def test_collection_parameter_does_not_require_compile
+    dynamic_component = Class.new(ViewComponent::Base) do
+      with_collection_parameter :greeting
+
+      def initialize(greeting = "hello world")
+        @greeting = greeting
+      end
+
+      def call
+        content_tag :h1, @greeting
+      end
+    end
+
+    # Necessary because anonymous classes don't have a `name` property
+    Object.const_set("MY_COMPONENT", dynamic_component)
+
+    render_inline MY_COMPONENT.new
+    assert_selector "h1", text: "hello world"
+
+    render_inline MY_COMPONENT.with_collection(["hello world", "hello view component"])
+    assert_selector "h1", text: "hello world"
+    assert_selector "h1", text: "hello view component"
+  ensure
+    Object.send(:remove_const, "MY_COMPONENT")
+  end
 end


### PR DESCRIPTION
This change removes the logic that removed and recreated the
`collection_parameter`, `collection_counter_parameter`, and
`counter_argument_present?` methods on each compile from the compiler.

I don't know the history behind this logic living in the compiler, but
it looks like we may be able to define these as class methods on
`ViewComponent::Base` directly.

Thanks to @mejackreed for reporting the issue and helping write a
failing test.

closes https://github.com/github/view_component/issues/642
