### PR TITLE
Add inline template example to benchmark script

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -19,6 +19,10 @@ title: Changelog
 
     *Ryo.gift*
 
+* Add inline template example to benchmark script.
+
+    *Andrew Tait*
+
 ## 2.36.0
 
 * Add `slot_type` helper method.

--- a/docs/index.md
+++ b/docs/index.md
@@ -171,6 +171,7 @@ ViewComponent is built by over a hundred members of the community, including:
 <img src="https://avatars.githubusercontent.com/matheusrich?s=64" alt="matheusrich" width="32" />
 <img src="https://avatars.githubusercontent.com/Matt-Yorkley?s=64" alt="Matt-Yorkley" width="32" />
 <img src="https://avatars.githubusercontent.com/ryogift?s=64" alt="ryogift" width="32" />
+<img src="https://avatars.githubusercontent.com/andrewjtait?s=64" alt="andrewjtait" width="32" />
 
 <hr />
 

--- a/performance/benchmark.rb
+++ b/performance/benchmark.rb
@@ -7,9 +7,10 @@ require "benchmark/ips"
 
 # Configure Rails Envinronment
 ENV["RAILS_ENV"] = "production"
-require File.expand_path("../test/config/environment.rb", __dir__)
+require File.expand_path("../test/sandbox/config/environment.rb", __dir__)
 
 require_relative "components/name_component.rb"
+require_relative "components/inline_component.rb"
 
 class BenchmarksController < ActionController::Base
 end
@@ -22,6 +23,7 @@ Benchmark.ips do |x|
   x.warmup = 2
 
   x.report("component:") { controller_view.render(NameComponent.new(name: "Fox Mulder")) }
+  x.report("inline:") { controller_view.render(InlineComponent.new(name: "Fox Mulder")) }
   x.report("partial:") { controller_view.render("partial", name: "Fox Mulder") }
 
   x.compare!

--- a/performance/components/inline_component.rb
+++ b/performance/components/inline_component.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class InlineComponent < ViewComponent::Base
+  def initialize(name:)
+    @name = name
+  end
+
+  def call
+    # rubocop:disable Rails/OutputSafety
+    "<h1>hello #{@name}</h1>".html_safe
+  end
+end


### PR DESCRIPTION
<!-- See https://github.com/github/view_component/blob/main/docs/CONTRIBUTING.md#submitting-a-pull-request -->

### Summary

After trying to run some benchmarks to compare components that use an ERB file with components that use a `call` method, I discussed the results here: https://github.com/github/view_component/discussions/1014

It was then considered if we should add this example to the benchmark script, so I have raised this PR in case you want it included.

### Other Information

Here are the benchmark results after this change:

```
Warming up --------------------------------------
          component:    14.495k i/100ms
             inline:    13.457k i/100ms
            partial:     1.770k i/100ms
Calculating -------------------------------------
          component:    150.094k (± 4.5%) i/s -      1.507M in  10.064767s
             inline:    184.791k (± 4.5%) i/s -      1.857M in  10.071958s
            partial:     18.655k (± 4.8%) i/s -    187.620k in  10.081517s

Comparison:
             inline::   184791.1 i/s
          component::   150094.5 i/s - 1.23x  (± 0.00) slower
            partial::    18655.1 i/s - 9.91x  (± 0.00) slower
```

Also, I should mention that it looks as though the benchmark scripts have been broken since this change https://github.com/github/view_component/commit/e2f0379b1bd94b74064eedb29c4017fceb99d054 in which the sandbox app was moved to a different directory.

The main benchmark script was an easy fix as I just had to update the location of `environment.rb`, however the other benchmark scripts require a bit more work to fix so I have not included them in this change. I will raise them as a separate issue.