### PR TITLE
Fix typo in documentation

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,10 @@ title: Changelog
 
 ## main
 
+* Fix typo in documentation
+
+    *Ryo.gift*
+
 ## 2.36.0
 
 * Add `slot_type` helper method.

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,7 +25,7 @@ end
 
 ```erb
 <%# app/components/message_component.html.erb %>
-<h1>Hello, <%= @name %>!<h1>
+<h1>Hello, <%= @name %>!</h1>
 ```
 
 Which is rendered by calling:
@@ -170,6 +170,7 @@ ViewComponent is built by over a hundred members of the community, including:
 <img src="https://avatars.githubusercontent.com/xronos-i-am?s=64" alt="xronos-i-am" width="32" />
 <img src="https://avatars.githubusercontent.com/matheusrich?s=64" alt="matheusrich" width="32" />
 <img src="https://avatars.githubusercontent.com/Matt-Yorkley?s=64" alt="Matt-Yorkley" width="32" />
+<img src="https://avatars.githubusercontent.com/ryogift?s=64" alt="ryogift" width="32" />
 
 <hr />
 


### PR DESCRIPTION
<!-- See https://github.com/github/view_component/blob/main/docs/CONTRIBUTING.md#submitting-a-pull-request -->

### Summary

Fix a typo of the h1 end tag in documentation.
