### PR TITLE
add note about variants to templates docs

### DIFF
--- a/docs/guide/templates.md
+++ b/docs/guide/templates.md
@@ -6,7 +6,7 @@ parent: Building ViewComponents
 
 # Templates
 
-ViewComponent templates can be defined in several ways:
+ViewComponents wrap one (or more, if using [variants](https://guides.rubyonrails.org/layouts_and_rendering.html#the-variants-option)) template(s), defined in one of several ways:
 
 ## Sibling file
 

--- a/docs/guide/templates.md
+++ b/docs/guide/templates.md
@@ -6,7 +6,7 @@ parent: Building ViewComponents
 
 # Templates
 
-ViewComponents wrap one template (or more, if using [variants](https://guides.rubyonrails.org/layouts_and_rendering.html#the-variants-option)), defined in one of several ways:
+ViewComponents wrap a template (or several, if using [variants](https://guides.rubyonrails.org/layouts_and_rendering.html#the-variants-option)), defined in one of several ways:
 
 ## Sibling file
 

--- a/docs/guide/templates.md
+++ b/docs/guide/templates.md
@@ -6,7 +6,7 @@ parent: Building ViewComponents
 
 # Templates
 
-ViewComponents wrap one (or more, if using [variants](https://guides.rubyonrails.org/layouts_and_rendering.html#the-variants-option)) template(s), defined in one of several ways:
+ViewComponents wrap one template (or more, if using [variants](https://guides.rubyonrails.org/layouts_and_rendering.html#the-variants-option)), defined in one of several ways:
 
 ## Sibling file
 


### PR DESCRIPTION
cc @paul

I've added a note to the Templates documentation to clarify that `variant` refers to ActionPack variants: https://guides.rubyonrails.org/layouts_and_rendering.html#the-variants-option.
