### PR TITLE
Require engine automatically

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,10 @@ title: Changelog
 
     *Gregory Igelmund*
 
+* Require `view_component/engine` automatically
+
+    *Cameron Dutro*
+
 ## 2.42.0
 
 * Add logo files and page to docs.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,7 +11,7 @@ title: Changelog
 
     *Gregory Igelmund*
 
-* Require `view_component/engine` automatically
+* Require `view_component/engine` automatically.
 
     *Cameron Dutro*
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -19,7 +19,7 @@ nav_order: 1
 In `Gemfile`, add:
 
 ```ruby
-gem "view_component", require: "view_component/engine"
+gem "view_component"
 ```
 
 ## Quick start

--- a/lib/view_component.rb
+++ b/lib/view_component.rb
@@ -17,3 +17,5 @@ module ViewComponent
   autoload :TemplateError
   autoload :Translatable
 end
+
+require "view_component/engine" if defined?(Rails::Engine)


### PR DESCRIPTION
### Summary

Currently anyone using the framework has to require `view_component/engine` manually, usually by putting `gem "view_component", require: "view_component/engine"` in the Gemfile or requiring it specifically in application.rb. Forgetting to do so can lead to weird reloading problems and other subtle issues as evidenced in #560.

This PR adds the relevant `require` to avoid these issues.