### PR TITLE
Fix handling of jbuilder templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## main
 
-* Fix handling of Jbuilder and other template engines with certain names.
+* Fix bug where a single `jbuilder` template matched multiple template handlers.
 
     *Niels Slot*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## main
 
+* Fix handling of Jbuilder and other template engines with certain names.
+
+    *Niels Slot*
+
 ## 2.28.0
 
 * Include SlotableV2 by default in Base. **Note:** It's no longer necessary to include `ViewComponent::SlotableV2` to use Slots.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -129,6 +129,8 @@ GEM
     i18n (1.8.7)
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.4)
+    jbuilder (2.11.2)
+      activesupport (>= 5.0.0)
     loofah (2.9.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -220,6 +222,7 @@ DEPENDENCIES
   bundler (~> 1.14)
   capybara (~> 3)
   haml (~> 5)
+  jbuilder (~> 2)
   minitest (= 5.6.0)
   pry (~> 0.13)
   rails!

--- a/docs/index.md
+++ b/docs/index.md
@@ -1234,7 +1234,7 @@ ViewComponent is built by:
 |@mixergtz|@jules2689|@g13ydson|@swanson|@bobmaerten|
 |Medellin, Colombia|Toronto, Canada|João Pessoa, Brazil|Indianapolis, IN|Valenciennes, France|
 
-|<img src="https://avatars.githubusercontent.com/nshki?s=256" alt="nshki" width="128" />|
-|:---:|
-|@nshki|
-|Los Angeles, CA|
+|<img src="https://avatars.githubusercontent.com/nshki?s=256" alt="nshki" width="128" />|<img src="https://avatars.githubusercontent.com/nielsslot?s=256" alt="nshki" width="128" />|
+|:---:|:---:|
+|@nshki|@nielsslot|
+|Los Angeles, CA|Amsterdam|

--- a/lib/view_component/compiler.rb
+++ b/lib/view_component/compiler.rb
@@ -157,7 +157,7 @@ module ViewComponent
 
       sidecar_directory_files = Dir["#{directory}/#{component_name}/#{filename}.*{#{extensions}}"]
 
-      (sidecar_files - [source_location] + sidecar_directory_files + nested_component_files)
+      (sidecar_files - [source_location] + sidecar_directory_files + nested_component_files).uniq
     end
 
     def inline_calls

--- a/test/app/components/jbuilder_component.json.jbuilder
+++ b/test/app/components/jbuilder_component.json.jbuilder
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+json.message @message
+json.conent content

--- a/test/app/components/jbuilder_component.rb
+++ b/test/app/components/jbuilder_component.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class JbuilderComponent < ViewComponent::Base
+  def initialize(message:)
+    @message = message
+  end
+end

--- a/test/config/application.rb
+++ b/test/config/application.rb
@@ -10,6 +10,7 @@ require "sprockets/railtie"
 
 require "haml"
 require "slim"
+require "jbuilder"
 
 module Dummy
   class Application < Rails::Application

--- a/test/view_component/view_component_test.rb
+++ b/test/view_component/view_component_test.rb
@@ -95,6 +95,13 @@ class ViewComponentTest < ViewComponent::TestCase
     assert_text("bar")
   end
 
+  def test_render_jbuilder_template
+    render_inline(JbuilderComponent.new(message: "bar")) { "foo" }
+
+    assert_text("foo")
+    assert_text("bar")
+  end
+
   def test_renders_button_to_component
     old_value = ActionController::Base.allow_forgery_protection
     ActionController::Base.allow_forgery_protection = true

--- a/view_component.gemspec
+++ b/view_component.gemspec
@@ -37,6 +37,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "haml", "~> 5"
   spec.add_development_dependency "slim", "~> 4.0"
   spec.add_development_dependency "better_html", "~> 1"
+  spec.add_development_dependency "jbuilder", "~> 2"
   spec.add_development_dependency "rubocop", "= 0.74"
   spec.add_development_dependency "rubocop-github", "~> 0.13.0"
   spec.add_development_dependency "simplecov", "~> 0.18.0"


### PR DESCRIPTION
<!-- See https://github.com/github/view_component/blob/main/CONTRIBUTING.md#submitting-a-pull-request  -->

### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

I had the crazy idea of trying to use ViewComponent with a Jbuilder template today and noticed fairly quickly that it doesn't work, but not for any reason I would've thought.

Rails ships builder as an included template handler and with jbuilder installed that means that both `.builder` and `.jbuilder` are valid template extensions. ViewComponent will look for template files with either extension but will find any jbuilder template twice, because it matches both `*builder` and `*jbuilder`. Because it finds the template twice it raises an error and doesn't render.

In this pull request I add a call to uniq to ensure that ViewComponent continues with a list of template paths that doesn't have any duplicates. I use jbuilder as an example, but any template handler whose extension is a sub string of another would show the same problem.

### Other Information

This is the same issue that was mentioned in #492. I solve it in a slightly different way, mostly because the code was changed since that pull request. And I use jbuilder as an example instead of relying on a custom template handler definition.

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file. -->
