### PR TITLE
Ensure Base#request is available to ActionView asset helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## main
 
+* Fix errors on `asset_url` helpers when `asset_host` has no protocol.
+
+    *Elia Schito*
+
 * Deprecate `with_slot` in favor of the new [slots API](https://viewcomponent.org/guide/slots.html).
 
     *Manuel Puyol*

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -169,14 +169,14 @@ module ViewComponent
       self
     end
 
-    private
-
     # Exposes the current request to the component.
     # Use sparingly as doing so introduces coupling
     # that inhibits encapsulation & reuse.
     def request
       @request ||= controller.request
     end
+
+    private
 
     attr_reader :view_context
 

--- a/test/app/components/asset_component.html.erb
+++ b/test/app/components/asset_component.html.erb
@@ -1,1 +1,1 @@
-<div><%= helpers.asset_url("application.css") %></div>
+<div><%= asset_url("application.css") %></div>

--- a/test/view_component/view_component_test.rb
+++ b/test/view_component/view_component_test.rb
@@ -326,9 +326,17 @@ class ViewComponentTest < ViewComponent::TestCase
   end
 
   def test_renders_component_with_asset_url
-    render_inline(AssetComponent.new)
+    component = AssetComponent.new
+    assert_match(%r{http://assets.example.com/assets/application-\w+.css}, render_inline(component).text)
 
-    assert_text(%r{http://assets.example.com/assets/application-\w+.css})
+    component.config.asset_host = nil
+    assert_match(%r{/assets/application-\w+.css}, render_inline(component).text)
+
+    component.config.asset_host = "http://assets.example.com"
+    assert_match(%r{http://assets.example.com/assets/application-\w+.css}, render_inline(component).text)
+
+    component.config.asset_host = "assets.example.com"
+    assert_match(%r{http://assets.example.com/assets/application-\w+.css}, render_inline(component).text)
   end
 
   def test_template_changes_are_not_reflected_if_cache_is_not_cleared


### PR DESCRIPTION
<!-- See https://viewcomponent.org/contributing.html#submitting-a-pull-request  -->

### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

`ActionView::Helpers::AssetUrlHelper#compute_asset_host` will try to access the request with `respond_to?(:request)`, but since `#request` was defined as private and the protocol option is forced to be `:request` inside AV `#asset_url` it ended up trying to ask for a protocol on `nil`.

This only happens if the asset_host is set to a hostname without a defined protocol.
Ref:
- https://github.com/rails/rails/blob/v6.1.3.1/actionview/lib/action_view/helpers/asset_url_helper.rb#L277
- https://github.com/rails/rails/blob/v6.1.3.1/actionview/lib/action_view/helpers/asset_url_helper.rb#L231



### Other Information


We got a weird <code>undefined method `protocol' for nil:NilClass</code> error in production that pointed to a webpacker asset tag helper, the PR was migrating some partials to view_component.

It was pointing to this line inside a component:

```erb
src="<%= asset_pack_url('media/videos/' + method[:video]) %>"
```

```
 - actionview (6.0.3.5) lib/action_view/helpers/asset_url_helper.rb:301:in `compute_asset_host'
 - actionview (6.0.3.5) lib/action_view/helpers/asset_url_helper.rb:210:in `asset_path'
 - actionview (6.0.3.5) lib/action_view/helpers/asset_url_helper.rb:229:in `asset_url'
 - webpacker (5.2.1) lib/webpacker/helper.rb:39:in `asset_pack_url'
 - app/components/shared/pdp/methods/component.html.erb:31:in `block in call'
```
<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file. -->


