### PR TITLE
Add #render_in to API docs

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,7 +14,12 @@ title: Changelog
 * Allow query parameters in `with_request_url` test helper.
 
     *Javi Martín*
+
 * Add "how to render a component to a string" to FAQ.
+
+    *Hans Lemuet*
+
+* Add `#render_in` to API docs.
 
     *Hans Lemuet*
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -52,31 +52,14 @@ coupling that inhibits encapsulation & reuse, often making testing difficult.
 
 Override to determine whether the ViewComponent should render.
 
-### #render_in(view_context, &block)
+### #render_in(view_context, &block) → [String]
 
 Entrypoint for rendering components.
 
-view_context: ActionView context from calling view
-block: optional block to be captured within the view context
+- `view_context`: ActionView context from calling view
+- `block`: optional block to be captured within the view context
 
-returns HTML that has been escaped by the respective template handler
-
-Example subclass:
-
-app/components/my_component.rb:
-class MyComponent < ViewComponent::Base
-  def initialize(title:)
-    @title = title
-  end
-end
-
-app/components/my_component.html.erb
-<span title="<%= @title %>">Hello, <%= content %>!</span>
-
-In use:
-<%= render MyComponent.new(title: "greeting") do %>world<% end %>
-returns:
-<span title="greeting">Hello, world!</span>
+Returns HTML that has been escaped by the respective template handler.
 
 ### #request → [ActionDispatch::Request]
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -52,6 +52,32 @@ coupling that inhibits encapsulation & reuse, often making testing difficult.
 
 Override to determine whether the ViewComponent should render.
 
+### #render_in(view_context, &block)
+
+Entrypoint for rendering components.
+
+view_context: ActionView context from calling view
+block: optional block to be captured within the view context
+
+returns HTML that has been escaped by the respective template handler
+
+Example subclass:
+
+app/components/my_component.rb:
+class MyComponent < ViewComponent::Base
+  def initialize(title:)
+    @title = title
+  end
+end
+
+app/components/my_component.html.erb
+<span title="<%= @title %>">Hello, <%= content %>!</span>
+
+In use:
+<%= render MyComponent.new(title: "greeting") do %>world<% end %>
+returns:
+<span title="greeting">Hello, world!</span>
+
 ### #request → [ActionDispatch::Request]
 
 The current request. Use sparingly as doing so introduces coupling that

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -39,27 +39,12 @@ module ViewComponent
 
     # Entrypoint for rendering components.
     #
-    # view_context: ActionView context from calling view
-    # block: optional block to be captured within the view context
+    # - `view_context`: ActionView context from calling view
+    # - `block`: optional block to be captured within the view context
     #
-    # returns HTML that has been escaped by the respective template handler
+    # Returns HTML that has been escaped by the respective template handler.
     #
-    # Example subclass:
-    #
-    # app/components/my_component.rb:
-    # class MyComponent < ViewComponent::Base
-    #   def initialize(title:)
-    #     @title = title
-    #   end
-    # end
-    #
-    # app/components/my_component.html.erb
-    # <span title="<%= @title %>">Hello, <%= content %>!</span>
-    #
-    # In use:
-    # <%= render MyComponent.new(title: "greeting") do %>world<% end %>
-    # returns:
-    # <span title="greeting">Hello, world!</span>
+    # @return [String]
     def render_in(view_context, &block)
       self.class.compile(raise_errors: true)
 

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -60,8 +60,6 @@ module ViewComponent
     # <%= render MyComponent.new(title: "greeting") do %>world<% end %>
     # returns:
     # <span title="greeting">Hello, world!</span>
-    #
-    # @private
     def render_in(view_context, &block)
       self.class.compile(raise_errors: true)
 


### PR DESCRIPTION
### Summary

Removed the `@private` YARD tag in order for the `#render_in` instance method to appear in the API docs.

### Other Information

Continued from https://github.com/github/view_component/pull/1068?notification_referrer_id=MDE4Ok5vdGlmaWNhdGlvblRocmVhZDI0MDIyMDE5MjE6Mzg1MjQ%3D#issuecomment-918589884