### PR TITLE
Add failing test for default form builder

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,10 @@ title: Changelog
 
 ## main
 
+* Add failing test for default form builder
+
+    *Simon Fish*
+
 ## 2.46.0
 
 * Add thread safety to the compiler.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,7 +7,7 @@ title: Changelog
 
 ## main
 
-* Add failing test for default form builder
+* Add failing test for default form builder and documentation around known issue.
 
     *Simon Fish*
 

--- a/docs/known_issues.md
+++ b/docs/known_issues.md
@@ -12,9 +12,10 @@ ViewComponent [isn't currently compatible](https://github.com/github/view_compon
 ## Inconsistent controller rendering behavior between Rails versions
 
 In versions of Rails < 6.1, rendering a ViewComponent from a controller doesn't include the layout.
-## Forms do not use the default form builder
 
-Calls to form helpers such as `form_with` in ViewComponents [do not use the default form builder](https://github.com/github/view_component/pull/1090#issue-753331927). This is by design, as it allows global state to change the rendered output of a component. Instead, consider passing a form builder into form helpers via the `builder` argument:
+## Forms don't use the default form builder
+
+Calls to form helpers such as `form_with` in ViewComponents [don't use the default form builder](https://github.com/github/view_component/pull/1090#issue-753331927). This is by design, as it allows global state to change the rendered output of a component. Instead, consider passing a form builder into form helpers via the `builder` argument:
 
 ```html.erb
 <%= form_for(record, builder: CustomFormBuilder) do |f| %>

--- a/docs/known_issues.md
+++ b/docs/known_issues.md
@@ -14,7 +14,7 @@ ViewComponent [isn't currently compatible](https://github.com/github/view_compon
 In versions of Rails < 6.1, rendering a ViewComponent from a controller doesn't include the layout.
 ## Forms do not use the default form builder
 
-Calls to form helpers such as `form_with` from ViewComponent [will not use the default form builder](https://github.com/github/view_component/pull/1090#issue-753331927). This is by design, as it allows global state to change the rendered output of a component. Instead, you may want to consider passing a form builder into form helpers via the `builder` argument.
+Calls to form helpers such as `form_with` in ViewComponents [do not use the default form builder](https://github.com/github/view_component/pull/1090#issue-753331927). This is by design, as it allows global state to change the rendered output of a component. Instead, consider passing a form builder into form helpers via the `builder` argument:
 
 ```html.erb
 <%= form_for(record, builder: CustomFormBuilder) do |f| %>

--- a/docs/known_issues.md
+++ b/docs/known_issues.md
@@ -12,3 +12,12 @@ ViewComponent [isn't currently compatible](https://github.com/github/view_compon
 ## Inconsistent controller rendering behavior between Rails versions
 
 In versions of Rails < 6.1, rendering a ViewComponent from a controller doesn't include the layout.
+## Forms do not use the default form builder
+
+Calls to form helpers such as `form_with` from ViewComponent [will not use the default form builder](https://github.com/github/view_component/pull/1090#issue-753331927). This is by design, as it allows global state to change the rendered output of a component. Instead, you may want to consider passing a form builder into form helpers via the `builder` argument.
+
+```html.erb
+<%= form_for(record, builder: CustomFormBuilder) do |f| %>
+  <%= f.text_field :name %>
+<% end %>
+```

--- a/test/sandbox/app/components/default_form_builder_component.html.erb
+++ b/test/sandbox/app/components/default_form_builder_component.html.erb
@@ -1,0 +1,3 @@
+<%= helpers.fields do |f| %>
+  <%= f.text_field :hello_world %>
+<% end %>

--- a/test/sandbox/app/components/default_form_builder_component.rb
+++ b/test/sandbox/app/components/default_form_builder_component.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+class DefaultFormBuilderComponent < ViewComponent::Base; end

--- a/test/sandbox/app/controllers/default_form_builder_controller.rb
+++ b/test/sandbox/app/controllers/default_form_builder_controller.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class OtherFormBuilder < ActionView::Helpers::FormBuilder
+  def text_field(*)
+    "changed by default form builder"
+  end
+end
+
+class DefaultFormBuilderController < ActionController::Base
+  default_form_builder OtherFormBuilder
+end

--- a/test/view_component/view_component_test.rb
+++ b/test/view_component/view_component_test.rb
@@ -586,6 +586,14 @@ class ViewComponentTest < ViewComponent::TestCase
     end
   end
 
+  def test_uses_default_form_builder
+    with_controller_class DefaultFormBuilderController do
+      render_inline(DefaultFormBuilderComponent.new)
+
+      assert_text("changed by default form builder")
+    end
+  end
+
   def test_backtrace_returns_correct_file_and_line_number
     error =
       assert_raises NameError do


### PR DESCRIPTION
<!-- See https://github.com/github/view_component/blob/main/docs/CONTRIBUTING.md#submitting-a-pull-request -->

### Summary

When form helpers are called directly, the default form builder is not used and must be specified. For example, calling this:

```
<%= fields do |f| %>
  <%= f.text_field :hello_world %>
<% end %>
```

does not use the default form builder. Either manually specifying the `builder:` argument to `fields` or calling `helpers.fields` (as I have in the tests here) works, though.

I feel that this is a little unintuitive - it's odd that form helpers do work directly within ViewComponent but do not inherit the default form builder specified by the controller. I feel that they should either raise an error or be delegated to `helpers` by default.