### PR TITLE
lock method_source at 1.0 to avoid open-ended dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,7 +89,7 @@ PATH
   specs:
     view_component (2.34.0)
       activesupport (>= 5.0.0, < 7.0)
-      method_source
+      method_source (~> 1.0)
 
 GEM
   remote: https://rubygems.org/

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,10 @@ title: Changelog
 
 ## main
 
+* Lock `method_source` at `1.0` to avoid open-ended dependency.
+
+    *Joel Hawksley*
+
 * Require all PRs to include changelog entries.
 
     *Joel Hawksley*

--- a/view_component.gemspec
+++ b/view_component.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.4.0"
 
   spec.add_runtime_dependency     "activesupport", [">= 5.0.0", "< 7.0"]
-  spec.add_runtime_dependency     "method_source"
+  spec.add_runtime_dependency     "method_source", "~> 1.0"
   spec.add_development_dependency "benchmark-ips", "~> 2.8.2"
   spec.add_development_dependency "bundler", "~> 2.2"
   spec.add_development_dependency "rake", "~> 13.0"


### PR DESCRIPTION
See title.