### PR TITLE
update renders_many in pass through slots

### DIFF
--- a/docs/guide/slots.md
+++ b/docs/guide/slots.md
@@ -141,7 +141,9 @@ end
 <div>
   <h1><%= header %></h1>
 
-  <%= posts %>
+  <% posts.each do |post| %>
+    <%= post %>
+  <% end %>
 </div>
 ```
 


### PR DESCRIPTION
When I use renders_many by pass through slots, I got something like " [#<ViewComponent::SlotV2:0x000055a3482eb5f8 ....>]". My view_component's version was updated to 2.30.0

<!-- See https://viewcomponent.org/contributing.html#submitting-a-pull-request  -->

### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file. -->
