### PR TITLE
Add --stimulus flag to component generator

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,10 @@ title: Changelog
 
 ## main
 
+* Add `--stimulus` flag to the component generator. Generates a Stimulus controller alongside the component.
+
+    *Sebastien Auriault*
+
 * Add test case for conflict with internal `@variant` variable.
 
    *David Backeus*

--- a/docs/index.md
+++ b/docs/index.md
@@ -172,6 +172,7 @@ ViewComponent is built by over a hundred members of the community, including:
 <img src="https://avatars.githubusercontent.com/Matt-Yorkley?s=64" alt="Matt-Yorkley" width="32" />
 <img src="https://avatars.githubusercontent.com/ryogift?s=64" alt="ryogift" width="32" />
 <img src="https://avatars.githubusercontent.com/andrewjtait?s=64" alt="andrewjtait" width="32" />
+<img src="https://avatars.githubusercontent.com/websebdev?s=64" alt="websebdev" width="32" />
 
 <hr />
 

--- a/lib/rails/generators/abstract_generator.rb
+++ b/lib/rails/generators/abstract_generator.rb
@@ -11,11 +11,19 @@ module ViewComponent
     private
 
     def destination
+      File.join(destination_directory, "#{destination_file_name}.html.#{engine_name}")
+    end
+
+    def destination_directory
       if options["sidecar"]
-        File.join(component_path, class_path, "#{file_name}_component", "#{file_name}_component.html.#{engine_name}")
+        File.join(component_path, class_path, destination_file_name)
       else
-        File.join(component_path, class_path, "#{file_name}_component.html.#{engine_name}")
+        File.join(component_path, class_path)
       end
+    end
+
+    def destination_file_name
+      "#{file_name}_component"
     end
 
     def file_name
@@ -24,6 +32,15 @@ module ViewComponent
 
     def component_path
       ViewComponent::Base.view_component_path
+    end
+
+    def stimulus_controller
+      if options["stimulus"]
+        File.join(destination_directory, destination_file_name)
+          .sub("#{component_path}/", "")
+          .gsub("_", "-")
+          .gsub("/", "--")
+      end
     end
   end
 end

--- a/lib/rails/generators/component/component_generator.rb
+++ b/lib/rails/generators/component/component_generator.rb
@@ -21,6 +21,8 @@ module Rails
 
       hook_for :preview, type: :boolean
 
+      hook_for :stimulus, type: :boolean
+
       hook_for :template_engine do |instance, template_engine|
         instance.invoke template_engine, [instance.name]
       end

--- a/lib/rails/generators/component/component_generator.rb
+++ b/lib/rails/generators/component/component_generator.rb
@@ -12,6 +12,8 @@ module Rails
       argument :attributes, type: :array, default: [], banner: "attribute"
       check_class_collision suffix: "Component"
       class_option :inline, type: :boolean, default: false
+      class_option :stimulus, type: :boolean, default: false
+      class_option :sidecar, type: :boolean, default: false
 
       def create_component_file
         template "component.rb", File.join(component_path, class_path, "#{file_name}_component.rb")

--- a/lib/rails/generators/component/templates/component.rb.tt
+++ b/lib/rails/generators/component/templates/component.rb.tt
@@ -8,7 +8,7 @@ class <%= class_name %>Component < <%= parent_class %>
 <%- end -%>
 <%- if initialize_call_method_for_inline? -%>  
   def call
-    content_tag :h1, "Hello world!"
+    content_tag :h1, "Hello world!"<%= ", data: { controller: \"#{stimulus_controller}\" }" if options["stimulus"] %>
   end
 <%- end -%>
 

--- a/lib/rails/generators/erb/component_generator.rb
+++ b/lib/rails/generators/erb/component_generator.rb
@@ -25,13 +25,7 @@ module Erb
 
       def data_attributes
         if options["stimulus"]
-          controller_path = destination
-            .sub("#{component_path}/", "")
-            .sub(".html.#{engine_name}", "")
-            .gsub("_", "-")
-            .gsub("/", "--")
-
-          " data-controller=\"#{controller_path}\""
+          " data-controller=\"#{stimulus_controller}\""
         end
       end
     end

--- a/lib/rails/generators/erb/component_generator.rb
+++ b/lib/rails/generators/erb/component_generator.rb
@@ -11,6 +11,7 @@ module Erb
       source_root File.expand_path("templates", __dir__)
       class_option :sidecar, type: :boolean, default: false
       class_option :inline, type: :boolean, default: false
+      class_option :stimulus, type: :boolean, default: false
 
       def engine_name
         "erb"
@@ -18,6 +19,20 @@ module Erb
 
       def copy_view_file
         super
+      end
+
+      private
+
+      def data_attributes
+        if options["stimulus"]
+          controller_path = destination
+            .sub("#{component_path}/", "")
+            .sub(".html.#{engine_name}", "")
+            .gsub("_", "-")
+            .gsub("/", "--")
+
+          " data-controller=\"#{controller_path}\""
+        end
       end
     end
   end

--- a/lib/rails/generators/erb/templates/component.html.erb.tt
+++ b/lib/rails/generators/erb/templates/component.html.erb.tt
@@ -1,1 +1,1 @@
-<div>Add <%= class_name %> template here</div>
+<div<%= data_attributes %>>Add <%= class_name %> template here</div>

--- a/lib/rails/generators/stimulus/component_generator.rb
+++ b/lib/rails/generators/stimulus/component_generator.rb
@@ -6,9 +6,20 @@ module Stimulus
       include ViewComponent::AbstractGenerator
 
       source_root File.expand_path("templates", __dir__)
+      class_option :sidecar, type: :boolean, default: false
 
       def create_stimulus_controller
-        template "component_controller.js", File.join(component_path, class_path, "#{file_name}_component_controller.js")
+        template "component_controller.js", destination
+      end
+
+      private
+
+      def destination
+        if options["sidecar"]
+          File.join(component_path, class_path, "#{file_name}_component", "#{file_name}_component_controller.js")
+        else
+          File.join(component_path, class_path, "#{file_name}_component_controller.js")
+        end
       end
     end
   end

--- a/lib/rails/generators/stimulus/component_generator.rb
+++ b/lib/rails/generators/stimulus/component_generator.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Stimulus
+  module Generators
+    class ComponentGenerator < ::Rails::Generators::NamedBase
+      include ViewComponent::AbstractGenerator
+
+      source_root File.expand_path("templates", __dir__)
+
+      def create_stimulus_controller
+        template "component_controller.js", File.join(component_path, class_path, "#{file_name}_component_controller.js")
+      end
+    end
+  end
+end

--- a/lib/rails/generators/stimulus/templates/component_controller.js.tt
+++ b/lib/rails/generators/stimulus/templates/component_controller.js.tt
@@ -1,0 +1,4 @@
+import { Controller } from "stimulus";
+
+export default class extends Controller {
+}

--- a/lib/rails/generators/stimulus/templates/component_controller.js.tt
+++ b/lib/rails/generators/stimulus/templates/component_controller.js.tt
@@ -1,4 +1,7 @@
 import { Controller } from "stimulus";
 
 export default class extends Controller {
+  connect() {
+    console.log("Hello, Stimulus!", this.element);
+  }
 }

--- a/test/generators/component_generator_test.rb
+++ b/test/generators/component_generator_test.rb
@@ -135,4 +135,10 @@ class ComponentGeneratorTest < Rails::Generators::TestCase
       assert_file "app/parts/user_component.html.erb"
     end
   end
+
+  def test_component_with_stimulus
+    run_generator %w[user --stimulus]
+
+    assert_file "app/components/user_component_controller.js"
+  end
 end

--- a/test/generators/component_generator_test.rb
+++ b/test/generators/component_generator_test.rb
@@ -139,6 +139,36 @@ class ComponentGeneratorTest < Rails::Generators::TestCase
   def test_component_with_stimulus
     run_generator %w[user --stimulus]
 
+    assert_file "app/components/user_component.html.erb" do |component|
+      assert_match(/data-controller="user-component"/, component)
+    end
+
     assert_file "app/components/user_component_controller.js"
+  end
+
+  def test_component_with_stimulus_and_inline
+    run_generator %w[user --stimulus --inline]
+
+    assert_file "app/components/user_component.rb" do |component|
+      assert_match(/data: { controller: "user-component" }/, component)
+    end
+
+    assert_file "app/components/user_component_controller.js"
+  end
+
+  def test_component_with_stimulus_and_sidecar
+    run_generator %w[user --stimulus --sidecar]
+
+    assert_file "app/components/user_component/user_component_controller.js"
+  end
+
+  def test_component_with_stimulus_and_sidecar_and_inline
+    run_generator %w[user --stimulus --sidecar --inline]
+
+    assert_file "app/components/user_component.rb" do |component|
+      assert_match(/data: { controller: "user-component--user-component" }/, component)
+    end
+
+    assert_file "app/components/user_component/user_component_controller.js"
   end
 end


### PR DESCRIPTION
### Summary
Add `--stimulus` flag to the component generator.
This will create a basic Stimulus controller alongside the component.

Example:
```
$ rails generate component User --stimulus
      create  app/components/user_component.rb
      invoke  rspec
      create    spec/components/user_component_spec.rb
      invoke  stimulus
      create    app/components/user_component_controller.js
      invoke  erb
      create    app/components/user_component.html.erb
```

Closes #627