### PR TITLE
deprecate `with_content_areas`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## main
 
+* Deprecate `with_content_areas` in favor of [slots](https://viewcomponent.org/guide/slots.html).
+
+    *Joel Hawksley*
+
 ## 2.29.0
 
 * Allow Slot lambdas to share data from the parent component and allow chaining on the returned component.

--- a/docs/content_areas.md
+++ b/docs/content_areas.md
@@ -4,7 +4,7 @@ nav_exclude: true
 
 # Content areas
 
-_Note: The content_areas APIs are soft-deprecated, and will soon be deprecated in favor of Slots._
+_Note: The content_areas APIs soft-deprecated, and will soon be deprecated in favor of [Slots](/slots)._
 
 ViewComponents can declare additional content areas. For example:
 

--- a/docs/content_areas.md
+++ b/docs/content_areas.md
@@ -4,7 +4,7 @@ nav_exclude: true
 
 # Content areas
 
-_Note: The content_areas APIs soft-deprecated, and will soon be deprecated in favor of [Slots](/slots)._
+_Note: The content_areas API is soft-deprecated, and will soon be deprecated in favor of [Slots](/slots)._
 
 ViewComponents can declare additional content areas. For example:
 

--- a/docs/guide/slots.md
+++ b/docs/guide/slots.md
@@ -14,7 +14,7 @@ Slots are defined with `renders_one` and `renders_many`:
 
 `renders_many` defines a slot that can be rendered multiple times per-component: `renders_many :blog_posts`
 
-_To view documentation for content_areas (soon to be deprecated) and the original implementation of Slots, see [/content_areas](/content_areas) and [/slots_v1](/slots_v1)._
+_To view documentation for content_areas (deprecated) and the original implementation of Slots (soon to be deprecated), see [/content_areas](/content_areas) and [/slots_v1](/slots_v1)._
 
 ## Defining slots
 

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -309,6 +309,11 @@ module ViewComponent
       end
 
       def with_content_areas(*areas)
+        ActiveSupport::Deprecation.warn(
+          "`with_content_areas` is deprecated and will be removed in ViewComponent v3.0.0.\n" \
+          "Use slots (https://viewcomponent.org/guide/slots.html) instead."
+        )
+
         if areas.include?(:content)
           raise ArgumentError.new ":content is a reserved content area name. Please use another name, such as ':body'"
         end


### PR DESCRIPTION
In anticipation of removing `with_content_areas` in ViewComponent v3, this PR adds a deprecation warning that encourages consumers to use slots (https://viewcomponent.org/guide/slots.html) instead.