### PR TITLE
Use single @output_buffer when rendering

### DIFF
--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -10,6 +10,53 @@ require "view_component/slotable"
 require "view_component/slotable_v2"
 require "view_component/with_content_helper"
 
+class ActionView::Base
+  attr_reader :children
+  attr_accessor :parent
+
+  def _prepare_context
+    @children = []
+    @parent = nil
+
+    super
+  end
+
+  def set_output_buffer(buf)
+    @output_buffer = buf
+  end
+
+  def output_buffer=(buf)
+    if parent.nil?
+      set_output_buffer_for_children(buf)
+    else
+      top_level_parent.set_output_buffer_for_children(buf)
+    end
+  end
+
+  def top_level_parent
+    return if parent.nil?
+    return @_top_level_parent if defined?(@_top_level_parent)
+
+    @_top_level_parent = begin
+      top_level = parent
+
+      while top_level.parent
+        top_level = top_level.parent
+      end
+
+      top_level
+    end
+  end
+
+  def set_output_buffer_for_children(buf)
+    set_output_buffer(buf)
+
+    children.each do |child|
+      child.set_output_buffer(buf)
+    end
+  end
+end
+
 module ViewComponent
   class Base < ActionView::Base
     include ActiveSupport::Configurable
@@ -92,10 +139,17 @@ module ViewComponent
       @__vc_content_evaluated = false
       @__vc_render_in_block = block
 
+      self.parent = view_context
+
+      top_level_parent = @_top_level_parent = parent&.top_level_parent || parent
+      top_level_parent.output_buffer ||= ActionView::OutputBuffer.new
+      @output_buffer = top_level_parent.output_buffer
+      top_level_parent.children << self
+
       before_render
 
       if render?
-        render_template_for(@__vc_variant).to_s + _output_postamble
+        capture { render_template_for(@__vc_variant).to_s + _output_postamble }
       else
         ""
       end

--- a/lib/view_component/collection.rb
+++ b/lib/view_component/collection.rb
@@ -12,11 +12,13 @@ module ViewComponent
 
       component.validate_collection_parameter!(validate_default: true)
 
-      @collection.map do |item|
-        content = component.new(**component_options(item, iterator)).render_in(view_context, &block)
-        iterator.iterate!
-        content
-      end.join.html_safe # rubocop:disable Rails/OutputSafety
+      view_context.capture do
+        @collection.map do |item|
+          content = component.new(**component_options(item, iterator)).render_in(view_context, &block)
+          iterator.iterate!
+          content
+        end.join.html_safe # rubocop:disable Rails/OutputSafety
+      end
     end
 
     private

--- a/lib/view_component/compiler.rb
+++ b/lib/view_component/compiler.rb
@@ -41,9 +41,8 @@ module ViewComponent
         method_name = call_method_name(template[:variant])
         component_class.send(:undef_method, method_name.to_sym) if component_class.instance_methods.include?(method_name.to_sym)
 
-        component_class.class_eval <<-RUBY, template[:path], -1
+        component_class.class_eval <<-RUBY, template[:path], 0
           def #{method_name}
-            @output_buffer = ActionView::OutputBuffer.new
             #{compiled_template(template[:path])}
           end
         RUBY

--- a/performance/benchmark.rb
+++ b/performance/benchmark.rb
@@ -15,14 +15,19 @@ class BenchmarksController < ActionController::Base
 end
 
 BenchmarksController.view_paths = [File.expand_path("./views", __dir__)]
-controller_view = BenchmarksController.new.view_context
 
 Benchmark.ips do |x|
   x.time = 10
   x.warmup = 2
 
-  x.report("component:") { controller_view.render(NameComponent.new(name: "Fox Mulder")) }
-  x.report("partial:") { controller_view.render("partial", name: "Fox Mulder") }
+  x.report("component:") {
+    controller_view = BenchmarksController.new.view_context
+    controller_view.render(NameComponent.new(name: "Fox Mulder"))
+  }
+  x.report("partial:") {
+    controller_view = BenchmarksController.new.view_context
+    controller_view.render("partial", name: "Fox Mulder")
+  }
 
   x.compare!
 end

--- a/test/app/components/form_for_component.html.erb
+++ b/test/app/components/form_for_component.html.erb
@@ -1,0 +1,3 @@
+<%= form_for Post.new, url: "/" do |form| %>
+  <%= render LabelComponent.new(form: form) %>
+<% end %>

--- a/test/app/components/form_for_component.rb
+++ b/test/app/components/form_for_component.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class FormForComponent < ViewComponent::Base
+  def initialize
+  end
+end

--- a/test/app/components/form_with_component.html.erb
+++ b/test/app/components/form_with_component.html.erb
@@ -1,0 +1,3 @@
+<%= form_with Post.new, url: "/" do |form| %>
+  <%= render LabelComponent.new(form: form) %>
+<% end %>

--- a/test/app/components/form_with_component.rb
+++ b/test/app/components/form_with_component.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class FormWithComponent < ViewComponent::Base
+  def initialize
+  end
+end

--- a/test/app/components/incompatible_form_component.html.erb
+++ b/test/app/components/incompatible_form_component.html.erb
@@ -1,0 +1,3 @@
+<%= form_for Post.new, url: "/" do |form| %>
+  <%= render LabelComponent.new(form: form) %>
+<% end %>

--- a/test/app/components/incompatible_form_component.rb
+++ b/test/app/components/incompatible_form_component.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class IncompatibleFormComponent < ViewComponent::Base
+  def initialize
+  end
+end

--- a/test/app/components/label_component.html.erb
+++ b/test/app/components/label_component.html.erb
@@ -1,0 +1,5 @@
+<div>
+  <%= form.label :published do %>
+    <%= form.check_box :published %>
+  <% end %>
+</div>

--- a/test/app/components/label_component.rb
+++ b/test/app/components/label_component.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class LabelComponent < ViewComponent::Base
+  def initialize(form:)
+    @form = form
+  end
+
+  private
+
+  attr_reader :form
+end

--- a/test/app/models/post.rb
+++ b/test/app/models/post.rb
@@ -3,5 +3,5 @@
 class Post
   include ActiveModel::Model
 
-  attr_accessor :title
+  attr_accessor :title, :published
 end

--- a/test/view_component/action_view_compatibility_test.rb
+++ b/test/view_component/action_view_compatibility_test.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ViewComponent::ActionViewCompatibilityTest < ViewComponent::TestCase
+  def test_renders_form_for_labels_with_block_correctly
+    render_inline(FormForComponent.new)
+
+    assert_selector("form > div > label > input")
+    refute_selector("form > div > input")
+  end
+
+  def test_renders_form_with_labels_with_block_correctly
+    render_inline(FormForComponent.new)
+
+    assert_selector("form > div > label > input")
+    refute_selector("form > div > input")
+  end
+
+  def test_form_without_compatability_does_not_raise
+    render_inline(IncompatibleFormComponent.new)
+
+    # Bad selector should be present, at least until fixed upstream or included by default
+    refute_selector("form > div > input")
+  end
+end


### PR DESCRIPTION
When rendering components we sometimes run into incompatibilities with
Rails due to Rails expecting a single `@output_buffer` when rendering
templates. This isn't true when using view components due to each
component having its own `@output_buffer`.

The most obvious issue I've run into due us not having a single
`@output_buffer` can be recreated by repeating the following:

1. Create a form using `form_for`
2. Pass the `f` variable to a component
3. Call `f.label` while passing it a block

This will cause the block content to be rendered incorrectly, usually
above the resulting `<label>` tag.

The tl;dr of that behavior is that `form_for` captures the
`view_context` of the template it's called in. When trying to evaluate
the block passed to `f.label` it calls `view_context.capture` *but* the
block was defined and is run in the context of the component, not
`view_context`! This causes the block content to be rendered in the
component's `@output_buffer` (since it's not capturing).

This attempts to resolve the issue by tracking and using a single
`@output_buffer`. When a component is rendered we find the top-level
`ActionView::Base` instance in the render hierarchy and use its
`@output_buffer`. We then tell the top-level renderer that we are one of
its children.

Now, when *any* `ActionView::Base` instance in the rendering hierarchy
changes its `@output_buffer`, it propagates that change to all
`ActionView::Base` instances. This matches Rails' expectations and
results in the previously broken behavior working as-expected.
