### PR TITLE
Add experimental `_output_postamble` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## main
 
-* Add experimental `_after_render` lifecyle method.
+* Add experimental `_output_postamble` lifecyle method.
 
     *Joel Hawksley*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## main
 
+* Add experimental `_after_render` lifecyle method.
+
+    *Joel Hawksley*
+
 * Add compatibility notes on FAQ.
 
     *Matheus Richard*

--- a/docs/api.md
+++ b/docs/api.md
@@ -9,6 +9,10 @@ title: API
 
 ## Instance methods
 
+### #_after_render → [String]
+
+EXPERIMENTAL: Optional content to be returned after the rendered template.
+
 ### #before_render → [void]
 
 Called before rendering the component. Override to perform operations that depend on having access to the view context, such as helpers.

--- a/docs/api.md
+++ b/docs/api.md
@@ -9,7 +9,7 @@ title: API
 
 ## Instance methods
 
-### #_after_render → [String]
+### #_output_postamble → [String]
 
 EXPERIMENTAL: Optional content to be returned after the rendered template.
 

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -91,12 +91,19 @@ module ViewComponent
       before_render
 
       if render?
-        render_template_for(@variant)
+        render_template_for(@variant) + _after_render
       else
         ""
       end
     ensure
       @current_template = old_current_template
+    end
+
+    # EXPERIMENTAL: Optional content to be returned after the rendered template.
+    #
+    # @return [String]
+    def _after_render
+      ""
     end
 
     # Called before rendering the component. Override to perform operations that depend on having access to the view context, such as helpers.

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -91,7 +91,7 @@ module ViewComponent
       before_render
 
       if render?
-        render_template_for(@variant) + _after_render
+        render_template_for(@variant) + _output_postamble
       else
         ""
       end
@@ -102,7 +102,7 @@ module ViewComponent
     # EXPERIMENTAL: Optional content to be returned after the rendered template.
     #
     # @return [String]
-    def _after_render
+    def _output_postamble
       ""
     end
 

--- a/test/app/components/after_render_component.rb
+++ b/test/app/components/after_render_component.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AfterRenderComponent < ViewComponent::Base
+  def call
+    "Hello, "
+  end
+
+  def _after_render
+    "World!"
+  end
+end

--- a/test/app/components/after_render_component.rb
+++ b/test/app/components/after_render_component.rb
@@ -5,7 +5,7 @@ class AfterRenderComponent < ViewComponent::Base
     "Hello, "
   end
 
-  def _after_render
+  def _output_postamble
     "World!"
   end
 end

--- a/test/app/views/view_components/_inline.html.erb
+++ b/test/app/views/view_components/_inline.html.erb
@@ -1,0 +1,1 @@
+<span>Hello, world!</span>

--- a/test/view_component/view_component_test.rb
+++ b/test/view_component/view_component_test.rb
@@ -761,4 +761,10 @@ class ViewComponentTest < ViewComponent::TestCase
       assert_text "/products?key=value"
     end
   end
+
+  def test_after_render
+    render_inline(AfterRenderComponent.new)
+
+    assert_text("Hello, World!")
+  end
 end

--- a/test/view_component/view_component_test.rb
+++ b/test/view_component/view_component_test.rb
@@ -762,7 +762,7 @@ class ViewComponentTest < ViewComponent::TestCase
     end
   end
 
-  def test_after_render
+  def test_output_postamble
     render_inline(AfterRenderComponent.new)
 
     assert_text("Hello, World!")


### PR DESCRIPTION
This PR adds an experiment `_after_render` method, as proposed in https://github.com/github/view_component/pull/677/files, for the sake of internal testing.