### PR TITLE
Add slot_type slotable helpers

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,7 +7,7 @@ title: Changelog
 
 ## main
 
-* Add slot_type slotable helpers.
+* Add slot_type helper method.
 
     *Jon Palmer*
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,7 +17,7 @@ title: Changelog
 
 * Setting a collection slot with the plural setter (`component.items(array)` for `renders_many :items`)  returns the array of slots.
 
-    *Jon Palmer*    
+    *Jon Palmer*
 
 * Update error messages to be more descriptive and helpful.
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,10 @@ title: Changelog
 
 ## main
 
+* Add slot_type slotable helpers.
+
+    *Jon Palmer*
+
 * Update error messages to be more descriptive and helpful.
 
     *Joel Hawksley*

--- a/lib/view_component/slotable_v2.rb
+++ b/lib/view_component/slotable_v2.rb
@@ -142,6 +142,17 @@ module ViewComponent
         register_slot(slot_name, collection: true, callable: callable)
       end
 
+      def slot_type(slot_name)
+        registered_slot = registered_slots[slot_name]
+        if registered_slot
+          registered_slot[:collection] ? :collection : :single
+        else
+          plural_slot_name = ActiveSupport::Inflector.pluralize(slot_name).to_sym
+          plural_registered_slot = registered_slots[plural_slot_name]
+          plural_registered_slot&.fetch(:collection) ? :collection_item : nil
+        end
+      end
+
       # Clone slot configuration into child class
       # see #test_slots_pollution
       def inherited(child)

--- a/test/view_component/slotable_v2_test.rb
+++ b/test/view_component/slotable_v2_test.rb
@@ -363,4 +363,20 @@ class SlotsV2sTest < ViewComponent::TestCase
 
     assert_includes error.message, "It looks like a block was provided after calling"
   end
+
+  def test_slot_type_single
+    assert_equal(:single, SlotsV2Component.slot_type(:title))
+  end
+
+  def test_slot_type_collection
+    assert_equal(:collection, SlotsV2Component.slot_type(:tabs))
+  end
+
+  def test_slot_type_collection_item?
+    assert_equal(:collection_item, SlotsV2Component.slot_type(:tab))
+  end
+
+  def test_slot_type_nil?
+    assert_nil(SlotsV2Component.slot_type(:junk))
+  end
 end


### PR DESCRIPTION
### Summary

Add three helper methods that allow introspection on what slots the component renders


```ruby
class SlotsV2Component < ViewComponent::Base
  renders_one :header
  renders_many :items
end
```
```ruby
SlotsV2Component.renders_one?(:header) # -> true
SlotsV2Component.renders_one?(:items) # -> false
SlotsV2Component.renders_one?(:item) # -> false

SlotsV2Component.renders_many?(:header) # -> false
SlotsV2Component.renders_many?(:items) # -> # true
SlotsV2Component.renders_many?(:item) # -> # false

SlotsV2Component.renders_many_item?(:header) # -> false
SlotsV2Component.renders_many_item?(:items) # -> # false
SlotsV2Component.renders_many_item?(:item) # -> # true
```

