### PR TITLE
[ADR] Remove suffix from naming conventions

### DIFF
--- a/adr/0002-naming-conventions-for-view-components.md
+++ b/adr/0002-naming-conventions-for-view-components.md
@@ -1,0 +1,26 @@
+# 2. Naming conventions for ViewComponents
+
+Date: 2021-07-13
+
+## Status
+
+Proposed
+
+## Context
+
+The `Component` suffix has been questioned a few times. Based on our ViewComponents at GitHub and those shared on the ViewComponent repo, it looks like the namespaces used are unique even when the `Component` suffix is removed. This is due to following the naming convention of views, which is to use the plural paths in the namespace. e.g. `users/index.html.erb` -> `Users::IndexComponent`/`Users::Index`.
+
+## Decision
+
+We will recommend that ViewComponents are named without the `-Component` suffix, for the User Interface elements they render, namespaced like views and controllers.
+
+## Alternatives considered
+
+We've used the `-Component` suffix for some time, so it is a viable alternative.
+
+## Consequences
+
+* **Pro**: Less boilerplate and better readability. No more `render Primer::LinkComponent.new`, we can now call `render Primer::Link.new`. Once you learn that components are objects that can be rendered, the `Component` suffix loses a lot of its value.
+* **Pro**: Component names now completely align with the `views` naming conventions. This will make it easier to put components in the `views` directory if we go down that path.
+* **Con**: It's no longer immediately clear that your class/object is a component. However, ViewComponents are often the only objects present in Rails view code, so the potential confusion is likely minimal.
+* **Con**: It will take time to migrate existing code to the new convention.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,10 @@ title: Changelog
 
 ## main
 
+* Change naming convention recommendation to remove `-Component` suffix.
+
+    *Joel Hawksley*
+
 * Update error messages to be more descriptive and helpful.
 
     *Joel Hawksley*

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -11,7 +11,7 @@ nav_order: 1
 
 - Components are subclasses of `ViewComponent::Base` and live in `app/components`. It's common practice to create and inherit from an `ApplicationComponent` that is a subclass of `ViewComponent::Base`.
 - Component module names are plural, as for controllers and views: `Users::Avatar`
-- Name components for what they render, not what they accept. (`Users::Avatar` instead of `Users::User`)
+- Name components after the UI element they render.
 
 ## Installation
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -10,9 +10,8 @@ nav_order: 1
 ## Conventions
 
 - Components are subclasses of `ViewComponent::Base` and live in `app/components`. It's common practice to create and inherit from an `ApplicationComponent` that is a subclass of `ViewComponent::Base`.
-- Component names end in -`Component`.
-- Component module names are plural, as for controllers and jobs: `Users::AvatarComponent`
-- Name components for what they render, not what they accept. (`AvatarComponent` instead of `UserComponent`)
+- Component module names are plural, as for controllers and views: `Users::Avatar`
+- Name components for what they render, not what they accept. (`Users::Avatar` instead of `Users::User`)
 
 ## Installation
 


### PR DESCRIPTION
[closes #670]

_Please read this pull request as a **proposal** that can and **should** change._

### Summary

I think we should move away from naming ViewComponents with the `-Component` suffix.

I've included documentation in the form of an Architectural Decision Record. I'd love to see us use that document as the grounds of debate for this proposal. 

Assuming we can agree on this change, I will take on the work of updating the project to follow these guidelines.