### PR TITLE
Support component generator for tailwindcss-rails

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -6,16 +6,20 @@ end
 
 appraise "rails-6.0" do
   gem "rails", "~> 6.0.0"
+  gem "tailwindcss-rails", "~> 2.0"
 end
 
 appraise "rails-6.1" do
   gem "rails", "~> 6.1.0"
+  gem "tailwindcss-rails", "~> 2.0"
 end
 
 appraise "rails-7.0" do
   gem "rails", "~> 7.0.0"
+  gem "tailwindcss-rails", "~> 2.0"
 end
 
 appraise "rails-head" do
   gem "rails", github: "rails/rails", branch: "main"
+  gem "tailwindcss-rails", "~> 2.0"
 end

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,10 @@ title: Changelog
 
 ## main
 
+* Add generators to support `tailwindcss-rails`.
+
+    *Dino Maric*, *Hans Lemuet*
+
 * Add a namespaced component example to docs.
 
     *Hans Lemuet*

--- a/docs/index.md
+++ b/docs/index.md
@@ -123,9 +123,11 @@ ViewComponent is built by over a hundred members of the community, including:
 <img src="https://avatars.githubusercontent.com/czj?s=64" alt="czj" width="32" />
 <img src="https://avatars.githubusercontent.com/dark-panda?s=64" alt="dark-panda" width="32" />
 <img src="https://avatars.githubusercontent.com/davekaro?s=64" alt="davekaro" width="32" />
+<img src="https://avatars.githubusercontent.com/dixpac?s=64" alt="dixpac" width="32" />
 <img src="https://avatars.githubusercontent.com/dukex?s=64" alt="dukex" width="32" />
 <img src="https://avatars.githubusercontent.com/dylanatsmith?s=64" alt="dylanatsmith" width="32" />
 <img src="https://avatars.githubusercontent.com/dylnclrk?s=64" alt="dylnclrk" width="32" />
+<img src="https://avatars.githubusercontent.com/edwinthinks?s=64" alt="edwinthinks" width="32" />
 <img src="https://avatars.githubusercontent.com/elia?s=64" alt="elia" width="32" />
 <img src="https://avatars.githubusercontent.com/franco?s=64" alt="franco" width="32" />
 <img src="https://avatars.githubusercontent.com/franks921?s=64" alt="franks921" width="32" />
@@ -164,12 +166,14 @@ ViewComponent is built by over a hundred members of the community, including:
 <img src="https://avatars.githubusercontent.com/rdavid1099?s=64" alt="rdavid1099" width="32" />
 <img src="https://avatars.githubusercontent.com/rmacklin?s=64" alt="rmacklin" width="32" />
 <img src="https://avatars.githubusercontent.com/ryogift?s=64" alt="ryogift" width="32" />
+<img src="https://avatars.githubusercontent.com/sammyhenningsson?s=64" alt="sammyhenningsson" width="32" />
 <img src="https://avatars.githubusercontent.com/seanpdoyle?s=64" alt="seanpdoyle" width="32" />
 <img src="https://avatars.githubusercontent.com/simonrand?s=64" alt="simonrand" width="32" />
 <img src="https://avatars.githubusercontent.com/skryukov?s=64" alt="skryukov" width="32" />
 <img src="https://avatars.githubusercontent.com/smashwilson?s=64" alt="smashwilson" width="32" />
 <img src="https://avatars.githubusercontent.com/spdawson?s=64" alt="spdawson" width="32" />
 <img src="https://avatars.githubusercontent.com/spone?s=64" alt="Spone" width="32" />
+<img src="https://avatars.githubusercontent.com/stiig?s=64" alt="stiig" width="32" />
 <img src="https://avatars.githubusercontent.com/swanson?s=64" alt="swanson" width="32" />
 <img src="https://avatars.githubusercontent.com/tbroad-ramsey?s=64" alt="tbroad-ramsey" width="32" />
 <img src="https://avatars.githubusercontent.com/tclem?s=64" alt="tclem" width="32" />
@@ -179,12 +183,9 @@ ViewComponent is built by over a hundred members of the community, including:
 <img src="https://avatars.githubusercontent.com/vinistock?s=64" alt="vinistock" width="32" />
 <img src="https://avatars.githubusercontent.com/wdrexler?s=64" alt="wdrexler" width="32" />
 <img src="https://avatars.githubusercontent.com/websebdev?s=64" alt="websebdev" width="32" />
-<img src="https://avatars.githubusercontent.com/edwinthinks?s=64" alt="edwinthinks" width="32" />
-<img src="https://avatars.githubusercontent.com/yykamei?s=64" alt="yykamei" width="32" />
 <img src="https://avatars.githubusercontent.com/xkraty?s=64" alt="xkraty" width="32" />
 <img src="https://avatars.githubusercontent.com/xronos-i-am?s=64" alt="xronos-i-am" width="32" />
-<img src="https://avatars.githubusercontent.com/sammyhenningsson?s=64" alt="sammyhenningsson" width="32" />
-<img src="https://avatars.githubusercontent.com/stiig?s=64" alt="stiig" width="32" />
+<img src="https://avatars.githubusercontent.com/yykamei?s=64" alt="yykamei" width="32" />
 
 ## Who uses ViewComponent?
 

--- a/gemfiles/rails_6.0.gemfile
+++ b/gemfiles/rails_6.0.gemfile
@@ -4,5 +4,6 @@ source "https://rubygems.org"
 
 gem "capybara", "~> 3"
 gem "rails", "~> 6.0.0"
+gem "tailwindcss-rails", "~> 2.0"
 
 gemspec path: "../"

--- a/gemfiles/rails_6.1.gemfile
+++ b/gemfiles/rails_6.1.gemfile
@@ -4,5 +4,6 @@ source "https://rubygems.org"
 
 gem "capybara", "~> 3"
 gem "rails", "~> 6.1.0"
+gem "tailwindcss-rails", "~> 2.0"
 
 gemspec path: "../"

--- a/gemfiles/rails_7.0.gemfile
+++ b/gemfiles/rails_7.0.gemfile
@@ -4,5 +4,6 @@ source "https://rubygems.org"
 
 gem "capybara", "~> 3"
 gem "rails", "~> 7.0.0"
+gem "tailwindcss-rails", "~> 2.0"
 
 gemspec path: "../"

--- a/gemfiles/rails_head.gemfile
+++ b/gemfiles/rails_head.gemfile
@@ -4,5 +4,6 @@ source "https://rubygems.org"
 
 gem "capybara", "~> 3"
 gem "rails", github: "rails/rails", branch: "main"
+gem "tailwindcss-rails", "~> 2.0"
 
 gemspec path: "../"

--- a/lib/rails/generators/tailwindcss/component_generator.rb
+++ b/lib/rails/generators/tailwindcss/component_generator.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "rails/generators/erb/component_generator"
+
+module Tailwindcss
+  module Generators
+    class ComponentGenerator < Erb::Generators::ComponentGenerator
+      source_root File.expand_path("templates", __dir__)
+    end
+  end
+end

--- a/lib/rails/generators/tailwindcss/templates/component.html.erb.tt
+++ b/lib/rails/generators/tailwindcss/templates/component.html.erb.tt
@@ -1,0 +1,1 @@
+<div<%= data_attributes %>>Add <%= class_name %> template here</div>

--- a/test/generators/component_generator_test.rb
+++ b/test/generators/component_generator_test.rb
@@ -154,6 +154,12 @@ class ComponentGeneratorTest < Rails::Generators::TestCase
     assert_file "app/components/user_component.html.haml"
   end
 
+  def test_invoking_tailwindcss_template_engine
+    run_generator %w[user --template-engine tailwindcss]
+
+    assert_file "app/components/user_component.html.erb"
+  end
+
   def test_generating_components_with_custom_component_path
     with_custom_component_path("app/parts") do
       run_generator %w[user]

--- a/test/generators/tailwindcss_generator_test.rb
+++ b/test/generators/tailwindcss_generator_test.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "rails/generators/test_case"
+require "rails/generators/tailwindcss/component_generator"
+
+Rails.application.load_generators
+
+class TailwindcssGeneratorTest < Rails::Generators::TestCase
+  tests Tailwindcss::Generators::ComponentGenerator
+  destination Dir.mktmpdir
+  setup :prepare_destination
+
+  arguments %w[user]
+
+  def test_component_generator
+    run_generator
+
+    assert_file "app/components/user_component.html.erb" do |view|
+      assert_match(/<div>Add User template here<\/div>/, view)
+    end
+  end
+
+  def test_component_generator_with_sidecar
+    run_generator %w[user --sidecar]
+
+    assert_file "app/components/user_component/user_component.html.erb" do |view|
+      assert_match(/<div>Add User template here<\/div>/, view)
+    end
+  end
+
+  def test_component_with_namespace
+    run_generator %w[admins/user]
+
+    assert_file "app/components/admins/user_component.html.erb"
+  end
+
+  def test_component_with_namespace_and_sidecar
+    run_generator %w[admins/user --sidecar]
+
+    assert_file "app/components/admins/user_component/user_component.html.erb"
+  end
+
+  def test_component_with_inline
+    run_generator %w[user name --inline]
+
+    assert_no_file "app/components/user_component.html.erb"
+  end
+end


### PR DESCRIPTION
This commit adds support for [tailwindcss-rails](https://github.com/rails/tailwindcss-rails) engine.

This is my first contribution so I hope I did this correctly.
I've spinend up demo app with `view_component` and `tailwindcss-rails`and it works.
But, I may have missed something :)