### PR TITLE
Increase feature-parity between Translatable and ActionView's TranslationHelper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## main
 
+* Improve feature parity with Rails translations
+  * Don't create a translation backend if the component has no translation file
+  * Mark translation keys ending with `html` as HTML-safe
+  * Always convert keys to String
+  * Support multiple keys
+
+    *Elia Schito*
+
 * Fix errors on `asset_url` helpers when `asset_host` has no protocol.
 
     *Elia Schito*

--- a/lib/view_component/translatable.rb
+++ b/lib/view_component/translatable.rb
@@ -55,9 +55,10 @@ module ViewComponent
       end
     end
 
-    def translate(key = nil, locale: nil, **options)
-      locale ||= ::I18n.locale
+    def translate(key = nil, **options)
+      return key.map { |k| translate(k, **options) } if key.is_a?(Array)
 
+      locale = options.delete(:locale) || ::I18n.locale
       key = "#{i18n_scope}#{key}" if key.start_with?(".")
 
       result = catch(:exception) do

--- a/lib/view_component/translatable.rb
+++ b/lib/view_component/translatable.rb
@@ -62,16 +62,16 @@ module ViewComponent
       key = key&.to_s unless key.is_a?(Symbol)
       key = "#{i18n_scope}#{key}" if key.start_with?(".")
 
-      result = catch(:exception) do
+      translated = catch(:exception) do
         i18n_backend.translate(locale, key, options)
       end
 
       # Fallback to the global translations
-      if result.is_a? ::I18n::MissingTranslation
-        result = helpers.t(key, locale: locale, **options)
+      if translated.is_a? ::I18n::MissingTranslation
+        return super(key, locale: locale, **options)
       end
 
-      result
+      translated
     end
     alias :t :translate
 

--- a/lib/view_component/translatable.rb
+++ b/lib/view_component/translatable.rb
@@ -59,6 +59,7 @@ module ViewComponent
       return key.map { |k| translate(k, **options) } if key.is_a?(Array)
 
       locale = options.delete(:locale) || ::I18n.locale
+      key = key&.to_s unless key.is_a?(Symbol)
       key = "#{i18n_scope}#{key}" if key.start_with?(".")
 
       result = catch(:exception) do

--- a/lib/view_component/translatable.rb
+++ b/lib/view_component/translatable.rb
@@ -67,7 +67,7 @@ module ViewComponent
       return key.map { |k| translate(k, **options) } if key.is_a?(Array)
 
       locale = options.delete(:locale) || ::I18n.locale
-      key = key&.to_s unless key.is_a?(Symbol)
+      key = key&.to_s unless key.is_a?(String)
       key = "#{i18n_scope}#{key}" if key.start_with?(".")
 
       translated = catch(:exception) do

--- a/lib/view_component/translatable.rb
+++ b/lib/view_component/translatable.rb
@@ -9,6 +9,8 @@ module ViewComponent
   module Translatable
     extend ActiveSupport::Concern
 
+    HTML_SAFE_TRANSLATION_KEY = /(?:_|\b)html\z/.freeze
+
     included do
       class_attribute :i18n_backend, instance_writer: false, instance_predicate: false
     end
@@ -69,6 +71,10 @@ module ViewComponent
       # Fallback to the global translations
       if translated.is_a? ::I18n::MissingTranslation
         return super(key, locale: locale, **options)
+      end
+
+      if HTML_SAFE_TRANSLATION_KEY.match?(key)
+        translated = translated.html_safe
       end
 
       translated

--- a/performance/components/translatable_component.rb
+++ b/performance/components/translatable_component.rb
@@ -8,6 +8,6 @@ class TranslatableComponent < ViewComponent::Base
   end
 
   def self.virtual_path
-    "/sidecar_i18n_component"
+    "/translatable_component"
   end
 end

--- a/performance/translatable_benchmark.rb
+++ b/performance/translatable_benchmark.rb
@@ -10,7 +10,7 @@ ENV["RAILS_ENV"] = "production"
 require File.expand_path("../test/config/environment.rb", __dir__)
 
 require_relative "components/global_i18n_component.rb"
-require_relative "components/sidecar_i18n_component.rb"
+require_relative "components/translatable_component.rb"
 
 class BenchmarksController < ActionController::Base
 end
@@ -23,7 +23,7 @@ I18n.backend.load_translations
 Benchmark.ips do |x|
   x.report(:global) { controller_view.render(GlobalI18nComponent.new("hello")) }
   x.report(:global_missing) { controller_view.render(GlobalI18nComponent.new("missing")) }
-  x.report(:sidecar_absolute) { controller_view.render(TranslatableComponent.new("sidecar_i18n_component.hello")) }
+  x.report(:sidecar_absolute) { controller_view.render(TranslatableComponent.new("translatable_component.hello")) }
   x.report(:sidecar) { controller_view.render(TranslatableComponent.new(".hello")) }
   x.report(:sidecar_missing) { controller_view.render(TranslatableComponent.new("missing")) }
   x.report(:sidecar_fallback) { controller_view.render(TranslatableComponent.new("from.rails")) }

--- a/performance/translatable_benchmark.rb
+++ b/performance/translatable_benchmark.rb
@@ -20,13 +20,21 @@ controller_view = BenchmarksController.new.view_context
 I18n.load_path = Dir[File.expand_path("../test/config/locales/*.{rb,yml,yaml}", __dir__)]
 I18n.backend.load_translations
 
+global_i18n_component = GlobalI18nComponent.new("hello")
+translatable_component = TranslatableComponent.new(".hello")
+
+controller_view.render(global_i18n_component)
+controller_view.render(translatable_component)
+
 Benchmark.ips do |x|
-  x.report(:global) { controller_view.render(GlobalI18nComponent.new("hello")) }
-  x.report(:global_missing) { controller_view.render(GlobalI18nComponent.new("missing")) }
-  x.report(:sidecar_absolute) { controller_view.render(TranslatableComponent.new("translatable_component.hello")) }
-  x.report(:sidecar) { controller_view.render(TranslatableComponent.new(".hello")) }
-  x.report(:sidecar_missing) { controller_view.render(TranslatableComponent.new("missing")) }
-  x.report(:sidecar_fallback) { controller_view.render(TranslatableComponent.new("from.rails")) }
+  x.report(:global) { global_i18n_component.t("hello") }
+  x.report(:sidecar) { translatable_component.t(".hello") }
+
+  x.report(:global_missing) { global_i18n_component.t("missing") }
+  x.report(:sidecar_missing) { translatable_component.t("missing") }
+
+  x.report(:sidecar_absolute) { translatable_component.t("translatable_component.hello") }
+  x.report(:sidecar_fallback) { translatable_component.t("from.rails") }
 
   x.compare!
 end

--- a/test/app/components/translatable_component.yml
+++ b/test/app/components/translatable_component.yml
@@ -1,4 +1,9 @@
 en:
   hello: "Hello from sidecar translations!"
+
+  hello_html: "Hello from <strong>sidecar translations</strong>!"
+
+  html: "hello <em>world</em>!"
+
   from:
     sidecar: This is coming from the sidecar

--- a/test/config/locales/en.yml
+++ b/test/config/locales/en.yml
@@ -5,5 +5,9 @@ en:
   translations_component:
     title: Lorem ipsum
     subtitle: More lorem ipsum
+
+  translatable_component:
+    relative_rails_key: Relative key from Rails
+
   editorb_component:
     title: Editorb!

--- a/test/view_component/translatable_test.rb
+++ b/test/view_component/translatable_test.rb
@@ -29,6 +29,12 @@ class TranslatableTest < ViewComponent::TestCase
     ])
   end
 
+  def test_converts_key_to_string_as_necessary
+    key = Struct.new(:to_s).new(".hello")
+    assert_equal "Hello from sidecar translations!", translate(key)
+    assert_equal key, translate(:"translations.missing", default: key)
+  end
+
   private
 
   def translate(key, **options)

--- a/test/view_component/translatable_test.rb
+++ b/test/view_component/translatable_test.rb
@@ -16,4 +16,24 @@ class TranslatableTest < ViewComponent::TestCase
     assert_selector("p.global.shared-key", text: "Hello from Rails translations!")
     assert_selector("p.global.nested", text: "This is coming from Rails")
   end
+
+  def test_multi_key_support
+    assert_equal [
+      "Hello from sidecar translations!",
+      "This is coming from the sidecar",
+      "This is coming from Rails",
+    ], translate([
+      ".hello",
+      ".from.sidecar",
+      "from.rails",
+    ])
+  end
+
+  private
+
+  def translate(key, **options)
+    component = TranslatableComponent.new
+    render_inline(component)
+    component.translate(key, **options)
+  end
 end

--- a/test/view_component/translatable_test.rb
+++ b/test/view_component/translatable_test.rb
@@ -33,6 +33,10 @@ class TranslatableTest < ViewComponent::TestCase
     assert_equal "Relative key from Rails", translate(".relative_rails_key")
   end
 
+  def test_symbol_keys
+    assert_equal "Hello from sidecar translations!", translate(:".hello")
+  end
+
   def test_converts_key_to_string_as_necessary
     key = Struct.new(:to_s).new(".hello")
     assert_equal "Hello from sidecar translations!", translate(key)

--- a/test/view_component/translatable_test.rb
+++ b/test/view_component/translatable_test.rb
@@ -29,6 +29,10 @@ class TranslatableTest < ViewComponent::TestCase
     ])
   end
 
+  def test_relative_keys_missing_from_component_translations
+    assert_equal "Relative key from Rails", translate(".relative_rails_key")
+  end
+
   def test_converts_key_to_string_as_necessary
     key = Struct.new(:to_s).new(".hello")
     assert_equal "Hello from sidecar translations!", translate(key)

--- a/test/view_component/translatable_test.rb
+++ b/test/view_component/translatable_test.rb
@@ -39,6 +39,16 @@ class TranslatableTest < ViewComponent::TestCase
     assert_equal key, translate(:"translations.missing", default: key)
   end
 
+  def test_translate_marks_translations_named_html_as_safe_html
+    assert_equal "hello <em>world</em>!", translate(".html")
+    assert_predicate translate(".html"), :html_safe?
+  end
+
+  def test_translate_marks_translations_with_a_html_suffix_as_safe_html
+    assert_equal "Hello from <strong>sidecar translations</strong>!", translate(".hello_html")
+    assert_predicate translate(".hello_html"), :html_safe?
+  end
+
   private
 
   def translate(key, **options)


### PR DESCRIPTION
<!-- See https://viewcomponent.org/contributing.html#submitting-a-pull-request  -->

### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

* Improve feature parity with Rails translations
  * Don't create a translation backend if the component has no translation file
  * Mark translation keys ending with `html` as HTML-safe
  * Always convert keys to String
  * Support multiple keys

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file. -->

While migrating from shared translations to `Translatable` in an application we run into problems related to the missing support for translation keys ending in `_html`.

Also we're including `Translatable` inside `ApplicationComponent`, doing this shouldn't affect memory after this change.
