### PR TITLE
Add require to load AbstractGenerator for Stimulus generator

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,10 @@ title: Changelog
 
 # Changelog
 
+* Fix loading issue with Stimulus generator and add specs for Stimulus generator.
+
+    *Peter Sumskas*
+
 ## 2.42.0
 
 * Add logo files and page to docs.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,7 +5,6 @@ title: Changelog
 
 # Changelog
 
-
 ## main
 
 * Fix loading issue with Stimulus generator and add specs for Stimulus generator.

--- a/lib/rails/generators/stimulus/component_generator.rb
+++ b/lib/rails/generators/stimulus/component_generator.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "rails/generators/erb/component_generator"
+require "rails/generators/abstract_generator"
 
 module Stimulus
   module Generators

--- a/lib/rails/generators/stimulus/component_generator.rb
+++ b/lib/rails/generators/stimulus/component_generator.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "rails/generators/erb/component_generator"
+
 module Stimulus
   module Generators
     class ComponentGenerator < ::Rails::Generators::NamedBase

--- a/test/generators/stimulus_generator_test.rb
+++ b/test/generators/stimulus_generator_test.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "rails/generators/test_case"
+require "rails/generators/stimulus/component_generator"
+
+Rails.application.load_generators
+
+class StimulusGeneratorTest < Rails::Generators::TestCase
+  tests Stimulus::Generators::ComponentGenerator
+  destination Dir.mktmpdir
+  setup :prepare_destination
+
+  arguments %w[user]
+
+  def test_component_generator
+    run_generator
+
+    assert_file "app/components/user_component_controller.js" do |view|
+      assert_match(/Hello, Stimulus!/, view)
+    end
+  end
+
+  def test_component_generator_with_sidecar
+    run_generator %w[user --sidecar]
+
+    assert_file "app/components/user_component/user_component_controller.js" do |view|
+      assert_match(/Hello, Stimulus!/, view)
+    end
+  end
+
+  def test_component_with_namespace
+    run_generator %w[admins/user]
+
+    assert_file "app/components/admins/user_component_controller.js"
+  end
+
+  def test_component_with_namespace_and_sidecar
+    run_generator %w[admins/user --sidecar]
+
+    assert_file "app/components/admins/user_component/user_component_controller.js"
+  end
+end


### PR DESCRIPTION
### Summary

<details><summary>
Running `bin/rails generate stimulus:component` results in an error:
</summary>

```bash
> bin/rails g stimulus:component
Running via Spring preloader in process 54655
[WARNING] Could not load generator "rails/generators/stimulus/component_generator". Error: uninitialized constant ViewComponent::AbstractGenerator
Did you mean?  AbstractController.
/Users/peter/Code/view_component/lib/rails/generators/stimulus/component_generator.rb:8:in `<class:ComponentGenerator>'
/Users/peter/Code/view_component/lib/rails/generators/stimulus/component_generator.rb:7:in `<module:Generators>'
/Users/peter/Code/view_component/lib/rails/generators/stimulus/component_generator.rb:6:in `<module:Stimulus>'
/Users/peter/Code/view_component/lib/rails/generators/stimulus/component_generator.rb:5:in `<main>'
/Users/peter/.asdf/installs/ruby/3.0.2/lib/ruby/gems/3.0.0/gems/bootsnap-1.7.5/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:23:in `require'
/Users/peter/.asdf/installs/ruby/3.0.2/lib/ruby/gems/3.0.0/gems/bootsnap-1.7.5/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:23:in `block in require_with_bootsnap_lfi'
/Users/peter/.asdf/installs/ruby/3.0.2/lib/ruby/gems/3.0.0/gems/bootsnap-1.7.5/lib/bootsnap/load_path_cache/loaded_features_index.rb:92:in `register'
/Users/peter/.asdf/installs/ruby/3.0.2/lib/ruby/gems/3.0.0/gems/bootsnap-1.7.5/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:22:in `require_with_bootsnap_lfi'
/Users/peter/.asdf/installs/ruby/3.0.2/lib/ruby/gems/3.0.0/gems/bootsnap-1.7.5/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:31:in `require'
/Users/peter/.asdf/installs/ruby/3.0.2/lib/ruby/gems/3.0.0/gems/zeitwerk-2.4.2/lib/zeitwerk/kernel.rb:34:in `require'
/Users/peter/.asdf/installs/ruby/3.0.2/lib/ruby/gems/3.0.0/gems/railties-6.1.4/lib/rails/command/behavior.rb:44:in `block (2 levels) in lookup'
/Users/peter/.asdf/installs/ruby/3.0.2/lib/ruby/gems/3.0.0/gems/railties-6.1.4/lib/rails/command/behavior.rb:40:in `each'
/Users/peter/.asdf/installs/ruby/3.0.2/lib/ruby/gems/3.0.0/gems/railties-6.1.4/lib/rails/command/behavior.rb:40:in `block in lookup'
/Users/peter/.asdf/installs/ruby/3.0.2/lib/ruby/gems/3.0.0/gems/railties-6.1.4/lib/rails/command/behavior.rb:39:in `each'
/Users/peter/.asdf/installs/ruby/3.0.2/lib/ruby/gems/3.0.0/gems/railties-6.1.4/lib/rails/command/behavior.rb:39:in `lookup'
/Users/peter/.asdf/installs/ruby/3.0.2/lib/ruby/gems/3.0.0/gems/railties-6.1.4/lib/rails/generators.rb:257:in `find_by_namespace'
/Users/peter/.asdf/installs/ruby/3.0.2/lib/ruby/gems/3.0.0/gems/railties-6.1.4/lib/rails/generators.rb:273:in `invoke'
/Users/peter/.asdf/installs/ruby/3.0.2/lib/ruby/gems/3.0.0/gems/railties-6.1.4/lib/rails/commands/generate/generate_command.rb:26:in `perform'
/Users/peter/.asdf/installs/ruby/3.0.2/lib/ruby/gems/3.0.0/gems/thor-1.1.0/lib/thor/command.rb:27:in `run'
/Users/peter/.asdf/installs/ruby/3.0.2/lib/ruby/gems/3.0.0/gems/thor-1.1.0/lib/thor/invocation.rb:127:in `invoke_command'
/Users/peter/.asdf/installs/ruby/3.0.2/lib/ruby/gems/3.0.0/gems/thor-1.1.0/lib/thor.rb:392:in `dispatch'
/Users/peter/.asdf/installs/ruby/3.0.2/lib/ruby/gems/3.0.0/gems/railties-6.1.4/lib/rails/command/base.rb:69:in `perform'
/Users/peter/.asdf/installs/ruby/3.0.2/lib/ruby/gems/3.0.0/gems/railties-6.1.4/lib/rails/command.rb:48:in `invoke'
/Users/peter/.asdf/installs/ruby/3.0.2/lib/ruby/gems/3.0.0/gems/railties-6.1.4/lib/rails/commands.rb:18:in `<main>'
/Users/peter/.asdf/installs/ruby/3.0.2/lib/ruby/gems/3.0.0/gems/bootsnap-1.7.5/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:23:in `require'
/Users/peter/.asdf/installs/ruby/3.0.2/lib/ruby/gems/3.0.0/gems/bootsnap-1.7.5/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:23:in `block in require_with_bootsnap_lfi'
/Users/peter/.asdf/installs/ruby/3.0.2/lib/ruby/gems/3.0.0/gems/bootsnap-1.7.5/lib/bootsnap/load_path_cache/loaded_features_index.rb:92:in `register'
/Users/peter/.asdf/installs/ruby/3.0.2/lib/ruby/gems/3.0.0/gems/bootsnap-1.7.5/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:22:in `require_with_bootsnap_lfi'
/Users/peter/.asdf/installs/ruby/3.0.2/lib/ruby/gems/3.0.0/gems/bootsnap-1.7.5/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:31:in `require'
/Users/peter/.asdf/installs/ruby/3.0.2/lib/ruby/gems/3.0.0/gems/zeitwerk-2.4.2/lib/zeitwerk/kernel.rb:34:in `require'
/Users/peter/Code/courtside/bin/rails:5:in `<main>'
/Users/peter/.asdf/installs/ruby/3.0.2/lib/ruby/gems/3.0.0/gems/bootsnap-1.7.5/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:59:in `load'
/Users/peter/.asdf/installs/ruby/3.0.2/lib/ruby/gems/3.0.0/gems/bootsnap-1.7.5/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:59:in `load'
/Users/peter/.asdf/installs/ruby/3.0.2/lib/ruby/gems/3.0.0/gems/spring-2.1.1/lib/spring/commands/rails.rb:6:in `call'
/Users/peter/.asdf/installs/ruby/3.0.2/lib/ruby/gems/3.0.0/gems/spring-2.1.1/lib/spring/command_wrapper.rb:38:in `call'
/Users/peter/.asdf/installs/ruby/3.0.2/lib/ruby/gems/3.0.0/gems/spring-2.1.1/lib/spring/application.rb:220:in `block in serve'
/Users/peter/.asdf/installs/ruby/3.0.2/lib/ruby/gems/3.0.0/gems/activesupport-6.1.4/lib/active_support/fork_tracker.rb:10:in `block in fork'
/Users/peter/.asdf/installs/ruby/3.0.2/lib/ruby/gems/3.0.0/gems/activesupport-6.1.4/lib/active_support/fork_tracker.rb:10:in `block in fork'
/Users/peter/.asdf/installs/ruby/3.0.2/lib/ruby/gems/3.0.0/gems/activesupport-6.1.4/lib/active_support/fork_tracker.rb:8:in `fork'
/Users/peter/.asdf/installs/ruby/3.0.2/lib/ruby/gems/3.0.0/gems/activesupport-6.1.4/lib/active_support/fork_tracker.rb:8:in `fork'
/Users/peter/.asdf/installs/ruby/3.0.2/lib/ruby/gems/3.0.0/gems/activesupport-6.1.4/lib/active_support/fork_tracker.rb:27:in `fork'
/Users/peter/.asdf/installs/ruby/3.0.2/lib/ruby/gems/3.0.0/gems/activesupport-6.1.4/lib/active_support/fork_tracker.rb:8:in `fork'
/Users/peter/.asdf/installs/ruby/3.0.2/lib/ruby/gems/3.0.0/gems/activesupport-6.1.4/lib/active_support/fork_tracker.rb:27:in `fork'
/Users/peter/.asdf/installs/ruby/3.0.2/lib/ruby/gems/3.0.0/gems/spring-2.1.1/lib/spring/application.rb:180:in `serve'
/Users/peter/.asdf/installs/ruby/3.0.2/lib/ruby/gems/3.0.0/gems/spring-2.1.1/lib/spring/application.rb:145:in `block in run'
/Users/peter/.asdf/installs/ruby/3.0.2/lib/ruby/gems/3.0.0/gems/spring-2.1.1/lib/spring/application.rb:139:in `loop'
/Users/peter/.asdf/installs/ruby/3.0.2/lib/ruby/gems/3.0.0/gems/spring-2.1.1/lib/spring/application.rb:139:in `run'
/Users/peter/.asdf/installs/ruby/3.0.2/lib/ruby/gems/3.0.0/gems/spring-2.1.1/lib/spring/application/boot.rb:19:in `<top (required)>'
<internal:/Users/peter/.asdf/installs/ruby/3.0.2/lib/ruby/3.0.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
<internal:/Users/peter/.asdf/installs/ruby/3.0.2/lib/ruby/3.0.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
-e:1:in `<main>'
Usage:
  rails generate stimulus:component NAME [options]
...
```
</details>

Copying from other generators, I included a `require "rails/generators/abstract_generator"`, which addressed the issue.

I added some tests. I'm not sure if they are completely correct (again, shamelessly copied from other generators).

### Other Information

The main issue with the tests is that when run with the full test suite they pass whether or not the `require` line I added was included in the code or not.

To show that the line makes a difference it is necessary to run just that Stimulus generator test file:

`rake test TEST=test/generators/stimulus_generator_test.rb` is adequate to show this.

