### PR TITLE
Preview docs: add link to Lookbook

### DIFF
--- a/docs/guide/previews.md
+++ b/docs/guide/previews.md
@@ -8,7 +8,7 @@ parent: Guide
 
 `ViewComponent::Preview`, like `ActionMailer::Preview`, provides a quick way to preview components in isolation.
 
-_For a more interactive experience, consider using [ViewComponent::Storybook](https://github.com/jonspalmer/view_component_storybook)._
+_For a more interactive experience, consider using [ViewComponent::Storybook](https://github.com/jonspalmer/view_component_storybook) or [Lookbook](https://github.com/allmarkedup/lookbook)._
 
 Define a `ViewComponent::Preview`:
 


### PR DESCRIPTION
### Summary

I suggest we add a link to Lookbook in the docs, as it's a great Ruby alternative to Storybook.

### Other Information

- [Lookbook](https://github.com/allmarkedup/lookbook)
- [Discussion about Lookbook](https://github.com/github/view_component/discussions/1006)