### PR TITLE
Clear cache in MethodSource to apply the change of preview code without app server restart

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -39,6 +39,10 @@ title: Changelog
 
     *Yoshiyuki Hirano*
 
+* Clear cache in MethodSource to apply the change odf preview code without app server restart.
+
+    *Yoshiyuki Hirano*
+
 ## 2.43.1
 
 * Remove unnecessary call to `ruby2_keywords` for polymorphic slot getters.

--- a/lib/view_component/engine.rb
+++ b/lib/view_component/engine.rb
@@ -34,7 +34,13 @@ module ViewComponent
           options.preview_paths << options.preview_path
         end
 
-        require "method_source" if options.show_previews_source
+        if options.show_previews_source
+          require "method_source"
+
+          app.config.to_prepare do
+            MethodSource.instance_variable_set(:@lines_for_file, {})
+          end
+        end
       end
 
       ActiveSupport.on_load(:view_component) do


### PR DESCRIPTION
### Summary

Currently, we can show preview codes in component previews if it enables `show_previews_code` option.

However, the change of preview class's code is not applied to screen without app server restart.

It's not convenient, isn't it?

So I configured to clear cache in `MethodSource` per request using `to_prepare` block.

### Usecase

For example, suppose you have a code like the following:

```ruby
class FooComponentPreview < ViewComponent::Preview
  def default
    render(FooComponent.new)
  end
end
```

In preview, it will display like this:

![Screenshot from 2021-11-19 00-28-29](https://user-images.githubusercontent.com/15371677/142445864-6c55576d-3a7c-4a8e-a4ca-bf747085f008.png)

Then, change the code while the server is running. 

```diff
  class FooComponentPreview < ViewComponent::Preview
    def default
+     # This is comment
      render(FooComponent.new)
    end
  end
```

Unfortunately, this change will not apply until we restart the server.

With this fix, the code changes will be applied to the screen without restarting the server.

![Screenshot from 2021-11-19 00-39-05](https://user-images.githubusercontent.com/15371677/142447165-eba0bc10-b122-401c-a1b2-aac91d7a39f7.png)

Thanks :pray: 