### PR TITLE
Added test for rendering integers when using slots

### DIFF
--- a/lib/view_component/slot_v2.rb
+++ b/lib/view_component/slot_v2.rb
@@ -40,7 +40,7 @@ module ViewComponent
       elsif defined?(@_content)
         @_content
       elsif defined?(@_content_block)
-        view_context.capture(&@_content_block)
+        view_context.capture { @_content_block.call.to_s }
       end
 
       @content

--- a/test/view_component/slotable_v2_test.rb
+++ b/test/view_component/slotable_v2_test.rb
@@ -304,7 +304,7 @@ class SlotsV2sTest < ViewComponent::TestCase
   def test_renders_integers
     render_inline(SlotsV2Component.new) do |component|
       component.title { 1 }
-      component.subtitle { '2' }
+      component.subtitle { "2" }
     end
 
     assert_selector(".title", text: "1")

--- a/test/view_component/slotable_v2_test.rb
+++ b/test/view_component/slotable_v2_test.rb
@@ -300,4 +300,14 @@ class SlotsV2sTest < ViewComponent::TestCase
     # Check shared data through Proc
     refute_selector("div.table div.table__header span", text: "Selectable")
   end
+
+  def test_renders_integers
+    render_inline(SlotsV2Component.new) do |component|
+      component.title { 1 }
+      component.subtitle { '2' }
+    end
+
+    assert_selector(".title", text: "1")
+    assert_selector(".subtitle", text: "2")
+  end
 end


### PR DESCRIPTION
### Summary

Hi @BlakeWilliams, the bug I was mentioning turned out an issue in our own codebase which I was able to resolve by simply following the document which I wrote myself in the previous PR 🤣 

There is an additional issue I wanted to show and with this PR you will find a test case to demonstrate the issue. In the testcase `'2'` will render, where as `1` won't render.

We ran into when displaying `.count` from for example.