### PR TITLE
Increase clarity around purpose and use of slots

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,10 @@ title: Changelog
 
 ## main
 
+* Increase clarity around purpose and use of slots.
+
+    *Simon Fish*
+
 ## 2.45.0
 
 * Remove internal APIs from API documentation, fix link to license.

--- a/docs/guide/slots.md
+++ b/docs/guide/slots.md
@@ -54,7 +54,14 @@ To render a `renders_many` slot, iterate over the name of the slot:
 <% end %>
 ```
 
-The link to "My blog" will render inside the `<h1>` tags, and links to each `BlogPost` will be rendered beneath.
+The rendered output will look like this:
+
+```erb
+<h1><a href="/">My blog</a></h1>
+
+<a href="/blog/first-post">First post</a>
+<a href="/blog/second-post">Second post</a>
+```
 
 ## Component slots
 

--- a/docs/guide/slots.md
+++ b/docs/guide/slots.md
@@ -13,8 +13,10 @@ Slots are defined with `renders_one` and `renders_many`:
 - `renders_one` defines a slot that will be rendered at most once per component: `renders_one :header`
 - `renders_many` defines a slot that can be rendered multiple times per-component: `renders_many :posts`
 
-If you don't specify a second argument to these methods, you'll create a **passthrough slot**. Arbitrary content can be
-rendered inside these slots. If you need to render arbitrary markup or components, these may be the way to go.
+If you don't specify a second argument to these methods, you'll create a
+**passthrough slot**. Any content you pass through can be rendered inside these
+slots. If you don't want to strictly specify what should go in the slot you're
+making, these may be the way to go.
 
 For example:
 

--- a/docs/guide/slots.md
+++ b/docs/guide/slots.md
@@ -6,8 +6,7 @@ parent: Guide
 
 # Slots
 
-In addition to the `content` accessor, ViewComponents accept content through slots. Slots are dedicated areas of a
-component that render content, including other components.
+In addition to the `content` accessor, ViewComponents can accept content through slots. Think of slots as a way to render multiple blocks of content, including other components.
 
 Slots are defined with `renders_one` and `renders_many`:
 
@@ -115,8 +114,7 @@ end
 
 ## Lambda slots
 
-Slots can be defined as lambdas that returns content to be rendered. Lambda slots are useful when you're outputting
-basic markup that doesn't warrant its own component yet.
+It's also possible to define a slot as a lambda that returns content to be rendered (either a string or a ViewComponent instance). Lambda slots are useful in cases where writing another component may be unnecessary, such as working with helpers like `content_tag` or as wrappers for another ViewComponent with specific default values:
 
 ```ruby
 class BlogComponent < ViewComponent::Base
@@ -129,8 +127,7 @@ class BlogComponent < ViewComponent::Base
     end
   end
 
-  # They can also be used as wrappers for another ViewComponent with preset
-  # default values
+  # It's also possible to return another ViewComponent with preset default values:
   renders_many :posts, -> (title:, classes:) do
     PostComponent.new(title: title, classes: "my-default-class " + classes)
   end
@@ -153,8 +150,7 @@ end
 
 ## Rendering collections
 
-`renders_many` slots can also be passed a collection. Instead of repeatedly calling the singular slot name (e.g.
-`c.link`), you can pass the arguments as an array.
+`renders_many` slots can also be passed a collection, using the plural setter (`links` in this example):
 
 ```ruby
 # navigation_component.rb

--- a/docs/guide/slots.md
+++ b/docs/guide/slots.md
@@ -13,7 +13,7 @@ Slots are defined with `renders_one` and `renders_many`:
 - `renders_one` defines a slot that will be rendered at most once per component: `renders_one :header`
 - `renders_many` defines a slot that can be rendered multiple times per-component: `renders_many :posts`
 
-If a second argument is not provided to these methods, a **passthrough slot** is registered. Any content passed through can be rendered inside these slots without restriction.
+If a second argument isn't provided to these methods, a **passthrough slot** is registered. Any content passed through can be rendered inside these slots without restriction.
 
 For example:
 

--- a/docs/guide/slots.md
+++ b/docs/guide/slots.md
@@ -65,9 +65,9 @@ The rendered output will look like this:
 
 ## Component slots
 
-Slots can also render other components. Pass the name of the component as the second argument. Component slots are
-useful when you want to render a specific component, but still allow full control of the arguments that are passed to
-it.
+Slots can also render other components. Pass the name of a component as the second argument to define a component slot.
+
+Any arguments you pass when calling a component slot will be used to initialize the component and render it. You can also pass a block to set that component's content and slots.
 
 ```ruby
 # blog_component.rb

--- a/docs/guide/slots.md
+++ b/docs/guide/slots.md
@@ -13,10 +13,7 @@ Slots are defined with `renders_one` and `renders_many`:
 - `renders_one` defines a slot that will be rendered at most once per component: `renders_one :header`
 - `renders_many` defines a slot that can be rendered multiple times per-component: `renders_many :posts`
 
-If you don't specify a second argument to these methods, you'll create a
-**passthrough slot**. Any content you pass through can be rendered inside these
-slots. If you don't want to strictly specify what should go in the slot you're
-making, these may be the way to go.
+If a second argument is not provided to these methods, a **passthrough slot** is registered. Any content passed through can be rendered inside these slots without restriction.
 
 For example:
 
@@ -56,7 +53,7 @@ To render a `renders_many` slot, iterate over the name of the slot:
 <% end %>
 ```
 
-The rendered output will look like this:
+Returning:
 
 ```erb
 <h1><a href="/">My blog</a></h1>
@@ -69,7 +66,7 @@ The rendered output will look like this:
 
 Slots can also render other components. Pass the name of a component as the second argument to define a component slot.
 
-Any arguments you pass when calling a component slot will be used to initialize the component and render it. You can also pass a block to set that component's content and slots.
+Arguments passed when calling a component slot will be used to initialize the component and render it. A block can also be passed to set the component's content.
 
 ```ruby
 # blog_component.rb


### PR DESCRIPTION
<!-- See https://github.com/github/view_component/blob/main/docs/CONTRIBUTING.md#submitting-a-pull-request -->

### Summary

I emailed @joelhawksley after discovering #1031 with @ollie-nye, since I'd identified some patterns in how folks are using slots. The aim of this PR is to make it clearer that slots render content and don't pass data.

This might make the docs a little more verbose and revert some of #956 by reintroducing passthrough slots as an official term, but I think that's important to make the distinction.

### Other Information

I also removed the comment under lambda slots stating that they "render the returned string". This isn't 100% true, because a component can also be the return value of a lambda slot's lambda, and that gets rendered in. 