### PR TITLE
Increase activesupport upper bound from `< 7.0` to `< 8.0`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,7 +88,7 @@ PATH
   remote: .
   specs:
     view_component (2.34.0)
-      activesupport (>= 5.0.0, < 7.0)
+      activesupport (>= 5.0.0, < 8.0)
       method_source (~> 1.0)
 
 GEM

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,10 @@ title: Changelog
 
 ## main
 
+* Bump `activesupport` upper bound from `< 7.0` to `< 8.0`.
+
+    *Richard Macklin*
+
 * Add ERB Lint for a few basic rules.
 
     *Joel Hawksley*

--- a/view_component.gemspec
+++ b/view_component.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.4.0"
 
-  spec.add_runtime_dependency     "activesupport", [">= 5.0.0", "< 7.0"]
+  spec.add_runtime_dependency     "activesupport", [">= 5.0.0", "< 8.0"]
   spec.add_runtime_dependency     "method_source", "~> 1.0"
   spec.add_development_dependency "benchmark-ips", "~> 2.8.2"
   spec.add_development_dependency "better_html", "~> 1"


### PR DESCRIPTION
### Summary

We already test view_component against edge rails (i.e. rails 7 alpha), but the `< 7.0` constraint (which is satisfied by `7.0.0.alpha` but not by `7.0.0`) would prevent the gem from being installed once the official rails 7.0.0 release comes out. Since we intend to support view_component on rails 7, let's bump the gemspec constraint to allow it.