### PR TITLE
add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,6 +10,7 @@
 /test/view_component/test_unit_generator_test.rb @spone
 
 /app/**/* @juanmanuelramallo
+/docs/guide/previews.md @juanmanuelramallo
 /lib/view_component/preview.rb @juanmanuelramallo
 /lib/view_component/previewable.rb @juanmanuelramallo
 /lib/view_component/preview_template_error.rb @juanmanuelramallo

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,28 @@
+# Code ownership for ViewComponent
+# Used to auto-assign PR reviews.
+# See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+# for details on how to update this file <3
 * @github/primer-rails-reviewers
+
+/lib/rails/generators/**/* @spone
+/docs/guide/generators.md @spone
+/test/generators/**/* @spone
+/test/view_component/test_unit_generator_test.rb @spone
+
+/app/**/* @juanmanuelramallo
+/lib/view_component/preview.rb @juanmanuelramallo
+/lib/view_component/previewable.rb @juanmanuelramallo
+/lib/view_component/preview_template_error.rb @juanmanuelramallo
+/test/sandbox/test/components/previews/preview_source_from_layout_component_preview.rb @juanmanuelramallo
+/test/view_component/default_preview_layout_integration_test.rb @juanmanuelramallo
+/test/view_component/preview_helper_test.rb @juanmanuelramallo
+
+/docs/guide/translations.md @elia
+/test/view_component/translatable_test.rb @elia
+/lib/view_component/translatable.rb @elia
+/performance/translatable_benchmark.rb @elia
+/test/sandbox/app/components/translatable_component.html.erb @elia
+/test/sandbox/app/components/translatable_component.rb @elia
+/test/sandbox/app/components/translatable_component.yml @elia
+/test/sandbox/app/components/translations_component.html.erb @elia
+/test/sandbox/app/components/translations_component.rb @elia

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,10 @@ title: Changelog
 
 ## main
 
+* Add CODEOWNERS entries for feature areas owned by community committers.
+
+    *Joel Hawksley*
+
 * Add section to docs listing users of ViewComponent. Please submit a PR to add your team to the list!
 
     *Joel Hawksley*


### PR DESCRIPTION
### Summary

This PR adds a CODEOWNERS file to auto-request reviews for a few key feature areas built by ViewComponent committers.