### PR TITLE
Forward keyword arguments from slot wrapper to component instance

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -40,6 +40,10 @@ title: Changelog
 
     *Hans Lemuet*
 
+* Forward keyword arguments from slot wrapper to component instance.
+
+    *Cameron Dutro*
+
 ## 2.40.0
 
 * Replace antipatterns section in the documentation with best practices.

--- a/lib/view_component/slot_v2.rb
+++ b/lib/view_component/slot_v2.rb
@@ -86,8 +86,8 @@ module ViewComponent
     #   end
     # end
     #
-    def method_missing(symbol, *args, &block)
-      @__vc_component_instance.public_send(symbol, *args, &block)
+    def method_missing(symbol, *args, **kwargs, &block)
+      @__vc_component_instance.public_send(symbol, *args, **kwargs, &block)
     end
 
     def html_safe?


### PR DESCRIPTION
### Summary

It looks like `SlotV2`'s `method_missing` method doesn't forward keyword arguments to the component instance. This PR fixes that.