### PR TITLE
Docs cleanups

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,10 @@ title: Changelog
 
     *Blake Williams*, *Cameron Dutro*, *Joel Hawksley*
 
+* Update docs page to be called Javascript and CSS, rename Building ViewComponents to Guide.
+
+    *Joel Hawksley*
+
 ## 2.38.0
 
 * Add `--stimulus` flag to the component generator. Generates a Stimulus controller alongside the component.

--- a/docs/guide/collections.md
+++ b/docs/guide/collections.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Collections
-parent: Building ViewComponents
+parent: Guide
 ---
 
 # Collections

--- a/docs/guide/conditional_rendering.md
+++ b/docs/guide/conditional_rendering.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Conditional rendering
-parent: Building ViewComponents
+parent: Guide
 ---
 
 # Conditional rendering

--- a/docs/guide/generators.md
+++ b/docs/guide/generators.md
@@ -66,7 +66,7 @@ bin/rails generate component Example title --preview
       create    app/components/example_component.html.erb
 ```
 
-### Generate a [Stimulus controller](/guide/sidecar_assets.html#stimulus)
+### Generate a [Stimulus controller](/guide/javascript_and_css.html#stimulus)
 
 ```console
 bin/rails generate component Example title --stimulus
@@ -82,7 +82,7 @@ bin/rails generate component Example title --stimulus
 
 To always generate a Stimulus controller, set `config.view_component.generate_stimulus_controller = true`.
 
-### Place the view in a [sidecar directory](/guide/sidecar_assets.html)
+### Place the view in a sidecar directory
 
 ```console
 bin/rails generate component Example title --sidecar

--- a/docs/guide/generators.md
+++ b/docs/guide/generators.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Generators
-parent: Building ViewComponents
+parent: Guide
 ---
 
 # Generators

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Getting started
-parent: Building ViewComponents
+parent: Guide
 nav_order: 1
 ---
 

--- a/docs/guide/helpers.md
+++ b/docs/guide/helpers.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Helpers
-parent: Building ViewComponents
+parent: Guide
 ---
 
 # Helpers

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -1,8 +1,8 @@
 ---
 layout: default
-title: Building ViewComponents
+title: Guide
 nav_order: 3
 has_children: true
 ---
 
-# Building ViewComponents
+# Guide

--- a/docs/guide/instrumentation.md
+++ b/docs/guide/instrumentation.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Instrumentation
-parent: Building ViewComponents
+parent: Guide
 ---
 
 # Instrumentation

--- a/docs/guide/javascript_and_css.md
+++ b/docs/guide/javascript_and_css.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Javascript and CSS
-parent: Building ViewComponents
+parent: Guide
 ---
 
 # Javascript and CSS (experimental)

--- a/docs/guide/javascript_and_css.md
+++ b/docs/guide/javascript_and_css.md
@@ -1,14 +1,14 @@
 ---
 layout: default
-title: Sidecar assets
+title: Javascript and CSS
 parent: Building ViewComponents
 ---
 
-# Sidecar assets (experimental)
+# Javascript and CSS (experimental)
 
-It’s possible to include Javascript and CSS alongside components, sometimes called "sidecar" assets or files.
+While ViewComponent does not provide any built-in tooling to do so, it’s possible to include Javascript and CSS alongside components.
 
-To use the Webpacker gem to compile sidecar assets located in `app/components`:
+To use the Webpacker gem to compile assets located in `app/components`:
 
 1. In `config/webpacker.yml`, add `"app/components"` to the `additional_paths` array (e.g. `additional_paths: ["app/components"]`).
 2. In the Webpack entry file (often `app/javascript/packs/application.js`), add an import statement to a helper file, and in the helper file, import the components' Javascript:
@@ -29,11 +29,11 @@ importAll(require.context("../components", true, /[_\/]component\.js$/))
 
 Any file with the `_component.js` suffix (such as `app/components/widget_component.js`) will be compiled into the Webpack bundle. If that file itself imports another file, for example `app/components/widget_component.css`, it will also be compiled and bundled into Webpack's output stylesheet if Webpack is being used for styles.
 
-## Encapsulating sidecar assets
+## Encapsulating assets
 
-Ideally, sidecar Javascript/CSS should not "leak" out of the context of its associated component.
+Ideally, Javascript and CSS should be scoped to the associated component.
 
-One approach is to use Web Components, which contain all Javascript functionality, internal markup, and styles within the shadow root of the Web Component.
+One approach is to use Web Components which contain all Javascript functionality, internal markup, and styles within the shadow root of the Web Component.
 
 For example:
 

--- a/docs/guide/lifecycle.md
+++ b/docs/guide/lifecycle.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Lifecycle
-parent: Building ViewComponents
+parent: Guide
 ---
 
 # Lifecycle

--- a/docs/guide/previews.md
+++ b/docs/guide/previews.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Previews
-parent: Building ViewComponents
+parent: Guide
 ---
 
 # Previews

--- a/docs/guide/slots.md
+++ b/docs/guide/slots.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Slots
-parent: Building ViewComponents
+parent: Guide
 ---
 
 # Slots

--- a/docs/guide/templates.md
+++ b/docs/guide/templates.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Templates
-parent: Building ViewComponents
+parent: Guide
 ---
 
 # Templates

--- a/docs/guide/testing.md
+++ b/docs/guide/testing.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Testing
-parent: Building ViewComponents
+parent: Guide
 ---
 
 # Testing

--- a/docs/guide/translations.md
+++ b/docs/guide/translations.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Translations
-parent: Building ViewComponents
+parent: Guide
 ---
 
 # Translations (experimental)


### PR DESCRIPTION
### Summary

This PR:

1) Renames `sidecar assets` to `Javascript and CSS` to make it easier to find.
2) Renames `Building ViewComponents` to `Guide` to match the URL for this section. It also doesn't cover much about actually building ViewComponents, something we should try to improve in future documentation.