### PR TITLE
Remove `require "rails/generators/test_case"` in generator tests

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,10 @@ title: Changelog
 
 ## main
 
+* Remove `require "rails/generators/test_case"` in generator tests
+
+    *Yoshiyuki Hirano*
+
 ## 2.44.0
 
 * Rename internal accessor to use private naming.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,7 +7,7 @@ title: Changelog
 
 ## main
 
-* Remove `require "rails/generators/test_case"` in generator tests
+* Remove `require "rails/generators/test_case"` in generator tests.
 
     *Yoshiyuki Hirano*
 

--- a/test/generators/component_generator_test.rb
+++ b/test/generators/component_generator_test.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "test_helper"
-require "rails/generators/test_case"
 require "rails/generators/component/component_generator"
 
 Rails.application.load_generators

--- a/test/generators/erb_generator_test.rb
+++ b/test/generators/erb_generator_test.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "test_helper"
-require "rails/generators/test_case"
 require "rails/generators/erb/component_generator"
 
 Rails.application.load_generators

--- a/test/generators/haml_generator_test.rb
+++ b/test/generators/haml_generator_test.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "test_helper"
-require "rails/generators/test_case"
 require "rails/generators/haml/component_generator"
 
 Rails.application.load_generators

--- a/test/generators/slim_generator_test.rb
+++ b/test/generators/slim_generator_test.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "test_helper"
-require "rails/generators/test_case"
 require "rails/generators/slim/component_generator"
 
 Rails.application.load_generators

--- a/test/generators/stimulus_generator_test.rb
+++ b/test/generators/stimulus_generator_test.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "test_helper"
-require "rails/generators/test_case"
 require "rails/generators/stimulus/component_generator"
 
 Rails.application.load_generators


### PR DESCRIPTION
### Summary

`require "rails/generators/test_case"` is called from rails/test_help on railtie gem. So we don't need to call them on each test files, removed them.

https://github.com/rails/rails/blob/5-2-stable/railties/lib/rails/test_help.rb#L11

---

In the process of following up on #1147, I noticed it while reading the code and opened a pull request. If you feel this is just like cosmetic change, would you please close it :pray: