### PR TITLE
Prepend preview routes instead of appending

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## main
 
+* Prepend Preview routes instead of appending, accounting for cases where host application has catchall route.
+
+    *Joel Hawksley*
+
 ## 2.27.0
 
 * Allow customization of the controller used in component tests.

--- a/lib/view_component/engine.rb
+++ b/lib/view_component/engine.rb
@@ -90,7 +90,7 @@ module ViewComponent
       options = app.config.view_component
 
       if options.show_previews
-        app.routes.append do
+        app.routes.prepend do
           preview_controller = options.preview_controller.sub(/Controller$/, "").underscore
 
           get options.preview_route, to: "#{preview_controller}#index", as: :preview_view_components, internal: true


### PR DESCRIPTION
### Problem

Given an application with a catchall route, previews are inaccessible, as they are _appended_ to the application's routes file.

### Solution

_Prepend_ them instead.

### Notes

I'd be curious if folks think this is worth testing. Doing so could be a bit of a hassle, but I'm up for the challenge 😅 