### PR TITLE
Call before_render only if component will render

### DIFF
--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -82,9 +82,9 @@ module ViewComponent
       @_content_evaluated = false
       @_render_in_block = block
 
-      before_render
-
       if render?
+        before_render
+
         render_template_for(@variant)
       else
         ""


### PR DESCRIPTION
This is a breaking change. Currently, `before_render` is called before
the `render?` method check. This is fine, but we already have that hook
in the form of the initializer.

I think this change makes the order of method calls more clear when
defining both a `before_render` and a `render?` method on a component.
e.g.

```
class MyComponent
  def render?
    Feature.enabled?(:my_component)
  end

  def before_render
    @my_value = Code.something_expensive
  end
end
```

In the example above, we want to perform a somewhat expensive
calculation to set `@my_value`. When reading the code, it's reasonable
to assume that `before_render` will only be called if `render?` returns
true. As-is, the expensive operation will be run even if the component
won't render.
