### PR TITLE
include SlotableV2 in Base

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## main
 
+* Include SlotableV2 by default in Base. **Note:** It's no longer necessary to include `ViewComponent::SlotableV2` to use Slots.
+
+    *Joel Hawksley*
+
 * Prepend Preview routes instead of appending, accounting for cases where host application has catchall route.
 
     *Joel Hawksley*

--- a/docs/index.md
+++ b/docs/index.md
@@ -161,8 +161,6 @@ Delegate slots delegate to another component:
 
 ```ruby
 class BlogComponent < ViewComponent::Base
-  include ViewComponent::SlotableV2
-
   # Since `HeaderComponent` is nested inside of this component, we have to
   # reference it as a string instead of a class name.
   renders_one :header, "HeaderComponent"
@@ -222,8 +220,6 @@ Lambda slots render their return value. Lambda slots are useful for working with
 
 ```ruby
 class BlogComponent < ViewComponent::Base
-  include ViewComponent::SlotableV2
-
   # Renders the returned string
   renders_one :header, -> (classes:) do
     content_tag :h1 do
@@ -247,8 +243,6 @@ Define a pass through slot by omitting the second argument to `renders_one` and 
 ```ruby
 # blog_component.rb
 class BlogComponent < ViewComponent::Base
-  include ViewComponent::SlotableV2
-
   renders_one :header
   renders_many :posts
 end
@@ -290,8 +284,6 @@ e.g.
 
 ```ruby
 class NavigationComponent < ViewComponent::Base
-  include ViewComponent::SlotableV2
-
   renders_many :links, "LinkComponent"
 
   class LinkComponent < ViewComponent::Base

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -12,6 +12,7 @@ module ViewComponent
   class Base < ActionView::Base
     include ActiveSupport::Configurable
     include ViewComponent::Previewable
+    include ViewComponent::SlotableV2
 
     ViewContextCalledBeforeRenderError = Class.new(StandardError)
 

--- a/performance/components/slots_v2_component.rb
+++ b/performance/components/slots_v2_component.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class SlotsV2Component < ViewComponent::Base
-  include ViewComponent::SlotableV2
-
   renders_one :header, -> (**kwargs) { HeaderComponent.new(**kwargs) }
   renders_many :items, -> (**kwargs) { ItemComponent.new(**kwargs) }
 

--- a/test/app/components/nested/slots_v2_component.rb
+++ b/test/app/components/nested/slots_v2_component.rb
@@ -2,13 +2,9 @@
 
 module Nested
   class SlotsV2Component < ViewComponent::Base
-    include ViewComponent::SlotableV2
-
     renders_many :items, "MyHighlightComponent"
 
     class MyHighlightComponent < ViewComponent::Base
-      include ViewComponent::SlotableV2
-
       renders_one :thing, "AnotherComponent"
 
       class AnotherComponent < ViewComponent::Base

--- a/test/app/components/slim_renders_many_component.rb
+++ b/test/app/components/slim_renders_many_component.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
 class SlimRendersManyComponent < ViewComponent::Base
-  include ViewComponent::SlotableV2
-
   renders_many :slim_components, SlimComponent
 end

--- a/test/app/components/slots_v2_before_render_component.rb
+++ b/test/app/components/slots_v2_before_render_component.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class SlotsV2BeforeRenderComponent < ViewComponent::Base
-  include ViewComponent::SlotableV2
-
   renders_one :title, "MyTitleComponent"
   renders_many :greetings, "MyGreetingComponent"
 

--- a/test/app/components/slots_v2_component.rb
+++ b/test/app/components/slots_v2_component.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class SlotsV2Component < ViewComponent::Base
-  include ViewComponent::SlotableV2
-
   renders_one :title
   renders_one :subtitle
   renders_one :footer, -> (classes: "", &block) do

--- a/test/app/components/slots_v2_delegate_component.rb
+++ b/test/app/components/slots_v2_delegate_component.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class SlotsV2DelegateComponent < ViewComponent::Base
-  include ViewComponent::SlotableV2
-
   renders_many :items, SlotsV2Component::MyHighlightComponent
 
   def initialize

--- a/test/app/components/slots_v2_render_predicate_component.rb
+++ b/test/app/components/slots_v2_render_predicate_component.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class SlotsV2RenderPredicateComponent < ViewComponent::Base
-  include ViewComponent::SlotableV2
-
   renders_one :title, "PredicateTitleComponent"
 
   def render?

--- a/test/app/components/slots_v2_with_pos_arg_component.rb
+++ b/test/app/components/slots_v2_with_pos_arg_component.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class SlotsV2WithPosArgComponent < ViewComponent::Base
-  include ViewComponent::SlotableV2
-
   renders_many :items, "Item"
 
   class Item < ViewComponent::Base

--- a/test/app/components/slots_v2_without_content_block_component.rb
+++ b/test/app/components/slots_v2_without_content_block_component.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class SlotsV2WithoutContentBlockComponent < ViewComponent::Base
-  include ViewComponent::SlotableV2
-
   renders_one :title, "MyTitleComponent"
 
   class MyTitleComponent < ViewComponent::Base

--- a/test/app/components/title_component.rb
+++ b/test/app/components/title_component.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
 class TitleComponent < ViewComponent::Base
-  include ViewComponent::SlotableV2
-
   renders_one :body
 end

--- a/test/view_component/slotable_v2_test.rb
+++ b/test/view_component/slotable_v2_test.rb
@@ -207,7 +207,6 @@ class SlotsV2sTest < ViewComponent::TestCase
   # was accidentally assigned to all components!
   def test_sub_components_pollution
     new_component_class = Class.new(ViewComponent::Base)
-    new_component_class.include(ViewComponent::SlotableV2)
     # this returned:
     # [SlotsV2Component::Subtitle, SlotsV2Component::Tab...]
     assert_empty new_component_class.registered_slots


### PR DESCRIPTION
As a step towards deprecating `content_areas` and `Slots` v1, this change includes SlotableV2 by default.

