### PR TITLE
move the deprecation warning below the template_errors check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## main
 
+* Fix `DEPRECATION WARNING: before_render_check` when compiling `ViewComponent::Base`
+
+    *Dave Kroondyk*
+
 ## 2.31.0
 
 * Add `#with_content` to allow setting content without a block.

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,6 +33,7 @@ ViewComponent is built by:
 <img src="https://avatars.githubusercontent.com/cover?s=128" alt="cover" width="64" />
 <img src="https://avatars.githubusercontent.com/czj?s=128" alt="czj" width="64" />
 <img src="https://avatars.githubusercontent.com/dark-panda?s=128" alt="dark-panda" width="64" />
+<img src="https://avatars.githubusercontent.com/davekaro?s=128" alt="davekaro" width="64" />
 <img src="https://avatars.githubusercontent.com/dukex?s=128" alt="dukex" width="64" />
 <img src="https://avatars.githubusercontent.com/dylnclrk?s=128" alt="dylnclrk" width="64" />
 <img src="https://avatars.githubusercontent.com/elia?s=128" alt="elia" width="64" />

--- a/lib/view_component/compiler.rb
+++ b/lib/view_component/compiler.rb
@@ -15,12 +15,6 @@ module ViewComponent
 
       subclass_instance_methods = component_class.instance_methods(false)
 
-      if subclass_instance_methods.include?(:before_render_check)
-        ActiveSupport::Deprecation.warn(
-          "`before_render_check` will be removed in v3.0.0. Use `before_render` instead."
-        )
-      end
-
       if subclass_instance_methods.include?(:with_content) && raise_errors
         raise ViewComponent::ComponentError.new("#{component_class} implements a reserved method, `with_content`.")
       end
@@ -28,6 +22,12 @@ module ViewComponent
       if template_errors.present?
         raise ViewComponent::TemplateError.new(template_errors) if raise_errors
         return false
+      end
+
+      if subclass_instance_methods.include?(:before_render_check)
+        ActiveSupport::Deprecation.warn(
+          "`before_render_check` will be removed in v3.0.0. Use `before_render` instead."
+        )
       end
 
       if raise_errors


### PR DESCRIPTION
### Summary

this was changed in https://github.com/github/view_component/pull/875/commits/6799a29af7daff334c34ccb0c6b26d2afd9d0e13,
but that causes deprecations when compiling ViewComponent::Base, which is
still allowed to call the before_render_check method

Fixes https://github.com/github/view_component/issues/886

### Other Information

Let me know if this seems good and needs a CHANGELOG entry.
