### PR TITLE
Add basic description of roles on the ViewComponent project

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ Committers and maintainers may also nominate triagers by opening a pull request 
 
 ViewComponent committers have `write` access, enabling them to push directly to the repository and approve/merge pull requests. Committers often have implicit ownership over a particular area of the project, such as previews, generators, or translations.
 
-Triagers are invited to become committers by having an existing committer or maintainer open a pull request on the repository to update this list of Committers:
+Triagers are invited to become committers by having an existing committer or maintainer open a pull request on the repository to update this list of committers:
 
 The committers team is @elia, @jonspalmer, @juanmanuelramallo, @rmacklin, and @spone.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,25 +12,29 @@ Contributions to this project are [released](https://help.github.com/articles/gi
 
 ### Triager
 
-ViewComponent triagers are able to manage issues and pull requests (such as assigning owners and labels, closing issues and marking duplicates)
+ViewComponent triagers are able to manage issues and pull request by assigning owners and labels, closing issues and marking duplicates.
 
-After showing interest in helping with the project by participating in issues, pull requests, and/or discussions, members of the community are welcome to request Triage access by opening an issue on the repository. Committers and Maintainers may also nominate Triagers through opening an issue on the repository.
+After helping with the project by participating in issues, pull requests, and/or discussions, members of the community are welcome to request triage access by opening a pull request to update this list:
+
+The triagers team is @andrewmcodes, @bbugh, @cesariouy, @dark-panda, @dylnclrk, @g13ydson, @horacio, @jcoyne, @johannesengl, @kaspermeyer, @mellowfish, @metade, @nashby, @rainerborene, @rdavid1099, @spdawson, and @vinistock.
+
+Committers and maintainers may also nominate triagers by opening a pull request to update this list.
 
 ### Committer
 
-ViewComponent committers have `write` access, enabling them to push directly to the repository and approve/merge pull requests.
+ViewComponent committers have `write` access, enabling them to push directly to the repository and approve/merge pull requests. Committers often have implicit ownership over a particular area of the project, such as previews, generators, or translations.
 
-Triagers are invited to become Committers by having an existing Committer or Maintainer open a PR on the repository to update this list of Committers:
+Triagers are invited to become committers by having an existing committer or maintainer open a pull request on the repository to update this list of Committers:
 
-The committers team is @jonspalmer, @elia, @juanmanuelramallo, @rmacklin, and @spone.
+The committers team is @elia, @jonspalmer, @juanmanuelramallo, @rmacklin, and @spone.
 
 ### Maintainer
 
-ViewComponent maintainers have `admin` access, enabling them to manage repository settings including access levels. They also have ownership of `view_component` on RubyGems and are required to have 2FA enabled for their accounts to minimize the risk of supply chain security issues.
+ViewComponent maintainers have `admin` access, enabling them to manage repository settings including access levels. They also have ownership of `view_component` on RubyGems and are required to have 2FA enabled for their GitHub and RubyGems accounts.
 
 Maintainership is open by invitation only at this time.
 
-The maintainers team is @blakewilliams, @manuelpuyol, @jonrohan, and @joelhawksley.
+The maintainers team is @blakewilliams, @joelhawksley, @jonrohan, and @manuelpuyol.
 
 ## Submitting a pull request
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,13 +10,13 @@ Contributions to this project are [released](https://help.github.com/articles/gi
 
 ## Roles
 
-**Triager**
+### Triager
 
 ViewComponent triagers are able to manage issues and pull requests.
 
 After showing interest in helping with the project by participating in issues, pull requests, and/or discussions, members of the community are welcome to request Triage access by opening an issue on the repository. Committers and Maintainers may also nominate Triagers through opening an issue on the repository.
 
-**Committer**
+### Committer
 
 ViewComponent committers have `write` access, enabling them to push directly to the repository and approve/merge pull requests.
 
@@ -24,7 +24,7 @@ Triagers are invited to become Committers by having an existing Committer or Mai
 
 The committers team is @jonspalmer, @elia, @juanmanuelramallo, @rmacklin, and @spone.
 
-**Maintainer**
+### Maintainer
 
 ViewComponent maintainers have `admin` access, enabling them to manage repository settings including access levels. They also have ownership of `view_component` on RubyGems and are required to have 2FA enabled for their accounts to minimize the risk of supply chain security issues.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ Contributions to this project are [released](https://help.github.com/articles/gi
 
 ### Triager
 
-ViewComponent triagers are able to manage issues and pull requests.
+ViewComponent triagers are able to manage issues and pull requests (such as assigning owners and labels, closing issues and marking duplicates)
 
 After showing interest in helping with the project by participating in issues, pull requests, and/or discussions, members of the community are welcome to request Triage access by opening an issue on the repository. Committers and Maintainers may also nominate Triagers through opening an issue on the repository.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-_This project is intended to be a safe, welcoming space for collaboration. Contributors are expected to adhere to the Contributor Covenant code of conduct._
+_This project is intended to be a safe, welcoming space for collaboration. By participating in this project you agree to abide by the [Contributor Code of Conduct](CODE_OF_CONDUCT.md)._
 
 Hi there! We're thrilled that you'd like to contribute to this project. Your help is essential for keeping it great.
 
@@ -8,7 +8,29 @@ If you have any substantial changes that you would like to make, please [open an
 
 Contributions to this project are [released](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) to the public under the [project's open source license](LICENSE.txt).
 
-Please note that this project is released with a [Contributor Code of Conduct](CODE_OF_CONDUCT.md). By participating in this project you agree to abide by its terms.
+## Roles
+
+**Triager**
+
+ViewComponent triagers are able to manage issues and pull requests.
+
+After showing interest in helping with the project by participating in issues, pull requests, and/or discussions, members of the community are welcome to request Triage access by opening an issue on the repository. Committers and Maintainers may also nominate Triagers through opening an issue on the repository.
+
+**Committer**
+
+ViewComponent committers have `write` access, enabling them to push directly to the repository and approve/merge pull requests.
+
+Triagers are invited to become Committers by having an existing Committer or Maintainer open a PR on the repository to update this list of Committers:
+
+The committers team is @jonspalmer, @elia, @juanmanuelramallo, @rmacklin, and @spone.
+
+**Maintainer**
+
+ViewComponent maintainers have `admin` access, enabling them to manage repository settings including access levels. They also have ownership of `view_component` on RubyGems and are required to have 2FA enabled for their accounts to minimize the risk of supply chain security issues.
+
+Maintainership is open by invitation only at this time.
+
+The maintainers team is @blakewilliams, @manuelpuyol, @jonrohan, and @joelhawksley.
 
 ## Submitting a pull request
 


### PR DESCRIPTION
In the interest of encouraging folks to contribute to ViewComponent,
I've outlined the current roles people generally fall into on the
project, along with some basic guidelines for how I think it might
make sense to manage membership of the project.