### PR TITLE
Fix broken link (404) in pull request template

### DIFF
--- a/.github/pull-request-template.md
+++ b/.github/pull-request-template.md
@@ -1,4 +1,4 @@
-<!-- See https://viewcomponent.org/contributing.html#submitting-a-pull-request  -->
+<!-- See https://github.com/github/view_component/blob/main/CONTRIBUTING.md#submitting-a-pull-request -->
 
 ### Summary
 


### PR DESCRIPTION
### Summary

This is partly reverting changes introduced in the commit 42a35a5. The link is broken since the commit d3288ea.

### Other Information

I've noticed this when opening my previous PR (#870).