### PR TITLE
Prevent method name conflicts when using slots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## main
 
+* Prevent slots from overriding the `#content` method when registering a slot with that name.
+
+    *Blake Williams*
+
 * Deprecate `with_slot` in favor of the new [slots API](https://viewcomponent.org/guide/slots.html).
 
     *Manuel Puyol*

--- a/lib/view_component/slotable_v2.rb
+++ b/lib/view_component/slotable_v2.rb
@@ -175,6 +175,10 @@ module ViewComponent
       end
 
       def validate_slot_name(slot_name)
+        if slot_name.to_sym == :content
+          raise ArgumentError.new("#{slot_name} is not a valid slot name.")
+        end
+
         if self.registered_slots.key?(slot_name)
           # TODO remove? This breaks overriding slots when slots are inherited
           raise ArgumentError.new("#{slot_name} slot declared multiple times")

--- a/test/view_component/slotable_v2_test.rb
+++ b/test/view_component/slotable_v2_test.rb
@@ -300,4 +300,14 @@ class SlotsV2sTest < ViewComponent::TestCase
     # Check shared data through Proc
     refute_selector("div.table div.table__header span", text: "Selectable")
   end
+
+  def test_component_raises_when_given_invalid_slot_name
+    exception = assert_raises ArgumentError do
+      Class.new(ViewComponent::Base) do
+        renders_one :content
+      end
+    end
+
+    assert_includes exception.message, "content is not a valid slot name"
+  end
 end


### PR DESCRIPTION
When registering a slot, it's possible to use an invalid name like
`:content` that can cause misleading behavior in components.

This change checks slot names when they're registered and raises if
they're invalid.

This adds `:content` as the only invalid slot name.
