### PR TITLE
Ensure blocks passed to slots are captured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
     *Joel Hawksley*
 
+* Fix bug where blocks passed to lambda slots will render incorrectly in certain situations.
+
+    *Blake Williams*
+
 ## 2.27.0
 
 * Allow customization of the controller used in component tests.

--- a/lib/view_component/slotable_v2.rb
+++ b/lib/view_component/slotable_v2.rb
@@ -226,7 +226,11 @@ module ViewComponent
         # Use `bind(self)` to ensure lambda is executed in the context of the
         # current component. This is necessary to allow the lambda to access helper
         # methods like `content_tag` as well as parent component state.
-        renderable_value = slot_definition[:renderable_function].bind(self).call(*args, **kwargs) { view_context.capture(&block) }
+        renderable_value = if block_given?
+          slot_definition[:renderable_function].bind(self).call(*args, **kwargs) { view_context.capture(&block) }
+        else
+          slot_definition[:renderable_function].bind(self).call(*args, **kwargs)
+        end
 
         # Function calls can return components, so if it's a component handle it specially
         if renderable_value.respond_to?(:render_in)

--- a/lib/view_component/slotable_v2.rb
+++ b/lib/view_component/slotable_v2.rb
@@ -226,7 +226,7 @@ module ViewComponent
         # Use `bind(self)` to ensure lambda is executed in the context of the
         # current component. This is necessary to allow the lambda to access helper
         # methods like `content_tag` as well as parent component state.
-        renderable_value = slot_definition[:renderable_function].bind(self).call(*args, **kwargs, &block)
+        renderable_value = slot_definition[:renderable_function].bind(self).call(*args, **kwargs) { view_context.capture(&block) }
 
         # Function calls can return components, so if it's a component handle it specially
         if renderable_value.respond_to?(:render_in)

--- a/test/app/components/slots_v2_block_component.html.erb
+++ b/test/app/components/slots_v2_block_component.html.erb
@@ -1,0 +1,22 @@
+<%= render SlotsV2Component.new(classes: "mt-4") do |component| %>
+  <%= component.title do %>
+    This is my title!
+  <% end %>
+
+  <%= component.subtitle do %>
+    This is my subtitle!
+  <% end %>
+
+  <%= component.tab do %>
+    Tab A
+  <% end %>
+
+  <%= component.tab do %>
+    Tab B
+  <% end %>
+
+  <%= component.footer(classes: "text-blue") do %>
+    <p>Footer part 1</p>
+    <p>Footer part 2</p>
+  <% end %>
+<% end %>

--- a/test/app/components/slots_v2_block_component.rb
+++ b/test/app/components/slots_v2_block_component.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class SlotsV2BlockComponent < ViewComponent::Base
+  include ViewComponent::SlotableV2
+end

--- a/test/view_component/slotable_v2_test.rb
+++ b/test/view_component/slotable_v2_test.rb
@@ -249,4 +249,11 @@ class SlotsV2sTest < ViewComponent::TestCase
 
     assert_selector("h1", text: "This is my title!")
   end
+
+  def test_slot_with_block_content
+    render_inline(SlotsV2BlockComponent.new)
+
+    assert_selector("p", text: "Footer part 1")
+    assert_selector("p", text: "Footer part 2")
+  end
 end

--- a/test/view_component/slotable_v2_test.rb
+++ b/test/view_component/slotable_v2_test.rb
@@ -256,4 +256,10 @@ class SlotsV2sTest < ViewComponent::TestCase
     assert_selector("p", text: "Footer part 1")
     assert_selector("p", text: "Footer part 2")
   end
+
+  def test_lambda_slot_with_missing_block
+    render_inline(SlotsV2Component.new(classes: "mt-4")) do |component|
+      component.footer(classes: "text-blue")
+    end
+  end
 end


### PR DESCRIPTION
Currently blocks given to a lambda slot aren't always captured which can
cause them to be rendered incorrectly in certain rendering situations.

This fix resolves the issue by ensuring the block passed to the lambda
slot is always captured.
