### PR TITLE
Raise error on renders_many :contents

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,10 @@ title: Changelog
 
 ## main
 
+* Raise an error if the slot name for renders_many is :contents
+
+    *Simon Fish*
+
 ## 2.35.0
 
 * Only load assets for Preview source highlighting if previews are enabled.

--- a/lib/view_component/slotable_v2.rb
+++ b/lib/view_component/slotable_v2.rb
@@ -65,7 +65,7 @@ module ViewComponent
       #     <% end %>
       #   <% end %>
       def renders_one(slot_name, callable = nil)
-        validate_slot_name(slot_name)
+        validate_singular_slot_name(slot_name)
 
         define_method slot_name do |*args, **kwargs, &block|
           if args.empty? && kwargs.empty? && block.nil?
@@ -116,7 +116,7 @@ module ViewComponent
       #     <% end %>
       #   <% end %>
       def renders_many(slot_name, callable = nil)
-        validate_slot_name(slot_name)
+        validate_plural_slot_name(slot_name)
 
         singular_name = ActiveSupport::Inflector.singularize(slot_name)
 
@@ -174,11 +174,23 @@ module ViewComponent
         self.registered_slots[slot_name] = slot
       end
 
-      def validate_slot_name(slot_name)
+      def validate_plural_slot_name(slot_name)
+        if slot_name.to_sym == :contents
+          raise ArgumentError.new("#{slot_name} is not a valid slot name.")
+        end
+
+        raise_if_slot_registered(slot_name)
+      end
+
+      def validate_singular_slot_name(slot_name)
         if slot_name.to_sym == :content
           raise ArgumentError.new("#{slot_name} is not a valid slot name.")
         end
 
+        raise_if_slot_registered(slot_name)
+      end
+
+      def raise_if_slot_registered(slot_name)
         if self.registered_slots.key?(slot_name)
           # TODO remove? This breaks overriding slots when slots are inherited
           raise ArgumentError.new("#{slot_name} slot declared multiple times")

--- a/test/view_component/slotable_v2_test.rb
+++ b/test/view_component/slotable_v2_test.rb
@@ -313,6 +313,16 @@ class SlotsV2sTest < ViewComponent::TestCase
     assert_includes exception.message, "content is not a valid slot name"
   end
 
+  def test_component_raises_when_given_invalid_slot_name_for_has_many
+    exception = assert_raises ArgumentError do
+      Class.new(ViewComponent::Base) do
+        renders_many :contents
+      end
+    end
+
+    assert_includes exception.message, "contents is not a valid slot name"
+  end
+
   def test_renders_pass_through_slot_using_with_content
     component = SlotsV2Component.new
     component.title("some_argument").with_content("This is my title!")


### PR DESCRIPTION
<!-- See https://github.com/github/view_component/blob/main/docs/CONTRIBUTING.md#submitting-a-pull-request -->

### Summary

If `renders_many :contents` is called, you'd have to use the slot like this:

```html.erb
<%= render Component.new do |c| %>
  <% c.content %>
<% end %>
```

Calling `content` here calls the private method `content` that already exists on the component.

Related to #976 