### PR TITLE
Prevent nil from being returned from a Slot V2's to_s method

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,7 +15,7 @@ title: Changelog
 
     *Nicolas Brousse*
 
-* Fix bug when using Slim and writing a slot whose block evaluates to `nil`
+* Fix bug when using Slim and writing a slot whose block evaluates to `nil`.
 
     *Yousuf Jukaku*
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,10 @@ title: Changelog
 
     *Nicolas Brousse*
 
+* Fix bug when using Slim and writing a slot whose block evaluates to `nil`
+
+    *Yousuf Jukaku*
+
 ## 2.39.0
 
 * Clarify documentation of `with_variant` as an override of Action Pack.

--- a/lib/view_component/slot_v2.rb
+++ b/lib/view_component/slot_v2.rb
@@ -64,7 +64,7 @@ module ViewComponent
           @__vc_content_set_by_with_content
              end
 
-      @content
+      @content = @content.to_s
     end
 
     # Allow access to public component methods via the wrapper

--- a/test/sandbox/app/components/empty_slot_v2_with_slim_component.html.slim
+++ b/test/sandbox/app/components/empty_slot_v2_with_slim_component.html.slim
@@ -1,0 +1,3 @@
+span
+  ' Hello
+  = title

--- a/test/sandbox/app/components/empty_slot_v2_with_slim_component.rb
+++ b/test/sandbox/app/components/empty_slot_v2_with_slim_component.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class EmptySlotV2WithSlimComponent < ViewComponent::Base
+  renders_one :title
+end

--- a/test/sandbox/app/views/integration_examples/empty_slot_v2_with_slim.html.slim
+++ b/test/sandbox/app/views/integration_examples/empty_slot_v2_with_slim.html.slim
@@ -1,0 +1,3 @@
+= render(EmptySlotV2WithSlimComponent.new) do |component|
+  - component.title
+    - nil

--- a/test/sandbox/config/routes.rb
+++ b/test/sandbox/config/routes.rb
@@ -5,6 +5,7 @@ Sandbox::Application.routes.draw do
   get :content_areas, to: "integration_examples#content_areas"
   get :slots, to: "integration_examples#slots"
   get :empty_slot, to: "integration_examples#empty_slot"
+  get :empty_slot_v2_with_slim, to: "integration_examples#empty_slot_v2_with_slim"
   get :partial, to: "integration_examples#partial"
   get :content, to: "integration_examples#content"
   get :variants, to: "integration_examples#variants"

--- a/test/view_component/integration_test.rb
+++ b/test/view_component/integration_test.rb
@@ -407,6 +407,12 @@ class IntegrationTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  def test_renders_empty_slot_v2_with_slim_without_error
+    get "/empty_slot_v2_with_slim"
+
+    assert_response :success
+  end
+
   if Rails.version.to_f >= 6.1
     def test_rendering_component_using_the_render_component_helper_raises_an_error
       error =

--- a/test/view_component/slotable_v2_test.rb
+++ b/test/view_component/slotable_v2_test.rb
@@ -272,6 +272,17 @@ class SlotsV2sTest < ViewComponent::TestCase
     assert_selector("p", text: "Footer part 2")
   end
 
+  def test_slot_with_block_content_returning_nil
+    component = SlotsV2Component.new
+    slot = component.title nil
+    slot.__vc_content_block = Proc.new { nil }
+    # Render the component so that the slot has a view_context
+    render_inline component
+
+    # No matter what, the slot shouldn't return nil from `to_s`
+    assert_not_nil(slot.to_s)
+  end
+
   def test_lambda_slot_with_missing_block
     render_inline(SlotsV2Component.new(classes: "mt-4")) do |component|
       component.footer(classes: "text-blue")

--- a/test/view_component/slotable_v2_test.rb
+++ b/test/view_component/slotable_v2_test.rb
@@ -272,17 +272,6 @@ class SlotsV2sTest < ViewComponent::TestCase
     assert_selector("p", text: "Footer part 2")
   end
 
-  def test_slot_with_block_content_returning_nil
-    component = SlotsV2Component.new
-    slot = component.title nil
-    slot.__vc_content_block = Proc.new { nil }
-    # Render the component so that the slot has a view_context
-    render_inline component
-
-    # No matter what, the slot shouldn't return nil from `to_s`
-    assert_not_nil(slot.to_s)
-  end
-
   def test_lambda_slot_with_missing_block
     render_inline(SlotsV2Component.new(classes: "mt-4")) do |component|
       component.footer(classes: "text-blue")


### PR DESCRIPTION
### Summary

Closes #1044 

When using `slim-rails` (and probably other temple-based languages), it's possible that a block defined in a Slim view evaluates to `nil`. When that block gets processed in a SlotV2's `to_s` method, that `nil` from the block can end up as the return value.

Returning `nil` from a call to `to_s` doesn't make sense and causes errors to be raised when rendering the view, so this patch prevents that from happening and instead returns an empty string.

### Other Information

I don't think the test I included is a good way to test this, but I can't think of a way to get the "real" issue to happen. `render_inline` doesn't raise an error like a Rails app using Slim will, because the temple gem used by Slim is what's raising the actual error I'm seeing in our app.

Perhaps instead of the test, I can include a comment next to the actual code change explaining that @content can be set to `nil` with certain template languages?