### PR TITLE
use Bundler v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,6 @@ jobs:
         key: gems-build-rails-main-ruby-2.7.2-${{ hashFiles('**/Gemfile.lock') }}
     - name: Lint with Rubocop
       run: |
-        gem install bundler:1.17.3
         bundle config path vendor/bundle
         bundle install --jobs 4 --retry 3
         bundle exec rubocop
@@ -35,18 +34,12 @@ jobs:
     strategy:
       matrix:
         rails_version: [5.2.5, 6.0.3.6, 6.1.3.1, main]
-        ruby_version: [2.4.10, 2.5.8, 2.6.6, 2.7.2, 3.0.0]
+        ruby_version: [2.5.8, 2.6.6, 2.7.2, 3.0.0]
         exclude:
           - rails_version: 5.2.5
             ruby_version: 3.0.0
           - rails_version: 6.0.3.6
             ruby_version: 3.0.0
-          - rails_version: 6.0.3.6
-            ruby_version: 2.4.10
-          - rails_version: 6.1.3.1
-            ruby_version: 2.4.10
-          - rails_version: main
-            ruby_version: 2.4.10
           - rails_version: main
             ruby_version: 2.5.8
           - rails_version: main
@@ -57,17 +50,12 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby_version }}
-    - name: Update rubygems when testing with Ruby 2.4.10
-      if: startsWith(matrix.ruby_version, '2.4')
-      run: |
-        gem update --system --no-document
     - uses: actions/cache@v2
       with:
         path: vendor/bundle
         key: gems-build-rails-${{ matrix.rails_version }}-ruby-${{ matrix.ruby_version }}-${{ hashFiles('**/Gemfile.lock') }}
     - name: Build and test with Rake
       run: |
-        gem install bundler:1.17.3
         bundle config path vendor/bundle
         bundle update
         bundle exec rake
@@ -108,7 +96,6 @@ jobs:
       run: |
         cd primer_view_components
         yarn install
-        gem install bundler:2.2.9
         bundle config path vendor/bundle
         bundle update
         bundle exec rake docs:preview
@@ -132,7 +119,6 @@ jobs:
         key: gems-build-rails-main-ruby-2.7.2-${{ hashFiles('**/Gemfile.lock') }}
     - name: Collate simplecov
       run: |
-        gem install bundler:1.17.3
         bundle config path vendor/bundle
         bundle install --jobs 4 --retry 3
         bundle exec rake coverage:report

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,14 @@
 
 _This project is intended to be a safe, welcoming space for collaboration. Contributors are expected to adhere to the Contributor Covenant code of conduct._
 
+ViewComponent would only be a shadow of what it is today if it weren't for the work of people like you. Thank you for your interest in contributing and we look forward to
+
+How you can help
+
+open a PR
+file a bug fix issue
+share how you're using ViewComponent in a discussion
+
 Hi there! We're thrilled that you'd like to contribute to this project. Your help is essential for keeping it great.
 
 If you have any substantial changes that you would like to make, please [open an issue](http://github.com/github/view_component/issues/new) first to discuss them with us.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,14 +2,6 @@
 
 _This project is intended to be a safe, welcoming space for collaboration. Contributors are expected to adhere to the Contributor Covenant code of conduct._
 
-ViewComponent would only be a shadow of what it is today if it weren't for the work of people like you. Thank you for your interest in contributing and we look forward to
-
-How you can help
-
-open a PR
-file a bug fix issue
-share how you're using ViewComponent in a discussion
-
 Hi there! We're thrilled that you'd like to contribute to this project. Your help is essential for keeping it great.
 
 If you have any substantial changes that you would like to make, please [open an issue](http://github.com/github/view_component/issues/new) first to discuss them with us.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -235,4 +235,4 @@ DEPENDENCIES
   yard (~> 0.9.25)
 
 BUNDLED WITH
-   1.17.3
+   2.2.17

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -7,7 +7,7 @@ title: Compatibility
 
 ViewComponent is [supported natively](https://edgeguides.rubyonrails.org/layouts_and_rendering.html#rendering-objects) in Rails 6.1, and compatible with Rails 5.0+ via an included [monkey patch](https://github.com/github/view_component/blob/main/lib/view_component/render_monkey_patch.rb).
 
-ViewComponent is tested for compatibility [with combinations of](https://github.com/github/view_component/blob/22e3d4ccce70d8f32c7375e5a5ccc3f70b22a703/.github/workflows/ruby_on_rails.yml#L10-L11) Ruby 2.4+ and Rails 5+.
+ViewComponent is tested for compatibility [with combinations of](https://github.com/github/view_component/blob/22e3d4ccce70d8f32c7375e5a5ccc3f70b22a703/.github/workflows/ruby_on_rails.yml#L10-L11) Ruby v2.5+ and Rails v5+. Ruby 2.4 is likely compatible, but is no longer tested.
 
 ## Disabling the render monkey patch (Rails < 6.1)
 

--- a/view_component.gemspec
+++ b/view_component.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency     "activesupport", [">= 5.0.0", "< 7.0"]
   spec.add_development_dependency "benchmark-ips", "~> 2.8.2"
-  spec.add_development_dependency "bundler", "~> 1.14"
+  spec.add_development_dependency "bundler", "~> 2.2"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "minitest", "= 5.6.0"
   spec.add_development_dependency "haml", "~> 5"


### PR DESCRIPTION
I think it's time for us to move to Bundler v2. Having both
v1 and v2 in our CI workflow has been a source of headaches
and friction for some time. Seeing it trip up @boardfish
in https://github.com/github/view_component/pull/958 was
the last straw for me.

There are also now security concerns around Bundler v1
that to my knowledge are unresolved.

Removing Bundler v1 means that we can't easily test
Ruby 2.4 in CI. I'm OK with this, as we've never had a 2.4
compatibility issue caught by running against it.