### PR TITLE
Allow disabling of collection parameter validation

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,10 @@ title: Changelog
 
 ## main
 
+* Allow disabling of `validate_collection_parameter` checks.
+
+    *Patrick Arnett*
+
 * Replace antipatterns section in the documentation with best practices.
 
     *Blake Williams*

--- a/docs/api.md
+++ b/docs/api.md
@@ -71,6 +71,14 @@ Set a custom default layout used for preview index and individual previews:
 
     config.view_component.default_preview_layout = "component_preview"
 
+### #enforce_collection_parameter
+
+Enable or disable enforcement of collection parameter as keyword argument in component initializer:
+
+    config.view_component.enforce_collection_parameter = false
+
+Defaults to `true`.
+
 ### #generate_stimulus_controller
 
 Always generate a Stimulus controller alongside the component:

--- a/docs/guide/collections.md
+++ b/docs/guide/collections.md
@@ -44,6 +44,7 @@ end
 By default, `.with_collection` raises an error when the collection parameter is not explicitly included in the `initialize` signature as a keyword argument.
 
 This behavior can be suppressed by setting
+
 ```ruby
 # config/application.rb
 config.view_component.enforce_collection_parameter = false

--- a/docs/guide/collections.md
+++ b/docs/guide/collections.md
@@ -39,6 +39,16 @@ class ProductComponent < ViewComponent::Base
 end
 ```
 
+## Collection parameter validation
+
+By default, `.with_collection` raises an error when the collection parameter is not explicitly included in the `initialize` signature as a keyword argument.
+
+This behavior can be suppressed by setting
+```ruby
+# config/application.rb
+config.view_component.enforce_collection_parameter = false
+```
+
 ## Additional arguments
 
 Additional arguments besides the collection are passed to each component instance:

--- a/docs/index.md
+++ b/docs/index.md
@@ -174,6 +174,7 @@ ViewComponent is built by over a hundred members of the community, including:
 <img src="https://avatars.githubusercontent.com/ryogift?s=64" alt="ryogift" width="32" />
 <img src="https://avatars.githubusercontent.com/andrewjtait?s=64" alt="andrewjtait" width="32" />
 <img src="https://avatars.githubusercontent.com/websebdev?s=64" alt="websebdev" width="32" />
+<img src="https://avatars.githubusercontent.com/patrickarnett?s=64" alt="patrickarnett" width="32" />
 
 <hr />
 

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -298,6 +298,14 @@ module ViewComponent
     # Defaults to "app/components".
     mattr_accessor :view_component_path, instance_writer: false, default: "app/components"
 
+    # Enable or disable enforcement of collection parameter as keyword argument in component initializer:
+    #
+    #     config.view_component.enforce_collection_parameter = false
+    #
+    # Defaults to `true`.
+    #
+    mattr_accessor :enforce_collection_parameter, instance_writer: false, default: true
+
     class << self
       # @private
       attr_accessor :source_location, :virtual_path

--- a/lib/view_component/collection.rb
+++ b/lib/view_component/collection.rb
@@ -10,8 +10,7 @@ module ViewComponent
 
     def render_in(view_context, &block)
       iterator = ActionView::PartialIteration.new(@collection.size)
-
-      component.validate_collection_parameter!(validate_default: true)
+      component.validate_collection_parameter!(validate_default: true) if ViewComponent::Base.enforce_collection_parameter
 
       @collection.map do |item|
         content = component.new(**component_options(item, iterator)).render_in(view_context, &block)

--- a/lib/view_component/collection.rb
+++ b/lib/view_component/collection.rb
@@ -10,7 +10,9 @@ module ViewComponent
 
     def render_in(view_context, &block)
       iterator = ActionView::PartialIteration.new(@collection.size)
-      component.validate_collection_parameter!(validate_default: true) if ViewComponent::Base.enforce_collection_parameter
+      if ViewComponent::Base.enforce_collection_parameter
+        component.validate_collection_parameter!(validate_default: true)
+      end
 
       @collection.map do |item|
         content = component.new(**component_options(item, iterator)).render_in(view_context, &block)

--- a/lib/view_component/compiler.rb
+++ b/lib/view_component/compiler.rb
@@ -37,7 +37,7 @@ module ViewComponent
 
       if raise_errors
         component_class.validate_initialization_parameters!
-        component_class.validate_collection_parameter!
+        component_class.validate_collection_parameter! if ViewComponent::Base.enforce_collection_parameter
       end
 
       templates.each do |template|

--- a/test/sandbox/app/components/missing_collection_parameter_name_component.rb
+++ b/test/sandbox/app/components/missing_collection_parameter_name_component.rb
@@ -3,5 +3,5 @@
 class MissingCollectionParameterNameComponent < ViewComponent::Base
   with_collection_parameter :foo
 
-  def initialize(bar:); end
+  def initialize(**opts); end
 end

--- a/test/view_component/view_component_test.rb
+++ b/test/view_component/view_component_test.rb
@@ -691,6 +691,14 @@ class ViewComponentTest < ViewComponent::TestCase
     )
   end
 
+  def test_collection_component_missing_parameter_name_with_enforcement_disabled
+    old_setting = ViewComponent::Base.enforce_collection_parameter
+    ViewComponent::Base.enforce_collection_parameter = false
+    render_inline(MissingCollectionParameterNameComponent.with_collection([]))
+  ensure
+    ViewComponent::Base.enforce_collection_parameter = old_setting
+  end
+
   def test_collection_component_missing_default_parameter_name
     exception =
       assert_raises ArgumentError do
@@ -700,6 +708,14 @@ class ViewComponentTest < ViewComponent::TestCase
       end
 
     assert_match(/MissingDefaultCollectionParameterComponent does not accept the parameter/, exception.message)
+  end
+
+  def test_collection_component_missing_default_parameter_name_with_enforcement_disabled
+    old_setting = ViewComponent::Base.enforce_collection_parameter
+    ViewComponent::Base.enforce_collection_parameter = false
+    render_inline(MissingDefaultCollectionParameterComponent.with_collection([OpenStruct.new(name: "Mints")]))
+  ensure
+    ViewComponent::Base.enforce_collection_parameter = old_setting
   end
 
   def test_component_with_invalid_parameter_names


### PR DESCRIPTION
<!-- See https://github.com/github/view_component/blob/main/docs/CONTRIBUTING.md#submitting-a-pull-request -->

### Summary
This PR adds a config option to disable `validate_collection_parameter` checks.

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file. -->

It feels like an overstep that this gem would require a particular pattern when defining a component's `initialize` method. As long as I set the correct instance variables, why shouldn't I be able to use an options hash if I wish?

When using dry-initializer, specifically, this validation results in useless `initialize` definitions like
```ruby
class MyComponent < ViewComponent::Base
  extend Dry::Initializer

  option :item
  option :another_option

  with_collection_parameter :item

  def initialize(item:, **opts)
    super
  end
end
```
