### PR TITLE
component with `link_to` with `url_for` throws `ActionController::UrlGenerationError`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## main
 
+* Add `with_request_url` test helper.
+
+    *Mario Schüttel*
+
 * Improve feature parity with Rails translations
   * Don't create a translation backend if the component has no translation file
   * Mark translation keys ending with `html` as HTML-safe

--- a/docs/guide/testing.md
+++ b/docs/guide/testing.md
@@ -120,32 +120,21 @@ class ExampleComponentTest < ViewComponent::TestCase
 end
 ```
 
-## Setting request.path_parameters
+## Setting `request.path_parameters`
 
-Some Rails helpers won't work unless `request.path_parameters` are set correctly. In this case, you may see this error:
+Some Rails helpers won't work unless `request.path_parameters` are set correctly, resulting in an `ActionController::UrlGenerationError`.
 
-```
-ActionController::UrlGenerationError: No route matches {...}
-```
-
-To set `request.path_parameters` for a test case, you can use `with_request_url` from `ViewComponent::TestHelpers`.
+To set `request.path_parameters` for a test case, use `with_request_url` from `ViewComponent::TestHelpers`:
 
 ```ruby
 class ExampleComponentTest < ViewComponent::TestCase
   def test_with_request_url
-    with_request_url "/" do
-      render_inline ExampleComponent.new # contains i.e. `link_to "French", url_for(locale: "fr")`
-      assert_link "French", href: "/?locale=fr"
-    end
-
     with_request_url "/products/42" do
       render_inline ExampleComponent.new # contains i.e. `link_to "French", url_for(locale: "fr")`
       assert_link "French", href: "/products/42?locale=fr"
     end
   end
 end
-```
-
 ## RSpec configuration
 
 To use RSpec, add the following:

--- a/docs/guide/testing.md
+++ b/docs/guide/testing.md
@@ -120,6 +120,32 @@ class ExampleComponentTest < ViewComponent::TestCase
 end
 ```
 
+## Setting request.path_parameters
+
+Some Rails helpers won't work unless `request.path_parameters` are set correctly. In this case, you may see this error:
+
+```
+ActionController::UrlGenerationError: No route matches {...}
+```
+
+To set `request.path_parameters` for a test case, you can use `with_request_url` from `ViewComponent::TestHelpers`.
+
+```ruby
+class ExampleComponentTest < ViewComponent::TestCase
+  def test_with_request_url
+    with_request_url "/" do
+      render_inline ExampleComponent.new # contains i.e. `link_to "French", url_for(locale: "fr")`
+      assert_link "French", href: "/?locale=fr"
+    end
+
+    with_request_url "/products/42" do
+      render_inline ExampleComponent.new # contains i.e. `link_to "French", url_for(locale: "fr")`
+      assert_link "French", href: "/products/42?locale=fr"
+    end
+  end
+end
+```
+
 ## RSpec configuration
 
 To use RSpec, add the following:

--- a/lib/view_component/test_helpers.rb
+++ b/lib/view_component/test_helpers.rb
@@ -60,6 +60,17 @@ module ViewComponent
       @controller = old_controller
     end
 
+    def with_request_url(path)
+      old_request_path_parameters = request.path_parameters
+      old_controller = defined?(@controller) && @controller
+
+      request.path_parameters = Rails.application.routes.recognize_path(path)
+      yield
+    ensure
+      request.path_parameters = old_request_path_parameters
+      @controller = old_controller
+    end
+
     def build_controller(klass)
       klass.new.tap { |c| c.request = request }.extend(Rails.application.routes.url_helpers)
     end

--- a/test/app/components/url_for_component.html.erb
+++ b/test/app/components/url_for_component.html.erb
@@ -1,0 +1,1 @@
+<%= url_for(key: 'value') %>

--- a/test/app/components/url_for_component.html.erb
+++ b/test/app/components/url_for_component.html.erb
@@ -1,1 +1,1 @@
-<%= url_for(key: 'value') %>
+<%= url_for(key: "value") %>

--- a/test/app/components/url_for_component.rb
+++ b/test/app/components/url_for_component.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class UrlForComponent < ViewComponent::Base
+end

--- a/test/view_component/view_component_test.rb
+++ b/test/view_component/view_component_test.rb
@@ -718,8 +718,15 @@ class ViewComponentTest < ViewComponent::TestCase
     Object.send(:remove_const, "MY_COMPONENT")
   end
 
-  def test_url_for
-    render_inline(UrlForComponent.new)
-    assert_link "Home", href: "/?key=value"
+  def test_with_request_url
+    with_request_url "/" do
+      render_inline UrlForComponent.new
+      assert_text "/?key=value"
+    end
+
+    with_request_url "/products" do
+      render_inline UrlForComponent.new
+      assert_text "/products?key=value"
+    end
   end
 end

--- a/test/view_component/view_component_test.rb
+++ b/test/view_component/view_component_test.rb
@@ -717,4 +717,9 @@ class ViewComponentTest < ViewComponent::TestCase
   ensure
     Object.send(:remove_const, "MY_COMPONENT")
   end
+
+  def test_url_for
+    render_inline(UrlForComponent.new)
+    assert_link "Home", href: "/?key=value"
+  end
 end


### PR DESCRIPTION
Hello dear ViewComponent people 👋

I think this is a bug, or I may use `link_to` the wrong way. Please let me know.


### Steps to reproduce

(See failing test)

Use `url_for` in a Rails `link_to` method:

```ruby
<%= link_to "Home", url_for(key: "value") %>
```

### Expected behavior

Should render something like this:

```html
<a href="/?key=value">Home</a>
```

### Actual behavior

It throws an error:

```
ViewComponentTest#test_render_link_to_with_url_for:
ActionController::UrlGenerationError: No route matches {:key=>"value"}
```


### System configuration
**Rails version**: 6.1.3.1

**Ruby version**: 3.0.1

**Gem version**: 2.30.0 (resp. master)