### PR TITLE
Replace antipatterns with best practices

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,10 @@ title: Changelog
 
 ## main
 
+* Replace antipatterns section in the documentation with best practices.
+
+    *Blake Williams*
+
 * Add components to `rails stats` task.
 
     *Nicolas Brousse*

--- a/docs/guide/testing.md
+++ b/docs/guide/testing.md
@@ -26,9 +26,9 @@ end
 
 _Note: `assert_selector` only matches on visible elements by default. To match on hidden elements, add `visible: false`. See the [Capybara documentation](https://rubydoc.info/github/jnicklas/capybara/Capybara/Node/Matchers) for more details._
 
-## Antipatterns
+## Best practices
 
-Avoid testing ViewComponent instance methods directly. Test the rendered output to ensure the correct behavior for the consumer of the ViewComponent:
+Prefer testing the behavior of your component over unit testing individual methods:
 
 ```ruby
 # Good


### PR DESCRIPTION
This re-frames the anti-pattern section of the docs as best practices. I think this may help convey the intentions behind the documentation.