### PR TITLE
Fix indentation of end in slot_v2.rb

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,10 @@ title: Changelog
 
 ## main
 
+* Fix Ruby indentation warning.
+
+    *Blake Williams*
+
 * Add `--parent` generator option to specify the parent class.
 * Add config option `config.view_component.component_parent_class` to change it project-wide.
 

--- a/lib/view_component/slot_v2.rb
+++ b/lib/view_component/slot_v2.rb
@@ -62,7 +62,7 @@ module ViewComponent
           view_context.capture(&@__vc_content_block)
         elsif defined?(@__vc_content_set_by_with_content)
           @__vc_content_set_by_with_content
-             end
+        end
 
       @content = @content.to_s
     end


### PR DESCRIPTION
It looks like Ruby is warning about the indentation of this file in my editor. This can also be seen via running `ruby -w lib/view_component/slot_v2.rb`