### PR TITLE
Rendering slot collections returns the array of slots

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,10 @@ title: Changelog
 
 ## main
 
+* Rendering slot collections returns the array of slots
+
+    *Jon Palmer*
+
 * Update error messages to be more descriptive and helpful.
 
     *Joel Hawksley*

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,7 +7,7 @@ title: Changelog
 
 ## main
 
-* Rendering slot collections returns the array of slots
+* Setting a collection slot with the plural setter (`component.items(array)` for `renders_many :items`)  returns the array of slots.
 
     *Jon Palmer*
 

--- a/lib/view_component/slotable_v2.rb
+++ b/lib/view_component/slotable_v2.rb
@@ -133,7 +133,7 @@ module ViewComponent
           if collection_args.nil? && block.nil?
             get_slot(slot_name)
           else
-            collection_args.each do |args|
+            collection_args.map do |args|
               set_slot(slot_name, **args, &block)
             end
           end

--- a/test/view_component/slotable_v2_test.rb
+++ b/test/view_component/slotable_v2_test.rb
@@ -196,6 +196,21 @@ class SlotsV2sTest < ViewComponent::TestCase
     assert_selector(".item.normal", count: 2)
   end
 
+  def test_slot_with_collection_returns_slots
+    render_inline SlotsV2DelegateComponent.new do |component|
+      component.items([{ highlighted: false }, { highlighted: true }, { highlighted: false }])
+      .each_with_index do |slot, index|
+        slot.with_content("My Item #{index+1}")
+      end
+    end
+
+    assert_selector(".item", count: 1, text: "My Item 1")
+    assert_selector(".item", count: 1, text: "My Item 2")
+    assert_selector(".item", count: 1, text: "My Item 3")
+    assert_selector(".item.highlighted", count: 1)
+    assert_selector(".item.normal", count: 2)
+  end
+
   def test_renders_nested_content_in_order
     render_inline TitleWrapperComponent.new(title: "Hello world!")
 

--- a/test/view_component/slotable_v2_test.rb
+++ b/test/view_component/slotable_v2_test.rb
@@ -198,10 +198,10 @@ class SlotsV2sTest < ViewComponent::TestCase
 
   def test_slot_with_collection_returns_slots
     render_inline SlotsV2DelegateComponent.new do |component|
-      component.items([{ highlighted: false }, { highlighted: true }, { highlighted: false }])
-      .each_with_index do |slot, index|
-        slot.with_content("My Item #{index+1}")
-      end
+      component.items([{ highlighted: false }, { highlighted: true }, { highlighted: false }]).
+        each_with_index do |slot, index|
+          slot.with_content("My Item #{index + 1}")
+        end
     end
 
     assert_selector(".item", count: 1, text: "My Item 1")


### PR DESCRIPTION
### Summary

Rendering slot collections doesn't return the array of slots. This is asymmetric with the singular slot rendering and make it impossible to call methods like `with_content` on the rendered slots.

With this fix we can do things like this which previously would have raised an exception

```ruby
component.items([{ highlighted: false }, { highlighted: true }, { highlighted: false }])
 .each_with_index do |slot, index|
    slot.with_content("My Item #{index+1}")
  end
```
