### PR TITLE
Fix a small typo in a comment in base.rb

### DIFF
--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -131,7 +131,7 @@ module ViewComponent
       @helpers ||= controller.view_context
     end
 
-    # Exposes .virutal_path as an instance method
+    # Exposes .virtual_path as an instance method
     def virtual_path
       self.class.virtual_path
     end


### PR DESCRIPTION
### Summary

Just fixing `virutal` to `virtual` in a comment!