### PR TITLE
Deprecate Base#with_variant

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,10 @@ title: Changelog
 
     *Blake Williams*, *Cameron Dutro*, *Joel Hawksley*
 
+* Deprecate `Base#with_variant`.
+
+    *Cameron Dutro*
+
 ## 2.38.0
 
 * Add `--stimulus` flag to the component generator. Generates a Stimulus controller alongside the component.

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -218,9 +218,15 @@ module ViewComponent
 
     # Use the provided variant instead of the one determined by the current request.
     #
+    # @deprecated Define separate per-variant templates instead. Will be removed in v3.0.0.
     # @param variant [Symbol] The variant to be used by the component.
     # @return [self]
     def with_variant(variant)
+      ActiveSupport::Deprecation.warn(
+        "`with_variant` is deprecated and will be removed in ViewComponent v3.0.0.\n\n" \
+        "Define separate per-variant templates instead."
+      )
+
       @__vc_variant = variant
 
       self

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -218,7 +218,7 @@ module ViewComponent
 
     # Use the provided variant instead of the one determined by the current request.
     #
-    # @deprecated Define separate per-variant templates instead. Will be removed in v3.0.0.
+    # @deprecated Will be removed in v3.0.0.
     # @param variant [Symbol] The variant to be used by the component.
     # @return [self]
     def with_variant(variant)

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -223,8 +223,7 @@ module ViewComponent
     # @return [self]
     def with_variant(variant)
       ActiveSupport::Deprecation.warn(
-        "`with_variant` is deprecated and will be removed in ViewComponent v3.0.0.\n\n" \
-        "Define separate per-variant templates instead."
+        "`with_variant` is deprecated and will be removed in ViewComponent v3.0.0."
       )
 
       @__vc_variant = variant


### PR DESCRIPTION
### Summary

Deprecates `Base#with_variant`. Variants are an often misunderstood feature that use the Action Pack variant information present in the request (i.e. phone, tablet, etc) to render a component differently depending on the requesting device. Normally one passes in a list of acceptable variants in an Action View template, eg:

```ruby
render(MyComponent.new, variants: [:phone, :tablet])
```

The variant can be overridden by calling `#with_variant` on the component, eg:

```ruby
class MyComponent < ViewComponent::Base
  def call
    render(OtherComponent.new.with_variant(:tablet))
  end
end
```

It's important to note that these are two distinct `render` functions (the second does not accept a `:variants` option). Since components don't have access to the request object, it doesn't really make sense for them to decide which variant to render (that's probably why `:variants` isn't available in the first place). The consensus on the team was that overriding the variant is something that should really only be done in a test environment and not supported otherwise.