### PR TITLE
Add previews generation to pvc workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,7 @@ jobs:
         gem install bundler:2.2.9
         bundle config path vendor/bundle
         bundle update
+        bundle exec rake docs:preview
         bundle exec rake
       env:
         VIEW_COMPONENT_PATH: ../view_component


### PR DESCRIPTION
### Summary

This PR ensures that there's a call to generate previews in the pvc workflow before the tests are run.

We [recently made updates in pvc](https://github.com/primer/view_components/pull/603) to auto-generate view component previews, which are used in one of our tests for accessibility.

