### PR TITLE
Update slots.md

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,7 +7,7 @@ title: Changelog
 
 ## main
 
-* Fix error in documentation for `render_many` passthrough slots
+* Fix error in documentation for `render_many` passthrough slots.
 
     *Ollie Nye*
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,10 @@ title: Changelog
 
 ## main
 
+* Fix error in documentation for `render_many` passthrough slots
+
+    *Ollie Nye*
+
 * Add test case for conflict with internal `@variant` variable.
 
    *David Backeus*

--- a/docs/guide/slots.md
+++ b/docs/guide/slots.md
@@ -44,7 +44,9 @@ To render a `renders_many` slot, iterate over the name of the slot:
   <% end %>
 
   <% @posts.each do |post| %>
-    <%= c.post { post } %>
+    <%= c.post do %>
+      <%= link_to post.name, post.url %>
+    <% end %>
   <% end %>
 <% end %>
 ```

--- a/docs/guide/slots.md
+++ b/docs/guide/slots.md
@@ -44,7 +44,7 @@ To render a `renders_many` slot, iterate over the name of the slot:
   <% end %>
 
   <% @posts.each do |post| %>
-    <%= c.post(post: post) %>
+    <%= c.post { post } %>
   <% end %>
 <% end %>
 ```


### PR DESCRIPTION
### Summary

Fix bug in docs for passthrough `renders_many` slot call. Needed a block argument instead of parameter argument.