### PR TITLE
Add `_iteration` parameter support to get access to collection iteration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## main
 
+* Add support for `_iteration` parameter when rendering in a collection
+
+    *Will Cosgrove*
+
 * Don't raise an error when rendering empty components.
 
     *Alex Robbin*

--- a/docs/guide/collections.md
+++ b/docs/guide/collections.md
@@ -88,3 +88,24 @@ end
   <%= @counter %> <%= @product.name %>
 </li>
 ```
+
+## Collection iteration
+
+ViewComponent defines a counter variable matching the parameter name above, followed by `_iteration`. To access the variable, add it to `initialize` as an argument:
+
+```ruby
+# app/components/product_component.rb
+class ProductComponent < ViewComponent::Base
+  def initialize(product:, product_iteration:)
+    @product = product
+    @iteration = product_iteration
+  end
+end
+```
+
+```erb
+<%# app/components/product_component.html.erb %>
+<li class="<%= "featured" if @iteration.first? %>">
+  <%= @product.name %>
+</li>
+```

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -425,6 +425,14 @@ module ViewComponent
         initialize_parameter_names.include?(collection_counter_parameter)
       end
 
+      def collection_iteration_parameter
+        "#{collection_parameter}_iteration".to_sym
+      end
+
+      def iteration_argument_present?
+        initialize_parameter_names.include?(collection_iteration_parameter)
+      end
+
       private
 
       def initialize_parameter_names

--- a/lib/view_component/collection.rb
+++ b/lib/view_component/collection.rb
@@ -38,6 +38,7 @@ module ViewComponent
     def component_options(item, iterator)
       item_options = { component.collection_parameter => item }
       item_options[component.collection_counter_parameter] = iterator.index + 1 if component.counter_argument_present?
+      item_options[component.collection_iteration_parameter] = iterator if component.iteration_argument_present?
 
       @options.merge(item_options)
     end

--- a/test/app/components/collection_iteration_component.html.erb
+++ b/test/app/components/collection_iteration_component.html.erb
@@ -1,0 +1,6 @@
+<figure data-index="<%= @iteration.index %>" class="<%= "first" if @iteration.first? %>">
+  <img src="<%= @item.url %>" alt="<%= @item.title %>" />
+  <figcaption>
+    Photo.<%= @counter %> - <%= @item.caption %>
+  </figcaption>
+<figure>

--- a/test/app/components/collection_iteration_component.rb
+++ b/test/app/components/collection_iteration_component.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class CollectionIterationComponent < ViewComponent::Base
+  with_collection_parameter :item
+
+  def initialize(item:, item_iteration:)
+    @item = item
+    @iteration = item_iteration
+    @counter = @iteration.index + 1
+  end
+end

--- a/test/app/components/product_component.html.erb
+++ b/test/app/components/product_component.html.erb
@@ -1,6 +1,6 @@
 <li>
   <h1>Product</h1>
-  <h2><%= @product.name %></h2>
+  <h2 class="<%= "first" if @iteration&.first? %>"><%= @product.name %></h2>
   <p><%= @notice %></p>
   <p><%= @product.name %> counter: <%= @counter %></p>
 </li>

--- a/test/app/components/product_component.rb
+++ b/test/app/components/product_component.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
 class ProductComponent < ViewComponent::Base
-  def initialize(product:, notice:, product_counter: nil)
+  def initialize(product:, notice:, product_counter: nil, product_iteration: nil)
     @product = product
     @notice  = notice
     @counter = product_counter
+    @iteration = product_iteration
   end
 end

--- a/test/view_component/view_component_test.rb
+++ b/test/view_component/view_component_test.rb
@@ -563,8 +563,8 @@ class ViewComponentTest < ViewComponent::TestCase
     render_inline(ProductComponent.with_collection(products, notice: "On sale"))
 
     assert_selector("h1", text: "Product", count: 2)
-    assert_selector("h2", text: "Radio clock")
-    assert_selector("h2", text: "Mints")
+    assert_selector("h2.first", text: "Radio clock")
+    assert_selector("h2:not(.first)", text: "Mints")
     assert_selector("p", text: "On sale", count: 2)
     assert_selector("p", text: "Radio clock counter: 1")
     assert_selector("p", text: "Mints counter: 2")
@@ -589,6 +589,20 @@ class ViewComponentTest < ViewComponent::TestCase
     assert_selector("figcaption", text: "Photo.1 - Yellow flowers")
 
     assert_selector("figure[data-index=1]", { count: 1 })
+    assert_selector("figcaption", text: "Photo.2 - Mountains at sunset")
+  end
+
+  def test_render_collection_custom_collection_parameter_name_iteration
+    photos = [
+      OpenStruct.new(title: "Flowers", caption: "Yellow flowers", url: "https://example.com/flowers.jpg"),
+      OpenStruct.new(title: "Mountains", caption: "Mountains at sunset", url: "https://example.com/mountains.jpg")
+    ]
+    render_inline(CollectionIterationComponent.with_collection(photos))
+
+    assert_selector("figure.first[data-index=0]", { count: 1 })
+    assert_selector("figcaption", text: "Photo.1 - Yellow flowers")
+
+    assert_selector("figure[data-index=1]:not(.first)", { count: 1 })
     assert_selector("figcaption", text: "Photo.2 - Mountains at sunset")
   end
 


### PR DESCRIPTION
Closes #939

<!-- See https://github.com/github/view_component/blob/main/CONTRIBUTING.md#submitting-a-pull-request -->

### Summary

This adds support for a `{collection_name}_iteration` named parameter for the component initializer. It will automatically be populated with the current collection iteration object, which responds to methods: `first?`, `last?`, `index`, and `size`.

This keeps things more in line with Rails' own partial collection rendering, which exposes both a `{collection_name}_counter` and a `{collection_name}_iteration` local variable to the partials being rendered.

### Other Information

I added docs and a changelog entry in separate commits in case they weren't wanted.
