### PR TITLE
add docs, test for #with_variant

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -35,6 +35,10 @@ The current controller. Use sparingly as doing so introduces coupling that inhib
 
 A proxy through which to access helpers. Use sparingly as doing so introduces coupling that inhibits encapsulation & reuse, often making testing difficult.
 
+### #with_variant(variant) → [self]
+
+Use the provided variant instead of the one determined by the current request.
+
 ### #request → [ActionDispatch::Request]
 
 The current request. Use sparingly as doing so introduces coupling that inhibits encapsulation & reuse, often making testing difficult.

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -136,6 +136,7 @@ module ViewComponent
     # This prevents an exception when rendering a partial inside of a component that has also been rendered outside
     # of the component. This is due to the partials compiled template method existing in the parent `view_context`,
     #  and not the component's `view_context`.
+    #
     # @private
     def render(options = {}, args = {}, &block)
       if options.is_a? ViewComponent::Base
@@ -162,6 +163,7 @@ module ViewComponent
     end
 
     # Exposes .virtual_path as an instance method
+    #
     # @private
     def virtual_path
       self.class.virtual_path
@@ -174,6 +176,7 @@ module ViewComponent
     end
 
     # For caching, such as #cache_if
+    #
     # @private
     def format
       # Ruby 2.6 throws a warning without checking `defined?`, 2.7 does not
@@ -183,6 +186,7 @@ module ViewComponent
     end
 
     # Assign the provided content to the content area accessor
+    #
     # @private
     def with(area, content = nil, &block)
       unless content_areas.include?(area)

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -201,7 +201,10 @@ module ViewComponent
       nil
     end
 
-    # @private TODO: add documentation
+    # Use the provided variant instead of the one determined by the current request.
+    #
+    # @param variant [Symbol] The variant to be used by the component.
+    # @return [self]
     def with_variant(variant)
       @variant = variant
 

--- a/test/generators/component_generator_test.rb
+++ b/test/generators/component_generator_test.rb
@@ -8,7 +8,7 @@ Rails.application.load_generators
 
 class ComponentGeneratorTest < Rails::Generators::TestCase
   tests Rails::Generators::ComponentGenerator
-  destination File.expand_path("../../tmp", __dir__)
+  destination Dir.mktmpdir
   setup :prepare_destination
 
   arguments %w[user]

--- a/test/generators/component_generator_test.rb
+++ b/test/generators/component_generator_test.rb
@@ -8,7 +8,7 @@ Rails.application.load_generators
 
 class ComponentGeneratorTest < Rails::Generators::TestCase
   tests Rails::Generators::ComponentGenerator
-  destination File.expand_path("../tmp", __dir__)
+  destination File.expand_path("../../tmp", __dir__)
   setup :prepare_destination
 
   arguments %w[user]

--- a/test/generators/erb_generator_test.rb
+++ b/test/generators/erb_generator_test.rb
@@ -8,7 +8,7 @@ Rails.application.load_generators
 
 class ErbGeneratorTest < Rails::Generators::TestCase
   tests Erb::Generators::ComponentGenerator
-  destination File.expand_path("../tmp", __dir__)
+  destination File.expand_path("../../tmp", __dir__)
   setup :prepare_destination
 
   arguments %w[user]

--- a/test/generators/erb_generator_test.rb
+++ b/test/generators/erb_generator_test.rb
@@ -8,7 +8,7 @@ Rails.application.load_generators
 
 class ErbGeneratorTest < Rails::Generators::TestCase
   tests Erb::Generators::ComponentGenerator
-  destination File.expand_path("../../tmp", __dir__)
+  destination Dir.mktmpdir
   setup :prepare_destination
 
   arguments %w[user]

--- a/test/generators/haml_generator_test.rb
+++ b/test/generators/haml_generator_test.rb
@@ -8,7 +8,7 @@ Rails.application.load_generators
 
 class HamlGeneratorTest < Rails::Generators::TestCase
   tests Haml::Generators::ComponentGenerator
-  destination File.expand_path("../../tmp", __dir__)
+  destination Dir.mktmpdir
   setup :prepare_destination
 
   arguments %w[user]

--- a/test/generators/haml_generator_test.rb
+++ b/test/generators/haml_generator_test.rb
@@ -8,7 +8,7 @@ Rails.application.load_generators
 
 class HamlGeneratorTest < Rails::Generators::TestCase
   tests Haml::Generators::ComponentGenerator
-  destination File.expand_path("../tmp", __dir__)
+  destination File.expand_path("../../tmp", __dir__)
   setup :prepare_destination
 
   arguments %w[user]

--- a/test/generators/slim_generator_test.rb
+++ b/test/generators/slim_generator_test.rb
@@ -8,7 +8,7 @@ Rails.application.load_generators
 
 class SlimGeneratorTest < Rails::Generators::TestCase
   tests Slim::Generators::ComponentGenerator
-  destination File.expand_path("../tmp", __dir__)
+  destination File.expand_path("../../tmp", __dir__)
   setup :prepare_destination
 
   arguments %w[user]

--- a/test/generators/slim_generator_test.rb
+++ b/test/generators/slim_generator_test.rb
@@ -8,7 +8,7 @@ Rails.application.load_generators
 
 class SlimGeneratorTest < Rails::Generators::TestCase
   tests Slim::Generators::ComponentGenerator
-  destination File.expand_path("../../tmp", __dir__)
+  destination Dir.mktmpdir
   setup :prepare_destination
 
   arguments %w[user]

--- a/test/view_component/test_unit_generator_test.rb
+++ b/test/view_component/test_unit_generator_test.rb
@@ -5,7 +5,7 @@ require_relative File.expand_path("../../../lib/rails/generators/test_unit/compo
 
 class ViewComponent::TestUnitGeneratorTest < ::Rails::Generators::TestCase
   tests TestUnit::Generators::ComponentGenerator
-  destination File.expand_path("../tmp", File.dirname(__FILE__))
+  destination File.expand_path("../../tmp", File.dirname(__FILE__))
   setup :prepare_destination
 
   setup do
@@ -13,7 +13,7 @@ class ViewComponent::TestUnitGeneratorTest < ::Rails::Generators::TestCase
   end
 
   teardown do
-    File.delete File.expand_path("../../tmp/test/components/dummy_component_test.rb", __FILE__)
+    File.delete File.expand_path("../../../tmp/test/components/dummy_component_test.rb", __FILE__)
   end
 
   def test_generates_component

--- a/test/view_component/test_unit_generator_test.rb
+++ b/test/view_component/test_unit_generator_test.rb
@@ -5,19 +5,15 @@ require_relative File.expand_path("../../../lib/rails/generators/test_unit/compo
 
 class ViewComponent::TestUnitGeneratorTest < ::Rails::Generators::TestCase
   tests TestUnit::Generators::ComponentGenerator
-  destination File.expand_path("../../tmp", File.dirname(__FILE__))
+  destination Dir.mktmpdir
   setup :prepare_destination
 
   setup do
     run_generator %w(Dummy data)
   end
 
-  teardown do
-    File.delete File.expand_path("../../../tmp/test/components/dummy_component_test.rb", __FILE__)
-  end
-
   def test_generates_component
-    assert_file "../tmp/test/components/dummy_component_test.rb" do |content|
+    assert_file "test/components/dummy_component_test.rb" do |content|
       assert_match(/render_inline\(DummyComponent.new\(message: "Hello, components!"\)\).css\("span"\).to_html/, content)
     end
   end

--- a/test/view_component/view_component_test.rb
+++ b/test/view_component/view_component_test.rb
@@ -163,6 +163,12 @@ class ViewComponentTest < ViewComponent::TestCase
     ActionController::Base.allow_forgery_protection = old_value
   end
 
+  def test_renders_component_with_variant_method
+    render_inline(VariantsComponent.new.with_variant(:phone))
+
+    assert_text("Phone")
+  end
+
   def test_renders_component_with_variant
     with_variant :phone do
       render_inline(VariantsComponent.new)


### PR DESCRIPTION
This PR adds documentation and a (missing 😱) test for `#with_variant`.

I also took the liberty of reconfiguring the generator specs to not create a `tmp` directory in the `test` folder, as it resulted in `bundle exec rake` running the generated tests on my machine.