### PR TITLE
Add Litmus to users

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,7 +7,7 @@ title: Changelog
 
 ## main
 
-* Add Litmus to users list
+* Add Litmus to users list.
 
     *Dylan Smith*
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,10 @@ title: Changelog
 
 ## main
 
+* Add Litmus to users list
+
+    *Dylan Smith*
+
 * Autoload `CompileCache`, which is optionally called in `engine.rb`.
 
     *Gregory Igelmund*

--- a/docs/index.md
+++ b/docs/index.md
@@ -185,6 +185,7 @@ ViewComponent is built by over a hundred members of the community, including:
 * [Podia](https://www.podia.com/)
 * [City of Paris](https://www.paris.fr/)
 * [Cults.](https://cults3d.com/)
+* [Litmus](https://litmus.engineering/)
 
 If your team starts using ViewComponent, [send a pull request](https://github.com/github/view_component/edit/main/docs/index.md) to let us know!
 You can also check out [how various projects use ViewComponent](https://github.com/github/view_component/network/dependents?package_id=UGFja2FnZS0xMDEwNjQxMzYx).


### PR DESCRIPTION
### Summary

Adds Litmus to list of teams using ViewComponent with a link to the Litmus Engineering blog (currently being redesigned into a more comprehensive site about how we work, job openings, etc).
