### PR TITLE
Ensure session is set on request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## main
 
+* Fix test helper compatibility with Rails 7.0, TestRequest, and TestSession.
+
+    *Leo Correa*
+
 * Add experimental `_output_postamble` lifecyle method.
 
     *Joel Hawksley*

--- a/docs/index.md
+++ b/docs/index.md
@@ -75,6 +75,7 @@ ViewComponent is built by:
 <img src="https://avatars.githubusercontent.com/tbroad-ramsey?s=64" alt="tbroad-ramsey" width="32" />
 <img src="https://avatars.githubusercontent.com/tclem?s=64" alt="tclem" width="32" />
 <img src="https://avatars.githubusercontent.com/tenderlove?s=64" alt="tenderlove" width="32" />
+<img src="https://avatars.githubusercontent.com/tonkpils?s=64" alt="tonkpils" width="32" />
 <img src="https://avatars.githubusercontent.com/traels?s=64" alt="traels" width="32" />
 <img src="https://avatars.githubusercontent.com/vinistock?s=64" alt="vinistock" width="32" />
 <img src="https://avatars.githubusercontent.com/xronos-i-am?s=64" alt="xronos-i-am" width="32" />

--- a/lib/view_component/test_helpers.rb
+++ b/lib/view_component/test_helpers.rb
@@ -39,7 +39,12 @@ module ViewComponent
     end
 
     def request
-      @request ||= ActionDispatch::TestRequest.create
+      @request ||=
+        begin
+          request = ActionDispatch::TestRequest.create
+          request.session = ActionController::TestSession.new
+          request
+        end
     end
 
     def with_variant(variant)


### PR DESCRIPTION
### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

Rails 7.0 deprecated writing to a session when the session is disabled
and defaults a session to a disabled session. https://github.com/rails/rails/pull/42231

In the past, ActionDispatch::TestRequest.create would set the
TestSession explicitly but this is not the case anymore and the default
session is used. With the PR mentioned above, this raises an exception
when testing view components that implement sessions.

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file. -->
