### PR TITLE
Remove unnecessary ruby2_keywords in polymorphic slots code

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,10 @@ title: Changelog
 
 ## main
 
+* Remove unnecessary call to `ruby2_keywords` for polymorphic slot getters.
+
+    *Cameron Dutro*
+
 ## 2.43.0
 
 * Add note about tests and instance methods.

--- a/lib/view_component/polymorphic_slots.rb
+++ b/lib/view_component/polymorphic_slots.rb
@@ -41,7 +41,6 @@ module ViewComponent
           define_method(getter_name) do
             get_slot(slot_name)
           end
-          ruby2_keywords(getter_name.to_sym) if respond_to?(:ruby2_keywords, true)
 
           define_method(setter_name) do |*args, &block|
             set_polymorphic_slot(slot_name, poly_type, *args, &block)


### PR DESCRIPTION
### Summary

Like regular slot getters, polymorphic getters don't take any arguments and therefore don't need a call to `ruby2_keywords`. The warning emitted is causing CI issues in github/github.