### PR TITLE
release 2.38.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,7 +87,7 @@ GIT
 PATH
   remote: .
   specs:
-    view_component (2.37.0)
+    view_component (2.38.0)
       activesupport (>= 5.0.0, < 8.0)
       method_source (~> 1.0)
 
@@ -256,4 +256,4 @@ DEPENDENCIES
   yard-activesupport-concern
 
 BUNDLED WITH
-   2.2.20
+   2.2.22

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,8 @@ title: Changelog
 
 ## main
 
+## 2.38.0
+
 * Add `--stimulus` flag to the component generator. Generates a Stimulus controller alongside the component.
 * Add config option `config.view_component.generate_stimulus_controller` to always generate a Stimulus controller.
 

--- a/lib/view_component/version.rb
+++ b/lib/view_component/version.rb
@@ -3,7 +3,7 @@
 module ViewComponent
   module VERSION
     MAJOR = 2
-    MINOR = 37
+    MINOR = 38
     PATCH = 0
 
     STRING = [MAJOR, MINOR, PATCH].join(".")


### PR DESCRIPTION
<!-- See https://github.com/github/view_component/blob/main/docs/CONTRIBUTING.md#submitting-a-pull-request -->

### Summary

* Add `--stimulus` flag to the component generator. Generates a Stimulus controller alongside the component.
* Add config option `config.view_component.generate_stimulus_controller` to always generate a Stimulus controller.

    *Sebastien Auriault*

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file. -->
