### PR TITLE
engine.rb: Change ActionDispatch::MiddlewareStack#insert_before -> #use

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,12 @@ title: Changelog
 
 # Changelog
 
+## main
+
+* Remove dependency on `ActionDispatch::Static` in Rails middleware stack when enabling statics assets for source code preview.
+
+    *Gregory Igelmund*
+
 ## 2.42.0
 
 * Add logo files and page to docs.

--- a/lib/view_component/engine.rb
+++ b/lib/view_component/engine.rb
@@ -103,7 +103,7 @@ module ViewComponent
 
     initializer "static assets" do |app|
       if app.config.view_component.show_previews
-        app.middleware.insert_before(::ActionDispatch::Static, ::ActionDispatch::Static, "#{root}/app/assets/vendor")
+        app.middleware.use(::ActionDispatch::Static, "#{root}/app/assets/vendor")
       end
     end
 


### PR DESCRIPTION
### Summary

See related issue #1112 

The call to `ActionDispatch::MiddlewareStack#insert_before` expected an instance of `ActionDispatch::Static` being present in the middleware stack.

Calling `ActionDispatch::MiddlewareStack#use` instead will instead append `ActionDispatch::Static`-middleware to the "end" of the middleware stack without any dependency.