### PR TITLE
Add view_component_path option to ViewComponent::Base

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,9 +7,9 @@ title: Changelog
 
 ## main
 
-* Make view_component_path config option available on ViewComponent::Base
+* Make view_component_path config option available on ViewComponent::Base.
 
-  *Matt-Yorkley*
+    *Matt-Yorkley*
 
 * Add @boardfish to Triage.
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,10 @@ title: Changelog
 
 ## main
 
+* Make view_component_path config option available on ViewComponent::Base
+
+  *Matt-Yorkley*
+
 * Add @boardfish to Triage.
 
     *Joel Hawksley*

--- a/docs/api.md
+++ b/docs/api.md
@@ -121,3 +121,11 @@ Set the controller used for testing components:
 
 Defaults to ApplicationController. Can also be configured on a per-test
 basis using `with_controller_class`.
+
+### #view_component_path
+
+Path for component files
+
+    config.view_component.view_component_path = "app/my_components"
+
+Defaults to "app/components".

--- a/lib/rails/generators/abstract_generator.rb
+++ b/lib/rails/generators/abstract_generator.rb
@@ -23,7 +23,7 @@ module ViewComponent
     end
 
     def component_path
-      Rails.application.config.view_component.view_component_path || "app/components"
+      ViewComponent::Base.view_component_path
     end
   end
 end

--- a/lib/rails/generators/component/component_generator.rb
+++ b/lib/rails/generators/component/component_generator.rb
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
 
+require "rails/generators/abstract_generator"
+
 module Rails
   module Generators
     class ComponentGenerator < Rails::Generators::NamedBase
+      include ViewComponent::AbstractGenerator
+
       source_root File.expand_path("templates", __dir__)
 
       argument :attributes, type: :array, default: [], banner: "attribute"
@@ -23,10 +27,6 @@ module Rails
 
       private
 
-      def file_name
-        @_file_name ||= super.sub(/_component\z/i, "")
-      end
-
       def parent_class
         defined?(ApplicationComponent) ? "ApplicationComponent" : "ViewComponent::Base"
       end
@@ -43,10 +43,6 @@ module Rails
 
       def initialize_call_method_for_inline?
         options["inline"]
-      end
-
-      def component_path
-        Rails.application.config.view_component.view_component_path || "app/components"
       end
     end
   end

--- a/lib/rails/generators/erb/component_generator.rb
+++ b/lib/rails/generators/erb/component_generator.rb
@@ -19,7 +19,6 @@ module Erb
       def copy_view_file
         super
       end
-
     end
   end
 end

--- a/lib/rails/generators/haml/component_generator.rb
+++ b/lib/rails/generators/haml/component_generator.rb
@@ -17,7 +17,6 @@ module Haml
       def copy_view_file
         super
       end
-
     end
   end
 end

--- a/lib/rails/generators/slim/component_generator.rb
+++ b/lib/rails/generators/slim/component_generator.rb
@@ -17,7 +17,6 @@ module Slim
       def copy_view_file
         super
       end
-
     end
   end
 end

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -249,6 +249,13 @@ module ViewComponent
     #
     mattr_accessor :show_previews_source, instance_writer: false, default: false
 
+    # Path for component files
+    #
+    #     config.view_component.view_component_path = "app/my_components"
+    #
+    # Defaults to "app/components".
+    mattr_accessor :view_component_path, instance_writer: false, default: "app/components"
+
     class << self
       # @private
       attr_accessor :source_location, :virtual_path

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -337,7 +337,9 @@ module ViewComponent
         child.source_location = caller_locations(1, 10).reject { |l| l.label == "inherited" }[0].absolute_path
 
         # Removes the first part of the path and the extension.
-        child.virtual_path = child.source_location.gsub(%r{(.*app/components)|(\.rb)}, "")
+        child.virtual_path = child.source_location.gsub(
+          %r{(.*#{Regexp.quote(ViewComponent::Base.view_component_path)})|(\.rb)}, ""
+        )
 
         super
       end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -52,10 +52,11 @@ def with_preview_controller(new_value)
 end
 
 def with_custom_component_path(new_value)
-  old_value = Rails.application.config.view_component.view_component_path
-  Rails.application.config.view_component.view_component_path = new_value
+  old_value = ViewComponent::Base.view_component_path
+  ViewComponent::Base.view_component_path = new_value
   yield
-  Rails.application.config.view_component.view_component_path = old_value
+ensure
+  ViewComponent::Base.view_component_path = old_value
 end
 
 def with_new_cache


### PR DESCRIPTION
<!-- See https://github.com/github/view_component/blob/main/CONTRIBUTING.md#submitting-a-pull-request -->

### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

Another little refactor proposal that came up while working on #980...

Exposes the (recently added) `view_component_path` option as an attribute on `ViewComponent::Base`. This clarifies the config option as the single source of truth for the components path and makes it more readily accessible from other parts of the engine (it's currently only used in generators, but would be useful elsewhere). It also makes the value slightly easier to modify in tests, because it's not tied to initialization.
