### PR TITLE
Fix benchmark scripts

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -19,7 +19,7 @@ title: Changelog
 
     *Ryo.gift*
 
-* Fix benchmark scripts
+* Fix benchmark scripts.
 
     *Andrew Tait*
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -19,6 +19,10 @@ title: Changelog
 
     *Ryo.gift*
 
+* Fix benchmark scripts
+
+    *Andrew Tait*
+
 ## 2.36.0
 
 * Add `slot_type` helper method.

--- a/docs/index.md
+++ b/docs/index.md
@@ -171,6 +171,7 @@ ViewComponent is built by over a hundred members of the community, including:
 <img src="https://avatars.githubusercontent.com/matheusrich?s=64" alt="matheusrich" width="32" />
 <img src="https://avatars.githubusercontent.com/Matt-Yorkley?s=64" alt="Matt-Yorkley" width="32" />
 <img src="https://avatars.githubusercontent.com/ryogift?s=64" alt="ryogift" width="32" />
+<img src="https://avatars.githubusercontent.com/andrewjtait?s=64" alt="andrewjtait" width="32" />
 
 <hr />
 

--- a/performance/benchmark.rb
+++ b/performance/benchmark.rb
@@ -5,11 +5,13 @@
 
 require "benchmark/ips"
 
-# Configure Rails Envinronment
+# Configure Rails Environment
 ENV["RAILS_ENV"] = "production"
-require File.expand_path("../test/config/environment.rb", __dir__)
+require File.expand_path("../test/sandbox/config/environment.rb", __dir__)
 
-require_relative "components/name_component.rb"
+module Performance
+  require_relative "components/name_component.rb"
+end
 
 class BenchmarksController < ActionController::Base
 end
@@ -21,7 +23,7 @@ Benchmark.ips do |x|
   x.time = 10
   x.warmup = 2
 
-  x.report("component:") { controller_view.render(NameComponent.new(name: "Fox Mulder")) }
+  x.report("component:") { controller_view.render(Performance::NameComponent.new(name: "Fox Mulder")) }
   x.report("partial:") { controller_view.render("partial", name: "Fox Mulder") }
 
   x.compare!

--- a/performance/components/content_areas_component.rb
+++ b/performance/components/content_areas_component.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-class ContentAreasComponent < ViewComponent::Base
+class Performance::ContentAreasComponent < ViewComponent::Base
   with_content_areas :header, :items
 end

--- a/performance/components/global_i18n_component.rb
+++ b/performance/components/global_i18n_component.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class GlobalI18nComponent < ViewComponent::Base
+class Performance::GlobalI18nComponent < ViewComponent::Base
   def initialize(key)
     @key = key
   end

--- a/performance/components/name_component.rb
+++ b/performance/components/name_component.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class NameComponent < ViewComponent::Base
+class Performance::NameComponent < ViewComponent::Base
   def initialize(name:)
     @name = name
   end

--- a/performance/components/slot_component.html.erb
+++ b/performance/components/slot_component.html.erb
@@ -1,12 +1,12 @@
 <header>
-  <%= render SlotsV2Component::HeaderComponent.new(classes: header.classes) do %>
+  <%= render Performance::SlotsV2Component::HeaderComponent.new(classes: header.classes) do %>
     <%= header.content %>
   <% end %>
 </header>
 
 <%= items.each do |item| %>
   <div>
-    <%= render SlotsV2Component::ItemComponent.new(classes: item.classes) do %>
+    <%= render Performance::SlotsV2Component::ItemComponent.new(classes: item.classes) do %>
       <%= item.content %>
     <% end %>
   </div>

--- a/performance/components/slot_component.rb
+++ b/performance/components/slot_component.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class SlotComponent < ViewComponent::Base
+class Performance::SlotComponent < ViewComponent::Base
   include ViewComponent::Slotable
 
   with_slot :header, class_name: "Header"

--- a/performance/components/slots_v2_component.rb
+++ b/performance/components/slots_v2_component.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class SlotsV2Component < ViewComponent::Base
+class Performance::SlotsV2Component < ViewComponent::Base
   renders_one :header, ->(**kwargs) { HeaderComponent.new(**kwargs) }
   renders_many :items, ->(**kwargs) { ItemComponent.new(**kwargs) }
 

--- a/performance/components/translatable_component.rb
+++ b/performance/components/translatable_component.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class TranslatableComponent < ViewComponent::Base
+class Performance::TranslatableComponent < ViewComponent::Base
   include ViewComponent::Translatable
 
   def initialize(key)

--- a/performance/slotable_benchmark.rb
+++ b/performance/slotable_benchmark.rb
@@ -5,13 +5,15 @@
 
 require "benchmark/ips"
 
-# Configure Rails Envinronment
+# Configure Rails Environment
 ENV["RAILS_ENV"] = "production"
-require File.expand_path("../test/config/environment.rb", __dir__)
+require File.expand_path("../test/sandbox/config/environment.rb", __dir__)
 
-require_relative "components/slot_component.rb"
-require_relative "components/slots_v2_component.rb"
-require_relative "components/content_areas_component.rb"
+module Performance
+  require_relative "components/slot_component.rb"
+  require_relative "components/slots_v2_component.rb"
+  require_relative "components/content_areas_component.rb"
+end
 
 class BenchmarksController < ActionController::Base
 end
@@ -24,18 +26,18 @@ Benchmark.ips do |x|
   x.warmup = 2
 
   x.report("content_areas:") do
-    component = ContentAreasComponent.new(name: "Fox Mulder")
+    component = Performance::ContentAreasComponent.new(name: "Fox Mulder")
 
     controller_view.render(component) do |c|
       c.with(:header) do
-        c.render SlotsV2Component::HeaderComponent.new(classes: "header") do
+        c.render Performance::SlotsV2Component::HeaderComponent.new(classes: "header") do
           "Header"
         end
       end
 
       c.with(:items) do
         ["a", "b", "c"].each do |item|
-          c.render SlotsV2Component::ItemComponent.new(classes: "header") do
+          c.render Performance::SlotsV2Component::ItemComponent.new(classes: "header") do
             item
           end
         end
@@ -44,7 +46,7 @@ Benchmark.ips do |x|
   end
 
   x.report("slot:") do
-    component = SlotComponent.new(name: "Fox Mulder")
+    component = Performance::SlotComponent.new(name: "Fox Mulder")
 
     controller_view.render(component) do |c|
       c.slot(:header, classes: "my-header") do
@@ -61,7 +63,7 @@ Benchmark.ips do |x|
     end
   end
   x.report("subcomponent:") do
-    component = SlotsV2Component.new(name: "Fox Mulder")
+    component = Performance::SlotsV2Component.new(name: "Fox Mulder")
 
     controller_view.render(component) do |c|
       c.header(classes: "my-header") do

--- a/performance/translatable_benchmark.rb
+++ b/performance/translatable_benchmark.rb
@@ -5,23 +5,25 @@
 
 require "benchmark/ips"
 
-# Configure Rails Envinronment
+# Configure Rails Environment
 ENV["RAILS_ENV"] = "production"
-require File.expand_path("../test/config/environment.rb", __dir__)
+require File.expand_path("../test/sandbox/config/environment.rb", __dir__)
 
-require_relative "components/global_i18n_component.rb"
-require_relative "components/translatable_component.rb"
+module Performance
+  require_relative "components/global_i18n_component.rb"
+  require_relative "components/translatable_component.rb"
+end
 
 class BenchmarksController < ActionController::Base
 end
 
 BenchmarksController.view_paths = [File.expand_path("./views", __dir__)]
 controller_view = BenchmarksController.new.view_context
-I18n.load_path = Dir[File.expand_path("../test/config/locales/*.{rb,yml,yaml}", __dir__)]
+I18n.load_path = Dir[File.expand_path("../test/sandbox/config/locales/*.{rb,yml,yaml}", __dir__)]
 I18n.backend.load_translations
 
-global_i18n_component = GlobalI18nComponent.new("hello")
-translatable_component = TranslatableComponent.new(".hello")
+global_i18n_component = Performance::GlobalI18nComponent.new("hello")
+translatable_component = Performance::TranslatableComponent.new(".hello")
 
 controller_view.render(global_i18n_component)
 controller_view.render(translatable_component)


### PR DESCRIPTION
Fixes #1025 

### Summary

Since the test sandbox application was moved, the benchmark scripts have not been working. This fixes the scripts by requiring files from the new location, as well as namespacing the components so that the classes do not conflict with components defined in the sandbox.

### Other Information

`bundle exec rake benchmark`:
```
Warming up --------------------------------------
          component:    14.902k i/100ms
            partial:     1.814k i/100ms
Calculating -------------------------------------
          component:    149.116k (± 4.0%) i/s -      1.490M in  10.011986s
            partial:     17.640k (± 9.2%) i/s -    175.958k in  10.068436s

Comparison:
          component::   149115.6 i/s
            partial::    17639.6 i/s - 8.45x  (± 0.00) slower
```

`bundle exec rake translatable_benchmark`:
```
Warming up --------------------------------------
              global    15.239k i/100ms
             sidecar    15.911k i/100ms
      global_missing     2.894k i/100ms
     sidecar_missing     2.288k i/100ms
    sidecar_absolute    20.728k i/100ms
    sidecar_fallback     7.358k i/100ms
Calculating -------------------------------------
              global    152.154k (± 1.6%) i/s -    761.950k in   5.009096s
             sidecar    178.742k (± 1.8%) i/s -    906.927k in   5.075542s
      global_missing     30.687k (± 1.8%) i/s -    153.382k in   4.999927s
     sidecar_missing     22.887k (± 1.7%) i/s -    114.400k in   5.000059s
    sidecar_absolute    206.282k (± 3.7%) i/s -      1.036M in   5.033110s
    sidecar_fallback     71.710k (± 3.9%) i/s -    360.542k in   5.036093s

Comparison:
    sidecar_absolute:   206282.0 i/s
             sidecar:   178742.2 i/s - 1.15x  (± 0.00) slower
              global:   152154.2 i/s - 1.36x  (± 0.00) slower
    sidecar_fallback:    71710.3 i/s - 2.88x  (± 0.00) slower
      global_missing:    30687.3 i/s - 6.72x  (± 0.00) slower
     sidecar_missing:    22886.7 i/s - 9.01x  (± 0.00) slower
```

`bundle exec rake slotable_benchmark`:
```
Warming up --------------------------------------
      content_areas:   600.000  i/100ms
               slot:   509.000  i/100ms
       subcomponent:   612.000  i/100ms
Calculating -------------------------------------
      content_areas:      6.042k (± 2.5%) i/s -     60.600k in  10.036093s
               slot:      5.007k (± 4.5%) i/s -     50.391k in  10.086785s
       subcomponent:      5.428k (± 8.3%) i/s -     54.468k in  10.109501s

Comparison:
      content_areas::     6042.4 i/s
       subcomponent::     5427.8 i/s - 1.11x  (± 0.00) slower
               slot::     5007.3 i/s - 1.21x  (± 0.00) slower
```