### PR TITLE
Error out in the CI if docs/api.md has to be regenerated

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,26 @@ jobs:
         bundle install --jobs 4 --retry 3
         bundle exec rubocop
         bundle exec erblint **/*.html.erb
+  docs_api:
+    needs: lint
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Setup Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 2.7.2
+    - uses: actions/cache@v2
+      with:
+        path: vendor/bundle
+        key: gems-build-rails-main-ruby-2.7.2-${{ hashFiles('**/Gemfile.lock') }}
+    - name: Generate docs/api.md from YARD comments
+      run: |
+        bundle config path vendor/bundle
+        bundle update
+        bundle exec rake docs:build
+    - name: Error out if docs/api.md has to be regenerated
+      run: git diff --exit-code docs/api.md || echo '::error file=docs/api.md.md,line=1,col=1::Please make sure to run `bundle exec rake docs:build` to regenerate docs/api.md to include changes in YARD comments from this pull request.'
   benchmark:
     needs: lint
     runs-on: ubuntu-latest

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -19,6 +19,10 @@ title: Changelog
 
     *Cameron Dutro*
 
+* Error out in the CI if docs/api.md has to be regenerated.
+
+    *Dany Marcoux*
+
 ## 2.38.0
 
 * Add `--stimulus` flag to the component generator. Generates a Stimulus controller alongside the component.


### PR DESCRIPTION
### Summary

Regenerating the API docs can be easily forgotten whenever creating/updating YARD comments. With the CI, this can be prevented.

### Other Information

I based the new job on the existing `benchmark` job.

Committing the changes in the API docs could be done, but I think it's better to let the PR submitter handle this since it can vary from a PR to another depending on the number of commits.