### PR TITLE
Add basic documentation for test helpers

### DIFF
--- a/.github/lint/markdown.json
+++ b/.github/lint/markdown.json
@@ -5,5 +5,6 @@
   "no-trailing-punctuation": false,
   "no-inline-html": false,
   "first-line-heading": false,
-  "single-h1": false
+  "single-h1": false,
+  "code-block-style": "fenced"
 }

--- a/.github/lint/markdown.json
+++ b/.github/lint/markdown.json
@@ -6,5 +6,5 @@
   "no-inline-html": false,
   "first-line-heading": false,
   "single-h1": false,
-  "code-block-style": "fenced"
+  "code-block-style": false
 }

--- a/Rakefile
+++ b/Rakefile
@@ -151,6 +151,42 @@ namespace :docs do
           f.puts("_#{method.tag(:deprecated).text}_")
         end
       end
+
+      f.puts
+      f.puts("## ViewComponent::TestHelpers")
+
+      registry.
+        get("ViewComponent::TestHelpers").
+        meths.
+        sort_by { |method| method[:name] }.
+        select do |method|
+          !method.tag(:private) &&
+            method.visibility == :public
+        end.
+        each do |method|
+          suffix =
+            if method.tag(:deprecated)
+              " (Deprecated)"
+            end
+
+          types =
+            if method.tag(:return)&.types
+              " → [#{method.tag(:return).types.join(',')}]"
+            end
+
+          f.puts
+          f.puts("### #{method.sep}#{method.signature.gsub('def ', '')}#{types}#{suffix}")
+
+          if method.docstring.length > 0
+            f.puts
+            f.puts(method.docstring)
+          end
+
+          if method.tag(:deprecated)
+            f.puts
+            f.puts("_#{method.tag(:deprecated).text}_")
+          end
+        end
     end
   end
 end

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -19,6 +19,10 @@ title: Changelog
 
     *Yousuf Jukaku*
 
+* Add documentation for test helpers.
+
+    *Joel Hawksley*
+
 ## 2.39.0
 
 * Clarify documentation of `with_variant` as an override of Action Pack.

--- a/docs/api.md
+++ b/docs/api.md
@@ -143,3 +143,46 @@ Path for component files
     config.view_component.view_component_path = "app/my_components"
 
 Defaults to "app/components".
+
+## ViewComponent::TestHelpers
+
+### #render_inline(component, **args, &block) → [Nokogiri::HTML]
+
+Render a component inline. Internally sets `page` to be a `Capybara::Node::Simple`,
+allowing for Capybara assertions to be used:
+
+```ruby
+render_inline(MyComponent.new)
+assert_text("Hello, World!")
+```
+
+### #with_controller_class(klass)
+
+Set the controller to be used while executing the given block,
+allowing access to controller-specific methods:
+
+```ruby
+with_controller_class(UsersController) do
+  render_inline(MyComponent.new)
+end
+```
+
+### #with_request_url(path)
+
+Set the URL for the current request (such as when using request-dependent path helpers):
+
+```ruby
+with_request_url("/users/42") do
+  render_inline(MyComponent.new)
+end
+```
+
+### #with_variant(variant)
+
+Set the Action Pack request variant for the given block:
+
+```ruby
+with_variant(:phone) do
+  render_inline(MyComponent.new)
+end
+```

--- a/lib/view_component/test_helpers.rb
+++ b/lib/view_component/test_helpers.rb
@@ -27,8 +27,19 @@ module ViewComponent
       # :nocov:
     end
 
+    # @private
     attr_reader :rendered_component
 
+    # Render a component inline. Internally sets `page` to be a `Capybara::Node::Simple`,
+    # allowing for Capybara assertions to be used:
+    #
+    # ```ruby
+    # render_inline(MyComponent.new)
+    # assert_text("Hello, World!")
+    # ```
+    #
+    # @param component [ViewComponent::Base] The instance of the component to be rendered.
+    # @return [Nokogiri::HTML]
     def render_inline(component, **args, &block)
       @rendered_component =
         if Rails.version.to_f >= 6.1
@@ -40,10 +51,12 @@ module ViewComponent
       Nokogiri::HTML.fragment(@rendered_component)
     end
 
+    # @private
     def controller
       @controller ||= build_controller(Base.test_controller.constantize)
     end
 
+    # @private
     def request
       @request ||=
         begin
@@ -53,6 +66,15 @@ module ViewComponent
         end
     end
 
+    # Set the Action Pack request variant for the given block:
+    #
+    # ```ruby
+    # with_variant(:phone) do
+    #   render_inline(MyComponent.new)
+    # end
+    # ```
+    #
+    # @param variant [Symbol] The variant to be set for the provided block.
     def with_variant(variant)
       old_variants = controller.view_context.lookup_context.variants
 
@@ -62,6 +84,16 @@ module ViewComponent
       controller.view_context.lookup_context.variants = old_variants
     end
 
+    # Set the controller to be used while executing the given block,
+    # allowing access to controller-specific methods:
+    #
+    # ```ruby
+    # with_controller_class(UsersController) do
+    #   render_inline(MyComponent.new)
+    # end
+    # ```
+    #
+    # @param klass [ActionController::Base] The controller to be used.
     def with_controller_class(klass)
       old_controller = defined?(@controller) && @controller
 
@@ -71,6 +103,15 @@ module ViewComponent
       @controller = old_controller
     end
 
+    # Set the URL for the current request (such as when using request-dependent path helpers):
+    #
+    # ```ruby
+    # with_request_url("/users/42") do
+    #   render_inline(MyComponent.new)
+    # end
+    # ```
+    #
+    # @param path [String] The path to set for the current request.
     def with_request_url(path)
       old_request_path_parameters = request.path_parameters
       old_controller = defined?(@controller) && @controller
@@ -82,6 +123,7 @@ module ViewComponent
       @controller = old_controller
     end
 
+    # @private
     def build_controller(klass)
       klass.new.tap { |c| c.request = request }.extend(Rails.application.routes.url_helpers)
     end


### PR DESCRIPTION
### Summary

This PR introduces preliminary API documentation for `ViewComponent::TestHelpers`.
