### PR TITLE
Add Base.sidecar_files to fetch sidecar paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## main
 
+* Experimental: call `._sidecar_files` to fetch the sidecar files for a given list of extensions, e.g. passing `["yml", "yaml"]`.
+
+    *Elia Schito*
+
 * Fix bug where a single `jbuilder` template matched multiple template handlers.
 
     *Niels Slot*

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -206,6 +206,47 @@ module ViewComponent
     class << self
       attr_accessor :source_location, :virtual_path
 
+      # EXPERIMENTAL: This API is experimental and may be removed at any time.
+      # Find sidecar files for the given extensions.
+      #
+      # The provided array of extensions is expected to contain
+      # strings starting without the "dot", example: `["erb", "haml"]`.
+      #
+      # For example, one might collect sidecar CSS files that need to be compiled.
+      def _sidecar_files(extensions)
+        return [] unless source_location
+
+        extensions = extensions.join(",")
+
+        # view files in a directory named like the component
+        directory = File.dirname(source_location)
+        filename = File.basename(source_location, ".rb")
+        component_name = name.demodulize.underscore
+
+        # Add support for nested components defined in the same file.
+        #
+        # e.g.
+        #
+        # class MyComponent < ViewComponent::Base
+        #   class MyOtherComponent < ViewComponent::Base
+        #   end
+        # end
+        #
+        # Without this, `MyOtherComponent` will not look for `my_component/my_other_component.html.erb`
+        nested_component_files = if name.include?("::") && component_name != filename
+          Dir["#{directory}/#{filename}/#{component_name}.*{#{extensions}}"]
+        else
+          []
+        end
+
+        # view files in the same directory as the component
+        sidecar_files = Dir["#{directory}/#{component_name}.*{#{extensions}}"]
+
+        sidecar_directory_files = Dir["#{directory}/#{component_name}/#{filename}.*{#{extensions}}"]
+
+        (sidecar_files - [source_location] + sidecar_directory_files + nested_component_files).uniq
+      end
+
       # Render a component collection.
       def with_collection(collection, **args)
         Collection.new(self, collection, **args)

--- a/lib/view_component/compiler.rb
+++ b/lib/view_component/compiler.rb
@@ -114,50 +114,18 @@ module ViewComponent
     end
 
     def templates
-      @templates ||= matching_views_in_source_location.each_with_object([]) do |path, memo|
-        pieces = File.basename(path).split(".")
+      @templates ||= begin
+        extensions = ActionView::Template.template_handler_extensions
 
-        memo << {
-          path: path,
-          variant: pieces.second.split("+").second&.to_sym,
-          handler: pieces.last
-        }
+        component_class._sidecar_files(extensions).each_with_object([]) do |path, memo|
+          pieces = File.basename(path).split(".")
+          memo << {
+            path: path,
+            variant: pieces.second.split("+").second&.to_sym,
+            handler: pieces.last
+          }
+        end
       end
-    end
-
-    def matching_views_in_source_location
-      source_location = component_class.source_location
-      return [] unless source_location
-
-      extensions = ActionView::Template.template_handler_extensions.join(",")
-
-      # view files in a directory named like the component
-      directory = File.dirname(source_location)
-      filename = File.basename(source_location, ".rb")
-      component_name = component_class.name.demodulize.underscore
-
-      # Add support for nested components defined in the same file.
-      #
-      # e.g.
-      #
-      # class MyComponent < ViewComponent::Base
-      #   class MyOtherComponent < ViewComponent::Base
-      #   end
-      # end
-      #
-      # Without this, `MyOtherComponent` will not look for `my_component/my_other_component.html.erb`
-      nested_component_files = if component_class.name.include?("::") && component_name != filename
-        Dir["#{directory}/#{filename}/#{component_name}.*{#{extensions}}"]
-      else
-        []
-      end
-
-      # view files in the same directory as the component
-      sidecar_files = Dir["#{directory}/#{component_name}.*{#{extensions}}"]
-
-      sidecar_directory_files = Dir["#{directory}/#{component_name}/#{filename}.*{#{extensions}}"]
-
-      (sidecar_files - [source_location] + sidecar_directory_files + nested_component_files).uniq
     end
 
     def inline_calls

--- a/test/view_component/base_test.rb
+++ b/test/view_component/base_test.rb
@@ -16,7 +16,8 @@ class ViewComponent::Base::UnitTest < Minitest::Test
     ]
 
     compiler = ViewComponent::Compiler.new(ViewComponent::Base)
-    compiler.stub(:matching_views_in_source_location, file_path) do
+
+    ViewComponent::Base.stub(:_sidecar_files, file_path) do
       templates = compiler.send(:templates)
 
       templates.each_with_index do |template, index|
@@ -41,5 +42,30 @@ class ViewComponent::Base::UnitTest < Minitest::Test
       component.controller
     end
     assert_equal "`controller` can only be called at render time.", err.message
+  end
+
+  def test_sidecar_files
+    root = ViewComponent::Engine.root
+
+    assert_equal(
+      [
+        "#{root}/test/app/components/template_and_sidecar_directory_template_component.html.erb",
+        "#{root}/test/app/components/template_and_sidecar_directory_template_component/template_and_sidecar_directory_template_component.html.erb",
+      ],
+      TemplateAndSidecarDirectoryTemplateComponent._sidecar_files(["erb"])
+    )
+
+    assert_equal(
+      [
+        "#{root}/test/app/components/css_sidecar_file_component.css",
+        "#{root}/test/app/components/css_sidecar_file_component.html.erb",
+      ],
+      CssSidecarFileComponent._sidecar_files(["css", "erb"])
+    )
+
+    assert_equal(
+      ["#{root}/test/app/components/css_sidecar_file_component.css"],
+      CssSidecarFileComponent._sidecar_files(["css"])
+    )
   end
 end


### PR DESCRIPTION

<!-- See https://github.com/github/view_component/blob/main/CONTRIBUTING.md#submitting-a-pull-request  -->

### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

This has been extracted from #660 but can actually be useful for supporting other types of sidecar assets.


### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file. -->

The original method in the compiler was only referencing the component class, which is a good hint this method should rather live there.
