### PR TITLE
Fix references to documentation files that were moved into `docs/`

### DIFF
--- a/.github/pull-request-template.md
+++ b/.github/pull-request-template.md
@@ -1,4 +1,4 @@
-<!-- See https://github.com/github/view_component/blob/main/CONTRIBUTING.md#submitting-a-pull-request -->
+<!-- See https://github.com/github/view_component/blob/main/docs/CONTRIBUTING.md#submitting-a-pull-request -->
 
 ### Summary
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ See [viewcomponent.org](https://viewcomponent.org/) for documentation.
 
 ## Contributing
 
-This project is intended to be a safe, welcoming space for collaboration. Contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct. We recommend reading the [contributing guide](./CONTRIBUTING.md) as well.
+This project is intended to be a safe, welcoming space for collaboration. Contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct. We recommend reading the [contributing guide](./docs/CONTRIBUTING.md) as well.
 
 ## License
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,10 @@ title: Changelog
 
 ## main
 
+* Fix references to moved documentation files.
+
+    *Richard Macklin*
+
 * Ensure consistent indentation with Rubocop.
 
     *Joel Hawksley

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -20,7 +20,7 @@ Contributions to this project are [released](https://help.github.com/articles/gi
 1. Make sure the tests pass on your machine: `bundle exec rake`. (Run a subset of tests by supplying a file glob to the test command: `TEST="test/components/YOUR_COMPONENT_test.rb" bundle exec rake`)
 1. Create a new branch: `git checkout -b my-branch-name`.
 1. Make your change, add tests, and make sure the tests still pass.
-1. Add an entry to the top of `CHANGELOG.md` for your changes, no matter how small they are. We want to recognize your contribution!
+1. Add an entry to the top of `docs/CHANGELOG.md` for your changes, no matter how small they are. We want to recognize your contribution!
 2. If it's your first time contributing, add yourself to `docs/index.md`.
 3. Push to your fork and [submit a pull request](https://github.com/github/view_component/compare).
 4. Pat yourself on the back and wait for your pull request to be reviewed and merged.

--- a/view_component.gemspec
+++ b/view_component.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
       "public gem pushes."
   end
 
-  spec.files         = Dir["CHANGELOG.md", "LICENSE.txt", "README.md", "app/**/*", "lib/**/*"]
+  spec.files         = Dir["LICENSE.txt", "README.md", "app/**/*", "docs/CHANGELOG.md", "lib/**/*"]
   spec.require_paths = ["lib"]
 
   spec.required_ruby_version = ">= 2.4.0"


### PR DESCRIPTION
### Summary

We moved these files into `docs/` in https://github.com/github/view_component/pull/972 but there were a few lingering references that still assumed they were in the repository root, including the `files` list in the gemspec which would've bundled a broken symlink instead of the actual CHANGELOG with the gem.