### PR TITLE
fix link to "Slots" in content_areas.md

### DIFF
--- a/docs/content_areas.md
+++ b/docs/content_areas.md
@@ -4,7 +4,7 @@ nav_exclude: true
 
 # Content areas
 
-_Note: The content_areas API is soft-deprecated, and will soon be deprecated in favor of [Slots](/slots)._
+_Note: The content_areas API is soft-deprecated, and will soon be deprecated in favor of [Slots](/guide/slots.html)._
 
 ViewComponents can declare additional content areas. For example:
 


### PR DESCRIPTION
### Summary

Hey there 👋 , I just discovered that the documentation for `content_areas.md` had a broken link.

![Screenshot 2021-04-06 at 07 58 20](https://user-images.githubusercontent.com/1409672/113665564-f5aa0100-96ad-11eb-8fd2-bacd57f5e0d7.png)
