### PR TITLE
Update Stimulus controller load folder reference

### DIFF
--- a/docs/guide/sidecar_assets.md
+++ b/docs/guide/sidecar_assets.md
@@ -118,9 +118,12 @@ customElements.define('my-comment', Comment)
 
 ## Stimulus
 
-In Stimulus, create a 1:1 mapping between a Stimulus controller and a component. In order to load in Stimulus controllers from the `app/components` tree, amend the Stimulus boot code in `app/javascript/packs/application.js`:
+In Stimulus, create a 1:1 mapping between a Stimulus controller and a component. In order to load in Stimulus controllers from the `app/components` tree, amend the Stimulus boot code in `app/javascript/controllers/index.js`:
 
 ```js
+import { Application } from "stimulus"
+import { definitionsFromContext } from "stimulus/webpack-helpers"
+
 const application = Application.start()
 const context = require.context("controllers", true, /\.js$/)
 const contextComponents = require.context("../../components", true, /_controller\.js$/)


### PR DESCRIPTION
<!-- See https://github.com/github/view_component/blob/main/CONTRIBUTING.md#submitting-a-pull-request -->

### Summary

When bootstrapping an app with `rails new --minimal` and installing Stimulus via `stimulus-rails`, this is the path to the file that needs to be changed.

There's not a linked issue for this - I saw the change and decided to propose it.

### To replicate

```
rails new --minimal -T=stimulus
# Possibly not necessary
# bundle add hotwire-rails
# touch config/cable.yml
# rails hotwire:install
```
