### PR TITLE
Add test case for controller rendering with block

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,10 @@ title: Changelog
 
 ## main
 
+* Add test case for rendering a ViewComponent with slots in a controller.
+
+    *Simon Fish*
+
 * Set maximum line length to 120.
 
     *Joel Hawksley*

--- a/test/sandbox/app/components/controller_inline_with_block_component.html.erb
+++ b/test/sandbox/app/components/controller_inline_with_block_component.html.erb
@@ -1,3 +1,5 @@
 <%= render partial: "integration_examples/controller_inline", locals: { message: @message } %>
 
 <%= slot %>
+
+<div id="content"><%= content %></div>

--- a/test/sandbox/app/components/controller_inline_with_block_component.html.erb
+++ b/test/sandbox/app/components/controller_inline_with_block_component.html.erb
@@ -1,0 +1,3 @@
+<%= render partial: "integration_examples/controller_inline", locals: { message: @message } %>
+
+<%= slot %>

--- a/test/sandbox/app/components/controller_inline_with_block_component.rb
+++ b/test/sandbox/app/components/controller_inline_with_block_component.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ControllerInlineWithBlockComponent < ViewComponent::Base
-  renders_one :slot, ->(name:) { tag.div name }
+  renders_one :slot, ->(name:) { tag.div name, id: "slot" }
 
   def initialize(message:)
     @message = message

--- a/test/sandbox/app/components/controller_inline_with_block_component.rb
+++ b/test/sandbox/app/components/controller_inline_with_block_component.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class ControllerInlineWithBlockComponent < ViewComponent::Base
+  renders_one :slot, ->(name:) { tag.div name }
+
+  def initialize(message:)
+    @message = message
+  end
+end

--- a/test/sandbox/app/controllers/integration_examples_controller.rb
+++ b/test/sandbox/app/controllers/integration_examples_controller.rb
@@ -12,9 +12,10 @@ class IntegrationExamplesController < ActionController::Base
   end
 
   def controller_inline_with_block
-    render ControllerInlineComponent.new(message: "bar") do |c|
+    render(ControllerInlineWithBlockComponent.new(message: "bar").tap do |c|
       c.slot(name: "baz")
-    end
+      c.with_content("bam")
+    end)
   end
 
   def controller_inline_baseline

--- a/test/sandbox/app/controllers/integration_examples_controller.rb
+++ b/test/sandbox/app/controllers/integration_examples_controller.rb
@@ -11,6 +11,12 @@ class IntegrationExamplesController < ActionController::Base
     render(ControllerInlineComponent.new(message: "bar"))
   end
 
+  def controller_inline_with_block
+    render ControllerInlineComponent.new(message: "bar") do |c|
+      c.slot(name: "baz")
+    end
+  end
+
   def controller_inline_baseline
     render("integration_examples/_controller_inline", locals: { message: "bar" })
   end

--- a/test/sandbox/config/routes.rb
+++ b/test/sandbox/config/routes.rb
@@ -13,6 +13,7 @@ Sandbox::Application.routes.draw do
   get :cached, to: "integration_examples#cached"
   get :render_check, to: "integration_examples#render_check"
   get :controller_inline, to: "integration_examples#controller_inline"
+  get :controller_inline_with_block, to: "integration_examples#controller_inline_with_block"
   get :controller_inline_baseline, to: "integration_examples#controller_inline_baseline"
   get :controller_to_string, to: "integration_examples#controller_to_string"
   get :render_component, to: "integration_examples#render_component"

--- a/test/view_component/integration_test.rb
+++ b/test/view_component/integration_test.rb
@@ -38,6 +38,15 @@ class IntegrationTest < ActionDispatch::IntegrationTest
     assert_includes inline_response, baseline_response
   end
 
+  def test_rendering_component_in_a_controller_with_block
+    # Currently unsupported.
+
+    get "/controller_inline_with_block"
+    assert_select("div", "bar")
+    assert_select("div", { count: 0, text: "baz" })
+    assert_response :success
+  end
+
   def test_template_changes_are_not_reflected_on_new_request_when_cache_template_loading_is_true
     # cache_template_loading is set to true on the initializer
 

--- a/test/view_component/integration_test.rb
+++ b/test/view_component/integration_test.rb
@@ -39,11 +39,11 @@ class IntegrationTest < ActionDispatch::IntegrationTest
   end
 
   def test_rendering_component_in_a_controller_with_block
-    # Currently unsupported.
-
     get "/controller_inline_with_block"
+
     assert_select("div", "bar")
-    assert_select("div", { count: 0, text: "baz" })
+    assert_select("div#slot", "baz")
+    assert_select("div#content", "bam")
     assert_response :success
   end
 


### PR DESCRIPTION
<!-- See https://github.com/github/view_component/blob/main/docs/CONTRIBUTING.md#submitting-a-pull-request -->

### Summary

As part of investigation into #909, I wrote a failing test case. It checked that a block passed when rendering a component from the controller is used in the final render output.

We've got a workaround now by calling `#tap` on the component instance itself, so this test serves as documentation of that.

### Other Information

As mentioned on #909, the ability to use blocks in controller rendering was removed in 473beedb342bafc53557383f5a8c840c94645917. It's likely that this was why it wasn't then supported by Rails when it was implemented over there.