### PR TITLE
Add test for rendering component from template without newline

### DIFF
--- a/test/app/components/display_inline_component.html.erb
+++ b/test/app/components/display_inline_component.html.erb
@@ -1,0 +1,1 @@
+<span>Hello, world!</span>

--- a/test/app/components/display_inline_component.rb
+++ b/test/app/components/display_inline_component.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class DisplayInlineComponent < ViewComponent::Base
+end

--- a/test/test/components/previews/display_inline_component_preview.rb
+++ b/test/test/components/previews/display_inline_component_preview.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class DisplayInlineComponentPreview < ViewComponent::Preview
+  def with_newline; end
+end

--- a/test/test/components/previews/display_inline_component_preview/with_newline.html.erb
+++ b/test/test/components/previews/display_inline_component_preview/with_newline.html.erb
@@ -1,0 +1,1 @@
+<%= render DisplayInlineComponent.new %><%= render DisplayInlineComponent.new %>

--- a/test/view_component/integration_test.rb
+++ b/test/view_component/integration_test.rb
@@ -443,6 +443,11 @@ class IntegrationTest < ActionDispatch::IntegrationTest
     end
   end
 
+  def test_does_not_render_additional_newline
+    get "/rails/view_components/display_inline_component/with_newline"
+    assert_includes response.body, "<span>Hello, world!</span><span>Hello, world!</span>"
+  end
+
   def test_renders_the_preview_example_with_its_own_template_and_a_layout
     get "/rails/view_components/my_component/inside_banner"
     assert_includes response.body, "ViewComponent - Admin - Test"


### PR DESCRIPTION
Test case for #913 

### Summary

Adds a failing test that renders the same component twice in sequence to ensure they're not separated by a newline.