### PR TITLE
Add basic API docs for instance methods, powered by YARD

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.gem
 *.rbc
+.ruby-version
 /.config
 /coverage/assets
 /coverage/index.html

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,8 @@
 /test/log/*
 /test/app/tmp/*
 /test/tmp/*
+/.yardoc
+/_yardoc/
 
 # Used by dotenv library to load environment variables.
 # .env

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,7 @@ Here are a few things you can do that will increase the likelihood of your pull 
 1. Configure and install the dependencies: `bundle`.
 1. Run Jekyll: `bundle exec jekyll serve`.
 1. Open the docs site at `http://127.0.0.1:4000/`.
+1. If making changes to the API, run `bundle exec rake docs:build` to generate `docs/api.md` from YARD comments.
 
 ## Releasing
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -209,6 +209,7 @@ GEM
     websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
+    yard (0.9.26)
     zeitwerk (2.4.2)
 
 PLATFORMS
@@ -231,6 +232,7 @@ DEPENDENCIES
   simplecov-console (~> 0.7.2)
   slim (~> 4.0)
   view_component!
+  yard (~> 0.9.25)
 
 BUNDLED WITH
    1.17.3

--- a/Rakefile
+++ b/Rakefile
@@ -2,6 +2,7 @@
 
 require "bundler/gem_tasks"
 require "rake/testtask"
+require "yard"
 
 Rake::TestTask.new(:test) do |t|
   t.libs << "test"
@@ -32,6 +33,61 @@ namespace :coverage do
 
     SimpleCov.collate Dir["simplecov-resultset-*/.resultset.json"], "rails" do
       formatter SimpleCov::Formatter::Console
+    end
+  end
+end
+
+namespace :docs do
+  # Build api.md documentation page from YARD comments.
+  task :build do
+    YARD::Rake::YardocTask.new
+    puts "Building YARD documentation."
+
+    Rake::Task["yard"].execute
+
+    puts "Converting YARD documentation to Markdown files."
+
+    registry = YARD::RegistryStore.new
+    registry.load!(".yardoc")
+
+    INSTANCE_METHODS_TO_DOCUMENT = [
+      :render?,
+      :before_render,
+      :before_render_check
+    ]
+
+    instance_methods = registry.get("ViewComponent::Base").meths.select { |method| method.scope != :class }
+    instance_methods_to_document = instance_methods.select { |method| INSTANCE_METHODS_TO_DOCUMENT.include?(method.name) }
+
+    File.open("docs/api.md", "w") do |f|
+      f.puts("---")
+      f.puts("layout: default")
+      f.puts("title: API")
+      f.puts("---")
+      f.puts
+      f.puts("<!-- Warning: AUTO-GENERATED file, do not edit. Add code comments to your Ruby instead <3 -->")
+      f.puts
+      f.puts("# API")
+      f.puts
+      f.puts("## Instance methods")
+      f.puts
+
+      instance_methods_to_document.each do |method|
+        suffix =
+          if method.tag(:deprecated)
+            " (Deprecated)"
+          end
+
+        f.puts("### #{method.signature.gsub('def ', '')} → [#{method.tag(:return).types.join(',')}]#{suffix}")
+        f.puts
+        f.puts(method.docstring)
+        f.puts
+
+        if method.tag(:deprecated)
+          f.puts("_#{method.tag(:deprecated).text}_")
+          f.puts
+        end
+      end
     end
   end
 end

--- a/Rakefile
+++ b/Rakefile
@@ -69,7 +69,6 @@ namespace :docs do
       f.puts("# API")
       f.puts
       f.puts("## Instance methods")
-      f.puts
 
       instance_methods_to_document.each do |method|
         suffix =
@@ -81,14 +80,14 @@ namespace :docs do
           " → [#{method.tag(:return).types.join(',')}]"
         end
 
+        f.puts
         f.puts("### #{method.sep}#{method.signature.gsub('def ', '')}#{types}#{suffix}")
         f.puts
         f.puts(method.docstring)
-        f.puts
 
         if method.tag(:deprecated)
-          f.puts("_#{method.tag(:deprecated).text}_")
           f.puts
+          f.puts("_#{method.tag(:deprecated).text}_")
         end
       end
     end

--- a/docs/api.md
+++ b/docs/api.md
@@ -34,4 +34,3 @@ A proxy through which to access helpers. Use sparingly as doing so introduces co
 ### #request → [ActionDispatch::Request]
 
 The current request. Use sparingly as doing so introduces coupling that inhibits encapsulation & reuse, often making testing difficult.
-

--- a/docs/api.md
+++ b/docs/api.md
@@ -9,17 +9,29 @@ title: API
 
 ## Instance methods
 
-### before_render → [void]
+### #before_render → [void]
 
 Called before rendering the component.
 
-### before_render_check → [void] (Deprecated)
+### #before_render_check → [void] (Deprecated)
 
 Called after rendering the component.
 
 _Use `before_render` instead. Will be removed in v3.0.0._
 
-### render? → [Boolean]
+### #render? → [Boolean]
 
 Whether the ViewComponent should render.
+
+### #controller → [ActionController::Base]
+
+The current controller. Use sparingly as doing so introduces coupling that inhibits encapsulation & reuse, often making testing difficult.
+
+### #helpers → [ActionView::Base]
+
+A proxy through which to access helpers. Use sparingly as doing so introduces coupling that inhibits encapsulation & reuse, often making testing difficult.
+
+### #request → [ActionDispatch::Request]
+
+The current request. Use sparingly as doing so introduces coupling that inhibits encapsulation & reuse, often making testing difficult.
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -11,7 +11,7 @@ title: API
 
 ### #before_render → [void]
 
-Called before rendering the component.
+Called before rendering the component. Override to perform operations that depend on having access to the view context, such as helpers.
 
 ### #before_render_check → [void] (Deprecated)
 
@@ -21,7 +21,7 @@ _Use `before_render` instead. Will be removed in v3.0.0._
 
 ### #render? → [Boolean]
 
-Whether the ViewComponent should render.
+Override to determine whether the ViewComponent should render.
 
 ### #controller → [ActionController::Base]
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,25 @@
+---
+layout: default
+title: API
+---
+
+<!-- Warning: AUTO-GENERATED file, do not edit. Add code comments to your Ruby instead <3 -->
+
+# API
+
+## Instance methods
+
+### before_render → [void]
+
+Called before rendering the component.
+
+### before_render_check → [void] (Deprecated)
+
+Called after rendering the component.
+
+_Use `before_render` instead. Will be removed in v3.0.0._
+
+### render? → [Boolean]
+
+Whether the ViewComponent should render.
+

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -99,7 +99,7 @@ module ViewComponent
       @current_template = old_current_template
     end
 
-    # Called before rendering the component.
+    # Called before rendering the component. Override to perform operations that depend on having access to the view context, such as helpers.
     #
     # @return [void]
     def before_render
@@ -114,7 +114,7 @@ module ViewComponent
       # noop
     end
 
-    # Whether the ViewComponent should render.
+    # Override to determine whether the ViewComponent should render.
     #
     # @return [Boolean]
     def render?

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -30,6 +30,7 @@ module ViewComponent
     # Hook for allowing components to do work as part of the compilation process.
     #
     # For example, one might compile component-specific assets at this point.
+    # @private TODO: add documentation
     def self._after_compile
       # noop
     end
@@ -58,6 +59,7 @@ module ViewComponent
     # returns:
     # <span title="greeting">Hello, world!</span>
     #
+    # @private
     def render_in(view_context, &block)
       self.class.compile(raise_errors: true)
 
@@ -119,6 +121,7 @@ module ViewComponent
       true
     end
 
+    # @private
     def initialize(*); end
 
     # Re-use original view_context if we're not rendering a component.
@@ -126,6 +129,7 @@ module ViewComponent
     # This prevents an exception when rendering a partial inside of a component that has also been rendered outside
     # of the component. This is due to the partials compiled template method existing in the parent `view_context`,
     #  and not the component's `view_context`.
+    # @private
     def render(options = {}, args = {}, &block)
       if options.is_a? ViewComponent::Base
         super
@@ -134,28 +138,36 @@ module ViewComponent
       end
     end
 
+    # The current controller. Use sparingly as doing so introduces coupling that inhibits encapsulation & reuse, often making testing difficult.
+    #
+    # @return [ActionController::Base]
     def controller
       raise ViewContextCalledBeforeRenderError, "`controller` can only be called at render time." if view_context.nil?
       @controller ||= view_context.controller
     end
 
-    # Provides a proxy to access helper methods from the context of the current controller
+    # A proxy through which to access helpers. Use sparingly as doing so introduces coupling that inhibits encapsulation & reuse, often making testing difficult.
+    #
+    # @return [ActionView::Base]
     def helpers
       raise ViewContextCalledBeforeRenderError, "`helpers` can only be called at render time." if view_context.nil?
       @helpers ||= controller.view_context
     end
 
     # Exposes .virtual_path as an instance method
+    # @private
     def virtual_path
       self.class.virtual_path
     end
 
     # For caching, such as #cache_if
+    # @private
     def view_cache_dependencies
       []
     end
 
     # For caching, such as #cache_if
+    # @private
     def format
       # Ruby 2.6 throws a warning without checking `defined?`, 2.7 does not
       if defined?(@variant)
@@ -164,6 +176,7 @@ module ViewComponent
     end
 
     # Assign the provided content to the content area accessor
+    # @private
     def with(area, content = nil, &block)
       unless content_areas.include?(area)
         raise ArgumentError.new "Unknown content_area '#{area}' - expected one of '#{content_areas}'"
@@ -177,15 +190,16 @@ module ViewComponent
       nil
     end
 
+    # @private TODO: add documentation
     def with_variant(variant)
       @variant = variant
 
       self
     end
 
-    # Exposes the current request to the component.
-    # Use sparingly as doing so introduces coupling
-    # that inhibits encapsulation & reuse.
+    # The current request. Use sparingly as doing so introduces coupling that inhibits encapsulation & reuse, often making testing difficult.
+    #
+    # @return [ActionDispatch::Request]
     def request
       @request ||= controller.request
     end

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -97,14 +97,24 @@ module ViewComponent
       @current_template = old_current_template
     end
 
+    # Called before rendering the component.
+    #
+    # @return [void]
     def before_render
       before_render_check
     end
 
+    # Called after rendering the component.
+    #
+    # @deprecated Use `before_render` instead. Will be removed in v3.0.0.
+    # @return [void]
     def before_render_check
       # noop
     end
 
+    # Whether the ViewComponent should render.
+    #
+    # @return [Boolean]
     def render?
       true
     end

--- a/view_component.gemspec
+++ b/view_component.gemspec
@@ -43,4 +43,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "simplecov", "~> 0.18.0"
   spec.add_development_dependency "simplecov-console", "~> 0.7.2"
   spec.add_development_dependency "pry", "~> 0.13"
+  spec.add_development_dependency "yard", "~> 0.9.25"
 end


### PR DESCRIPTION
### Summary

We don't have API-focused documentation. This PR aims to give us a basic system for generating it from YARD code comments, inspired by a similar approach we've taken in Primer ViewComponents.
