### PR TITLE
Fixed link to project's open source license

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -11,7 +11,7 @@ Hi there! We're thrilled that you'd like to contribute to this project. Your hel
 
 If you have any substantial changes that you would like to make, please [open an issue](http://github.com/github/view_component/issues/new) first to discuss them with us.
 
-Contributions to this project are [released](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) to the public under the [project's open source license](LICENSE.txt).
+Contributions to this project are [released](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) to the public under the [project's open source license](/LICENSE.txt).
 
 ## Submitting a pull request
 


### PR DESCRIPTION
Leading "/" required in the link to search parent directory for LICENSE.txt.

<!-- See https://github.com/github/view_component/blob/main/docs/CONTRIBUTING.md#submitting-a-pull-request -->

### Summary

LICENSE.txt lives in /main. Without the leading "/" in the link to the license, it's searching the /main/docs/ folder. No current GitHub issues to reference.

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file. -->
