### PR TITLE
Check for `#request` on the controller before attempting to call it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## main
 
-* Check for `#request` on the controller before attempting to call it
+* Fix bug where ViewComponents did not work in ActionMailers.
 
     *dark-panda*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## main
 
+* Check for `#request` on the controller before attempting to call it
+
+    *dark-panda*
+
 ## 2.33.0
 
 * Add support for `_iteration` parameter when rendering in a collection

--- a/app/views/test_mailer/test_email.html.erb
+++ b/app/views/test_mailer/test_email.html.erb
@@ -1,2 +1,1 @@
-
 <%= render MailerComponent.new %>

--- a/app/views/test_mailer/test_email.html.erb
+++ b/app/views/test_mailer/test_email.html.erb
@@ -1,0 +1,2 @@
+
+<%= render MailerComponent.new %>

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -208,7 +208,7 @@ module ViewComponent
     #
     # @return [ActionDispatch::Request]
     def request
-      @request ||= controller.request
+      @request ||= controller.request if controller.respond_to?(:request)
     end
 
     private

--- a/test/app/components/mailer_component.html.erb
+++ b/test/app/components/mailer_component.html.erb
@@ -1,0 +1,2 @@
+
+<div>Hello world!</div>

--- a/test/app/components/mailer_component.html.erb
+++ b/test/app/components/mailer_component.html.erb
@@ -1,2 +1,1 @@
-
 <div>Hello world!</div>

--- a/test/app/components/mailer_component.rb
+++ b/test/app/components/mailer_component.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class MailerComponent < ViewComponent::Base
+end

--- a/test/app/mailers/test_mailer.rb
+++ b/test/app/mailers/test_mailer.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class TestMailer < ActionMailer::Base
+  def test_email
+    mail(
+      from: "no-reply@example.com",
+      to: "test@example.com",
+      subject: "Testing ViewComponent in ActionMailer",
+    )
+  end
+end

--- a/test/config/application.rb
+++ b/test/config/application.rb
@@ -4,6 +4,7 @@ require File.expand_path("../boot", __FILE__)
 
 require "active_model/railtie"
 require "action_controller/railtie"
+require "action_mailer/railtie"
 require "action_view/railtie"
 require "view_component/engine"
 require "sprockets/railtie"

--- a/test/config/environments/test.rb
+++ b/test/config/environments/test.rb
@@ -32,7 +32,7 @@ Dummy::Application.configure do
   # Tell Action Mailer not to deliver emails to the real world.
   # The :test delivery method accumulates sent emails in the
   # ActionMailer::Base.deliveries array.
-  #config.action_mailer.delivery_method = :test
+  config.action_mailer.delivery_method = :test
 
   # Use SQL instead of Active Record's schema dumper when creating the test database.
   # This is necessary if your schema can't be completely dumped by the schema dumper,

--- a/test/view_component/mailer_test.rb
+++ b/test/view_component/mailer_test.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class MailerTest < ViewComponent::TestCase
+  def test_rendering_component_in_an_action_mailer
+    assert_includes TestMailer.test_email.deliver_now.body.raw_source, "<div>Hello world!</div>"
+  end
+end


### PR DESCRIPTION
Fix for #940 - Error when using a component in a mailer view

### Summary

ActionMailer controllers don't have a `#request`, so check to see that it exists before calling it.