### PR TITLE
Add instrumentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## main
 
+* Add the ability to enable ActiveSupport notifications (`!render.view_component` event) with `config.view_component.instrumentation_enabled`.
+
+  *Svyatoslav Kryukov*
+
 ## 2.32.0
 
 * Enable previews by default in test environment.

--- a/docs/guide/instrumentation.md
+++ b/docs/guide/instrumentation.md
@@ -1,0 +1,25 @@
+---
+layout: default
+title: Instrumentation
+parent: Building ViewComponents
+---
+
+# Instrumentation
+
+To enable ActiveSupport notifications, use the `instrumentation_enabled` option:
+
+```ruby
+# config/application.rb
+# Enable ActiveSupport notifications for all ViewComponents
+config.view_component.instrumentation_enabled = true
+```
+
+Then subscribe to the `!render.view_component` event:
+
+```ruby
+ActiveSupport::Notifications.subscribe("!render.view_component") do |*args|
+  event = ActiveSupport::Notifications::Event.new(*args)
+  event.name    # => "!render.view_component"
+  event.payload # => { name: "MyComponent", identifier: "/Users/mona/project/app/components/my_component.rb" }
+end
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -70,6 +70,7 @@ ViewComponent is built by:
 <img src="https://avatars.githubusercontent.com/rmacklin?s=64" alt="rmacklin" width="32" />
 <img src="https://avatars.githubusercontent.com/seanpdoyle?s=64" alt="seanpdoyle" width="32" />
 <img src="https://avatars.githubusercontent.com/simonrand?s=64" alt="simonrand" width="32" />
+<img src="https://avatars.githubusercontent.com/skryukov?s=64" alt="skryukov" width="32" />
 <img src="https://avatars.githubusercontent.com/smashwilson?s=64" alt="smashwilson" width="32" />
 <img src="https://avatars.githubusercontent.com/spdawson?s=64" alt="spdawson" width="32" />
 <img src="https://avatars.githubusercontent.com/swanson?s=64" alt="swanson" width="32" />

--- a/lib/view_component.rb
+++ b/lib/view_component.rb
@@ -8,6 +8,7 @@ module ViewComponent
   autoload :Base
   autoload :Compiler
   autoload :ComponentError
+  autoload :Instrumentation
   autoload :Preview
   autoload :PreviewTemplateError
   autoload :TestHelpers

--- a/lib/view_component/engine.rb
+++ b/lib/view_component/engine.rb
@@ -13,6 +13,7 @@ module ViewComponent
 
       options.render_monkey_patch_enabled = true if options.render_monkey_patch_enabled.nil?
       options.show_previews = Rails.env.development? || Rails.env.test? if options.show_previews.nil?
+      options.instrumentation_enabled = false if options.instrumentation_enabled.nil?
       options.preview_route ||= ViewComponent::Base.preview_route
       options.preview_controller ||= ViewComponent::Base.preview_controller
 
@@ -30,7 +31,17 @@ module ViewComponent
       end
 
       ActiveSupport.on_load(:view_component) do
-        options.each { |k, v| send("#{k}=", v) }
+        options.each { |k, v| send("#{k}=", v) if respond_to?("#{k}=") }
+      end
+    end
+
+    initializer "view_component.enable_instrumentation" do |app|
+      ActiveSupport.on_load(:view_component) do
+        if app.config.view_component.instrumentation_enabled.present?
+          # :nocov:
+          ViewComponent::Base.prepend(ViewComponent::Instrumentation)
+          # :nocov:
+        end
       end
     end
 

--- a/lib/view_component/instrumentation.rb
+++ b/lib/view_component/instrumentation.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "active_support/notifications"
+
+module ViewComponent # :nodoc:
+  module Instrumentation
+    def self.included(mod)
+      mod.prepend(self)
+    end
+
+    def render_in(view_context, &block)
+      ActiveSupport::Notifications.instrument("!render.view_component", name: self.class.name, identifier: self.class.identifier) do
+        super(view_context, &block)
+      end
+    end
+  end
+end

--- a/test/app/components/instrumentation_component.html.erb
+++ b/test/app/components/instrumentation_component.html.erb
@@ -1,0 +1,1 @@
+<div>hello,world!</div>

--- a/test/app/components/instrumentation_component.rb
+++ b/test/app/components/instrumentation_component.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class InstrumentationComponent < ViewComponent::Base
+  include ViewComponent::Instrumentation
+end

--- a/test/view_component/instrumentation_test.rb
+++ b/test/view_component/instrumentation_test.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class InstrumentationTest < ViewComponent::TestCase
+  def test_instrumentation
+    events = []
+    ActiveSupport::Notifications.subscribe("!render.view_component") do |*args|
+      events << ActiveSupport::Notifications::Event.new(*args)
+    end
+    render_inline(InstrumentationComponent.new)
+
+    assert_selector("div", text: "hello,world!")
+    assert_equal(events.size, 1)
+    assert_equal(events[0].name, "!render.view_component")
+    assert_equal(events[0].payload[:name], "InstrumentationComponent")
+    assert_match("app/components/instrumentation_component.rb", events[0].payload[:identifier])
+  end
+end


### PR DESCRIPTION
### Summary

Closes #893

This PR adds a new configuration option `config.view_component.instrumentation_enabled`. When set true, ActiveSupport notification event `render.view_component` is enabled.