### PR TITLE
Add preview command line, format change, fix typo

### DIFF
--- a/docs/guide/previews.md
+++ b/docs/guide/previews.md
@@ -33,9 +33,15 @@ class ExampleComponentPreview < ViewComponent::Preview
 end
 ```
 
-Which generates <http://localhost:3000/rails/view_components/example_component/with_default_title>,
-<http://localhost:3000/rails/view_components/example_component/with_long_title>,
-and <http://localhost:3000/rails/view_components/example_component/with_content_block>.
+Generate the preview using:
+```console
+bin/rails generate component Example title --preview
+```
+
+Which generates: 
+* <http://localhost:3000/rails/view_components/example_component/with_default_title>
+* <http://localhost:3000/rails/view_components/example_component/with_long_title>
+* <http://localhost:3000/rails/view_components/example_component/with_content_block>
 
 It's also possible to set dynamic values from the params by setting them as arguments:
 
@@ -65,7 +71,7 @@ class ExampleComponentPreview < ViewComponent::Preview
 end
 ```
 
-You can also set a custom layout to be used by default for previews as well as the preview index pages via the `default_preview_layout` configuration option:
+You can also set a custom layout to be used by default for previews as well as preview the index pages via the `default_preview_layout` configuration option:
 
 ```ruby
 # config/application.rb

--- a/docs/guide/previews.md
+++ b/docs/guide/previews.md
@@ -71,7 +71,7 @@ class ExampleComponentPreview < ViewComponent::Preview
 end
 ```
 
-You can also set a custom layout to be used by default for previews as well as preview the index pages via the `default_preview_layout` configuration option:
+To set a custom layout for previews and the previews index page, set: `default_preview_layout`:
 
 ```ruby
 # config/application.rb

--- a/docs/guide/previews.md
+++ b/docs/guide/previews.md
@@ -33,12 +33,8 @@ class ExampleComponentPreview < ViewComponent::Preview
 end
 ```
 
-Generate the preview using:
-```console
-bin/rails generate component Example title --preview
-```
+Then access the resulting previews at:
 
-Which generates: 
 * <http://localhost:3000/rails/view_components/example_component/with_default_title>
 * <http://localhost:3000/rails/view_components/example_component/with_long_title>
 * <http://localhost:3000/rails/view_components/example_component/with_content_block>


### PR DESCRIPTION
### Summary

I thought it would be nice to present the command line argument to generate a preview again before the first examples for localhost are listed in case someone new comes directly to Previews before reading https://viewcomponent.org/guide/#quick-start.
I put the list of localhost URLs in a list
I fixed a typo where `the` should come after `preview`
