### PR TITLE
Allow accessing slot arguments via new args method

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,10 @@ title: Changelog
 
 ## main
 
+* Add support for slot arguments
+
+    *dkniffin*
+
 * Add @boardfish to Triage.
 
     *Joel Hawksley*

--- a/docs/guide/slots.md
+++ b/docs/guide/slots.md
@@ -29,10 +29,10 @@ To render a `renders_many` slot, iterate over the name of the slot:
 
 ```erb
 <%# blog_component.html.erb %>
-<h1><%= header %></h1>
+<h1 class="<%= header.args[:classes] %>"><%= header %></h1>
 
 <% posts.each do |post| %>
-  <%= post %>
+  <%= post.args.post %>
 <% end %>
 ```
 

--- a/lib/view_component/slot_v2.rb
+++ b/lib/view_component/slot_v2.rb
@@ -6,7 +6,7 @@ module ViewComponent
   class SlotV2
     include ViewComponent::WithContentHelper
 
-    attr_writer :__vc_component_instance, :__vc_content_block, :__vc_content
+    attr_writer :__vc_component_instance, :__vc_content_block, :__vc_content, :__vc_args, :__vc_kwargs
 
     def initialize(parent)
       @parent = parent
@@ -58,6 +58,17 @@ module ViewComponent
       end
 
       @content
+    end
+
+    # Allow access to slot arguments
+    def args
+      @args ||= begin
+        a = @__vc_kwargs
+        @__vc_args.each_with_index do |arg, i|
+          a[i] = arg
+        end
+        a
+      end
     end
 
     # Allow access to public component methods via the wrapper

--- a/lib/view_component/slotable_v2.rb
+++ b/lib/view_component/slotable_v2.rb
@@ -219,6 +219,10 @@ module ViewComponent
       # `view_context.capture` twice, which is slower
       slot.__vc_content_block = block if block_given?
 
+      # Used to allow access to slot arguments via SlotV2#args
+      slot.__vc_args = args
+      slot.__vc_kwargs = kwargs
+
       # If class
       if slot_definition[:renderable]
         slot.__vc_component_instance = slot_definition[:renderable].new(*args, **kwargs)

--- a/test/app/components/slots_v2_with_args_component.html.erb
+++ b/test/app/components/slots_v2_with_args_component.html.erb
@@ -1,0 +1,9 @@
+<div class="slot-with-arg">
+  <div class="arg-0"><%= slot_with_arg.args[0] %></div>
+  <div class="content"><%= slot_with_arg %></div>
+</div>
+
+<div class="slot-with-kwarg">
+  <div class="kwarg-a"><%= slot_with_kwarg.args[:a] %></div>
+  <div class="content"><%= slot_with_kwarg %></div>
+</div>

--- a/test/app/components/slots_v2_with_args_component.rb
+++ b/test/app/components/slots_v2_with_args_component.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class SlotsV2WithArgsComponent < ViewComponent::Base
+  renders_one :slot_with_arg
+  renders_one :slot_with_kwarg
+end

--- a/test/view_component/slotable_v2_test.rb
+++ b/test/view_component/slotable_v2_test.rb
@@ -50,6 +50,23 @@ class SlotsV2sTest < ViewComponent::TestCase
     assert_selector(".footer.text-blue")
   end
 
+  def test_renders_slots_with_args
+    render_inline(SlotsV2WithArgsComponent.new) do |component|
+      component.slot_with_arg("Arg 0") do
+        "Arg slot content"
+      end
+      component.slot_with_kwarg(a: "Kwarg a") do
+        "Kwarg slot content"
+      end
+    end
+
+    assert_selector(".slot-with-arg .arg-0", text: "Arg 0")
+    assert_selector(".slot-with-arg .content", text: "Arg slot content")
+
+    assert_selector(".slot-with-kwarg .kwarg-a", text: "Kwarg a")
+    assert_selector(".slot-with-kwarg .content", text: "Kwarg slot content")
+  end
+
   def test_renders_slots_in_inherited_components
     render_inline(InheritedSlotsV2Component.new(classes: "mt-4")) do |component|
       component.title do


### PR DESCRIPTION
### Summary

When using "generic" slots (aka, slots that are not classes or lambdas), it doesn't seem currently possible to access arguments passed to the slot. In this PR, I've added that ability.

For example, this is now possible, where it wasn't before:
```rb
# Usage:
render_inline(SlotsV2WithArgsComponent.new) do |component|
  component.slot_with_arg("Arg 0") do
    "Arg slot content"
  end
  component.slot_with_kwarg(a: "Kwarg a") do
    "Kwarg slot content"
  end
end
```

```rb
# app/components/slots_v2_with_args_component.rb
class SlotsV2WithArgsComponent < ViewComponent::Base
  renders_one :slot_with_arg
  renders_one :slot_with_kwarg
end
```

```erb
<%#  app/components/slots_v2_with_args_component.html.erb %>
<div class="slot-with-arg">
  <div class="arg-0"><%= slot_with_arg.args[0] %></div>
  <div class="content"><%= slot_with_arg %></div>
</div>

<div class="slot-with-kwarg">
  <div class="kwarg-a"><%= slot_with_kwarg.args[:a] %></div>
  <div class="content"><%= slot_with_kwarg %></div>
</div>
```
