### PR TITLE
Generator --parent option: add more tests and fix edge case

### DIFF
--- a/lib/rails/generators/component/component_generator.rb
+++ b/lib/rails/generators/component/component_generator.rb
@@ -33,13 +33,9 @@ module Rails
       private
 
       def parent_class
-        if options[:parent]
-          options[:parent]
-        elsif defined?(ApplicationComponent)
-          ApplicationComponent
-        else
-          ViewComponent::Base.component_parent_class
-        end
+        return options[:parent] if options[:parent]
+
+        ViewComponent::Base.component_parent_class || default_parent_class
       end
 
       def initialize_signature
@@ -54,6 +50,10 @@ module Rails
 
       def initialize_call_method_for_inline?
         options["inline"]
+      end
+
+      def default_parent_class
+        defined?(ApplicationComponent) ? ApplicationComponent : ViewComponent::Base
       end
     end
   end

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -287,8 +287,7 @@ module ViewComponent
     #
     # Defaults to "ApplicationComponent" if defined, "ViewComponent::Base" otherwise.
     mattr_accessor :component_parent_class,
-                   instance_writer: false,
-                   default: "ViewComponent::Base"
+                   instance_writer: false
 
     class << self
       # @private

--- a/test/generators/component_generator_test.rb
+++ b/test/generators/component_generator_test.rb
@@ -84,10 +84,30 @@ class ComponentGeneratorTest < Rails::Generators::TestCase
   end
 
   def test_component_with_parent
-    run_generator %w[user --parent MyBaseComponent]
+    run_generator %w[user --parent MyOtherBaseComponent]
 
     assert_file "app/components/user_component.rb" do |component|
-      assert_match(/class UserComponent < MyBaseComponent/, component)
+      assert_match(/class UserComponent < MyOtherBaseComponent/, component)
+    end
+  end
+
+  def test_component_with_parent_and_application_component_class
+    with_application_component_class do
+      run_generator %w[user --parent MyOtherBaseComponent]
+
+      assert_file "app/components/user_component.rb" do |component|
+        assert_match(/class UserComponent < MyOtherBaseComponent/, component)
+      end
+    end
+  end
+
+  def test_component_with_parent_and_custom_component_parent_class
+    with_custom_component_parent_class("MyBaseComponent") do
+      run_generator %w[user --parent MyOtherBaseComponent]
+
+      assert_file "app/components/user_component.rb" do |component|
+        assert_match(/class UserComponent < MyOtherBaseComponent/, component)
+      end
     end
   end
 
@@ -160,6 +180,18 @@ class ComponentGeneratorTest < Rails::Generators::TestCase
 
       assert_file "app/components/user_component.rb" do |component|
         assert_match(/class UserComponent < MyBaseComponent/, component)
+      end
+    end
+  end
+
+  def test_generating_components_with_application_component_class_and_custom_parent_class
+    with_application_component_class do
+      with_custom_component_parent_class("MyBaseComponent") do
+        run_generator %w[user]
+
+        assert_file "app/components/user_component.rb" do |component|
+          assert_match(/class UserComponent < MyBaseComponent/, component)
+        end
       end
     end
   end


### PR DESCRIPTION
### Summary

(Continued from #1073)

I found an edge case: when you both have `ApplicationComponent` defined in your project and configure a `component_parent_class`, `ApplicationComponent` was always used.

I added more tests, fixed the issue and refactored `ComponentGenerator#parent_class`.