### PR TITLE
Coerce rendered component to a string even if nothing is rendered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## main
 
+* Don't raise an error when rendering empty components.
+
+    *Alex Robbin*
+
 ## 2.32.0
 
 * Enable previews by default in test environment.

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -91,7 +91,7 @@ module ViewComponent
       before_render
 
       if render?
-        render_template_for(@variant) + _output_postamble
+        render_template_for(@variant).to_s + _output_postamble
       else
         ""
       end

--- a/test/app/components/empty_component.rb
+++ b/test/app/components/empty_component.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class EmptyComponent < ViewComponent::Base
+  def call; end
+end

--- a/test/view_component/view_component_test.rb
+++ b/test/view_component/view_component_test.rb
@@ -86,6 +86,12 @@ class ViewComponentTest < ViewComponent::TestCase
     assert_selector("input[type='text'][name='name']")
   end
 
+  def test_render_empty_component
+    assert_nothing_raised do
+      render_inline(EmptyComponent.new)
+    end
+  end
+
   def test_renders_slim_template
     render_inline(SlimComponent.new(message: "bar")) { "foo" }
 


### PR DESCRIPTION
### Summary

If a component or slot is empty and the rendering of the component returns `nil`, we would attempt to add the postamble to `nil`, which throws an exception:

```
undefined method `+' for nil:NilClass
```

Now we are explicitly coercing the result of the render to a string, to ensure it can be appended to.

### Other Information

Closes #937.