### PR TITLE
Allow query parameters in `with_request_url`

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,10 @@ title: Changelog
 
 ## main
 
+* Allow query parameters in `with_request_url` test helper.
+
+    *Javi Martín*
+
 * Replace antipatterns section in the documentation with best practices.
 
     *Blake Williams*

--- a/docs/guide/testing.md
+++ b/docs/guide/testing.md
@@ -137,6 +137,19 @@ class ExampleComponentTest < ViewComponent::TestCase
 end
 ```
 
+It's also possible to set query parameters:
+
+```ruby
+class ExampleComponentTest < ViewComponent::TestCase
+  def test_with_request_url
+    with_request_url "/products/42?locale=en" do
+      render_inline ExampleComponent.new # contains i.e. `link_to "Recent", url_for(request.query_parameters.merge(filter: "recent"))`
+      assert_link "Recent", href: "/?locale=en&filter=recent"
+    end
+  end
+end
+```
+
 ## RSpec configuration
 
 To use RSpec, add the following:

--- a/docs/index.md
+++ b/docs/index.md
@@ -131,6 +131,7 @@ ViewComponent is built by over a hundred members of the community, including:
 <img src="https://avatars.githubusercontent.com/g13ydson?s=64" alt="g13ydson" width="32" />
 <img src="https://avatars.githubusercontent.com/horacio?s=64" alt="horacio" width="32" />
 <img src="https://avatars.githubusercontent.com/jaredcwhite?s=64" alt="jaredcwhite" width="32" />
+<img src="https://avatars.githubusercontent.com/javierm?s=64" alt="javierm" width="32" />
 <img src="https://avatars.githubusercontent.com/jcoyne?s=64" alt="jcoyne" width="32" />
 <img src="https://avatars.githubusercontent.com/jensljungblad?s=64" alt="jensljungblad" width="32" />
 <img src="https://avatars.githubusercontent.com/joelhawksley?s=64" alt="joelhawksley" width="32" />

--- a/lib/view_component/test_helpers.rb
+++ b/lib/view_component/test_helpers.rb
@@ -73,12 +73,15 @@ module ViewComponent
 
     def with_request_url(path)
       old_request_path_parameters = request.path_parameters
+      old_request_query_parameters = request.query_parameters
       old_controller = defined?(@controller) && @controller
 
       request.path_parameters = Rails.application.routes.recognize_path(path)
+      request.set_header("action_dispatch.request.query_parameters", Rack::Utils.parse_query(path.split("?")[1]))
       yield
     ensure
       request.path_parameters = old_request_path_parameters
+      request.set_header("action_dispatch.request.query_parameters", old_request_query_parameters)
       @controller = old_controller
     end
 

--- a/test/sandbox/app/components/url_for_component.html.erb
+++ b/test/sandbox/app/components/url_for_component.html.erb
@@ -1,1 +1,1 @@
-<%= url_for(key: "value") %>
+<%= url_for({ key: "value" }.merge(request.query_parameters)) %>

--- a/test/view_component/view_component_test.rb
+++ b/test/view_component/view_component_test.rb
@@ -838,6 +838,23 @@ class ViewComponentTest < ViewComponent::TestCase
     end
   end
 
+  def test_with_request_url_with_query_parameters
+    with_request_url "/?mykey=myvalue" do
+      render_inline UrlForComponent.new
+      assert_text "/?key=value&mykey=myvalue"
+    end
+
+    with_request_url "/?mykey=myvalue&otherkey=othervalue" do
+      render_inline UrlForComponent.new
+      assert_text "/?key=value&mykey=myvalue&otherkey=othervalue"
+    end
+
+    with_request_url "/products?mykey=myvalue" do
+      render_inline UrlForComponent.new
+      assert_text "/products?key=value&mykey=myvalue"
+    end
+  end
+
   def test_output_postamble
     render_inline(AfterRenderComponent.new)
 


### PR DESCRIPTION
### Summary

Query parameters were ignored when using the `with_request_url` test helper. With these changes, that's no longer the case :smile:.

### Other Information

My knowledge of the internals of Rails routing is very limited, so if there's a more elegant solution than using `set_header` and `parse_query`, please let me know! :wink: