### PR TITLE
Can set custom templates explicitly now.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## 2.33.0
 
+* Add support for custom `template` option
+
+    *Vikas Raveendran*
+
 * Add support for `_iteration` parameter when rendering in a collection
 
     *Will Cosgrove*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 ## main
 
-## 2.33.0
-
 * Add support for custom `template` option
 
     *Vikas Raveendran*
+
+## 2.33.0
 
 * Add support for `_iteration` parameter when rendering in a collection
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -78,6 +78,7 @@ ViewComponent is built by:
 <img src="https://avatars.githubusercontent.com/tenderlove?s=64" alt="tenderlove" width="32" />
 <img src="https://avatars.githubusercontent.com/tonkpils?s=64" alt="tonkpils" width="32" />
 <img src="https://avatars.githubusercontent.com/traels?s=64" alt="traels" width="32" />
+<img src="https://avatars.githubusercontent.com/vikks?s=64" alt="Vikas Raveendran" width="32" />
 <img src="https://avatars.githubusercontent.com/vinistock?s=64" alt="vinistock" width="32" />
 <img src="https://avatars.githubusercontent.com/xronos-i-am?s=64" alt="xronos-i-am" width="32" />
 <img src="https://avatars.githubusercontent.com/matheusrich?s=64" alt="matheusrich" width="32" />

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -243,6 +243,13 @@ module ViewComponent
     class << self
       attr_accessor :source_location, :virtual_path
 
+      # Explicitly set the template name when components are defined with
+      # sidecar flag
+      # @return [String]
+      def template(str)
+        @template ||= str
+      end
+
       # EXPERIMENTAL: This API is experimental and may be removed at any time.
       # Find sidecar files for the given extensions.
       #
@@ -259,6 +266,7 @@ module ViewComponent
         directory = File.dirname(source_location)
         filename = File.basename(source_location, ".rb")
         component_name = name.demodulize.underscore
+        template_name = @template || component_name
 
         # Add support for nested components defined in the same file.
         #
@@ -271,13 +279,13 @@ module ViewComponent
         #
         # Without this, `MyOtherComponent` will not look for `my_component/my_other_component.html.erb`
         nested_component_files = if name.include?("::") && component_name != filename
-          Dir["#{directory}/#{filename}/#{component_name}.*{#{extensions}}"]
+          Dir["#{directory}/#{filename}/#{template_name}.*{#{extensions}}"]
         else
           []
         end
 
         # view files in the same directory as the component
-        sidecar_files = Dir["#{directory}/#{component_name}.*{#{extensions}}"]
+        sidecar_files = Dir["#{directory}/#{template_name}.*{#{extensions}}"]
 
         sidecar_directory_files = Dir["#{directory}/#{component_name}/#{filename}.*{#{extensions}}"]
 

--- a/test/app/components/custom_template.html.erb
+++ b/test/app/components/custom_template.html.erb
@@ -1,0 +1,1 @@
+<div>Custom HTML Template</div>

--- a/test/app/components/custom_template.rb
+++ b/test/app/components/custom_template.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class CustomTemplate < ViewComponent::Base
+  template "custom_template"
+end

--- a/test/view_component/view_component_test.rb
+++ b/test/view_component/view_component_test.rb
@@ -13,6 +13,12 @@ class ViewComponentTest < ViewComponent::TestCase
     assert_includes render_inline(MyComponent.new).css("div").to_html, "hello,world!"
   end
 
+  def test_custom_template
+    render_inline(CustomTemplate.new)
+
+    assert_includes rendered_component, "Custom HTML Template"
+  end
+
   def test_render_inline_sets_rendered_component
     render_inline(MyComponent.new)
 


### PR DESCRIPTION
### Summary

When working with many components, having an option to name custom templates and set them in 
the components makes editing and fixing code much easier rather than having to double check every time
a template file is opened for editing.

```ruby
# app/components/image/component.rb

class Image::Component < ViewComponent::Base
  # Uses app/components/image/image_template.html.erb
  template "image_template"
end
```
```ruby
# app/components/image/component.rb

class Button::Component < ViewComponent::Base
  # Uses the default app/components/button/component.html.erb
end
```
```
components/
   button/
     component.html.erb
     component.rb
   image/
     image_template.html.erb
     component.rb  
     controller.js
```

### Other Information

Added test files for CustomTemplate component and its corresponding html template.
