### PR TITLE
Add "how to render a component to a string" to FAQ

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,7 +14,6 @@ title: Changelog
 * Allow query parameters in `with_request_url` test helper.
 
     *Javi Martín*
-    
 * Add "how to render a component to a string" to FAQ.
 
     *Hans Lemuet*

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ title: Changelog
 * Allow query parameters in `with_request_url` test helper.
 
     *Javi Martín*
+    
+* Add "how to render a component to a string" to FAQ
+
+    *Hans Lemuet*
 
 ## 2.40.0
 
@@ -66,7 +70,7 @@ title: Changelog
 
 * Add test case for conflict with internal `@variant` variable.
 
-   *David Backeus*
+    *David Backeus*
 
 * Document decision to not change naming convention recommendation to remove `-Component` suffix.
 
@@ -130,7 +134,7 @@ title: Changelog
 
 * Ensure consistent indentation with Rubocop.
 
-    *Joel Hawksley
+    *Joel Hawksley*
 
 * Bump `activesupport` upper bound from `< 7.0` to `< 8.0`.
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,7 +11,7 @@ title: Changelog
 
     *Javi Martín*
     
-* Add "how to render a component to a string" to FAQ
+* Add "how to render a component to a string" to FAQ.
 
     *Hans Lemuet*
 

--- a/docs/frequently-asked-questions.md
+++ b/docs/frequently-asked-questions.md
@@ -13,6 +13,24 @@ Yes. ViewComponent is tested against ERB, Haml, and Slim, but it should support 
 
 If the view could benefit from unit testing, making it a ViewComponent is probably a good idea.
 
+## Can I render a ViewComponent to a string, from inside a controller action?
+
+When rendering multiple times the same component, you may want to render it only once, from the controller action, and reuse it.
+
+```rb
+class PagesController < ApplicationController
+  def index
+    # Does not work: triggers a `AbstractController::DoubleRenderError`
+    # @reusable_icon = render IconComponent.new('close')
+    
+    # Does not work: renders the whole index view as a string
+    # @reusable_icon = render_to_string IconComponent.new('close')
+  
+    # Works: renders the component as a string
+    @reusable_icon = IconComponent.new('close').render_in(view_context)
+  end
+```
+
 ## Isn't this just like X library?
 
 ViewComponent is far from a novel idea! Popular implementations of view components in Ruby include, but are not limited to:


### PR DESCRIPTION
### Summary

It's not obvious that you cannot use `render` or `render_to_string` to render a ViewComponent from inside a controller action.

### Other Information

The `#render_in` method is private, but I can't find any other way to achieve this. I think it's a good idea to mention this in the FAQ (especially to help people debug `AbstractController::DoubleRenderError`), but maybe add a disclaimer? Or consider making the method public?