### PR TITLE
include ViewComponent::SlotableV2 module

### DIFF
--- a/docs/guide/slots.md
+++ b/docs/guide/slots.md
@@ -32,6 +32,8 @@ Delegate slots delegate to another component:
 
 ```ruby
 class BlogComponent < ViewComponent::Base
+  include ViewComponent::SlotableV2
+
   # Since `HeaderComponent` is nested inside of this component, we have to
   # reference it as a string instead of a class name.
   renders_one :header, "HeaderComponent"
@@ -91,6 +93,8 @@ Lambda slots render their return value. Lambda slots are useful for working with
 
 ```ruby
 class BlogComponent < ViewComponent::Base
+  include ViewComponent::SlotableV2
+
   # Renders the returned string
   renders_one :header, -> (classes:) do
     content_tag :h1 do
@@ -109,6 +113,8 @@ Lambda are able to access state from the parent component:
 
 ```ruby
 class TableComponent < ViewComponent::Base
+  include ViewComponent::SlotableV2
+
   renders_one :header, -> do
     HeaderComponent.new(selectable: @selectable)
   end
@@ -128,6 +134,8 @@ Define a pass through slot by omitting the second argument to `renders_one` and 
 ```ruby
 # blog_component.rb
 class BlogComponent < ViewComponent::Base
+  include ViewComponent::SlotableV2
+  
   renders_one :header
   renders_many :posts
 end
@@ -169,6 +177,8 @@ e.g.
 
 ```ruby
 class NavigationComponent < ViewComponent::Base
+  include ViewComponent::SlotableV2
+
   renders_many :links, "LinkComponent"
 
   class LinkComponent < ViewComponent::Base


### PR DESCRIPTION
When I am not include the `ViewComponent::SlotableV2` module，It raises the renders_many/renders_one method not found exception.

<!-- See https://viewcomponent.org/contributing.html#submitting-a-pull-request  -->

### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file. -->
