### PR TITLE
Update landing page to incorporate internal documentation

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,7 @@ title: Changelog
 
 ## main
 
+<<<<<<< Updated upstream
 * Add `slot_type` helper method.
 
     *Jon Palmer*
@@ -14,6 +15,11 @@ title: Changelog
 * Add test case for rendering a ViewComponent with slots in a controller.
 
     *Simon Fish*
+=======
+* Add example ViewComponent to documentation landing page.
+
+    *Joel Hawksley*
+>>>>>>> Stashed changes
 
 * Set maximum line length to 120.
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,7 +7,6 @@ title: Changelog
 
 ## main
 
-<<<<<<< Updated upstream
 * Add `slot_type` helper method.
 
     *Jon Palmer*
@@ -15,11 +14,10 @@ title: Changelog
 * Add test case for rendering a ViewComponent with slots in a controller.
 
     *Simon Fish*
-=======
+
 * Add example ViewComponent to documentation landing page.
 
     *Joel Hawksley*
->>>>>>> Stashed changes
 
 * Set maximum line length to 120.
 

--- a/docs/frequently-asked-questions.md
+++ b/docs/frequently-asked-questions.md
@@ -9,6 +9,10 @@ title: Frequently asked questions
 
 Yes. ViewComponent is tested against ERB, Haml, and Slim, but it should support most Rails template handlers.
 
+## Can I use a ViewComponent for an entire view?
+
+If the view could benefit from unit testing, making it a ViewComponent is probably a good idea.
+
 ## Isn't this just like X library?
 
 ViewComponent is far from a novel idea! Popular implementations of view components in Ruby include, but are not limited to:


### PR DESCRIPTION
In reviewing our internal documentation at GitHub, I found a
couple sections that I thought would be nice to add to the
framework documentation.