### PR TITLE
Remove `config/boot.rb` in Sandbox

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,10 @@ title: Changelog
 
 ## main
 
+* Remove `config/boot.rb` in Sandbox.
+
+    *Yoshiyuki Hirano*
+
 ## 2.45.0
 
 * Remove internal APIs from API documentation, fix link to license.

--- a/test/sandbox/config/application.rb
+++ b/test/sandbox/config/application.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require File.expand_path("../boot", __FILE__)
-
 require "active_model/railtie"
 require "action_controller/railtie"
 require "action_mailer/railtie"

--- a/test/sandbox/config/boot.rb
+++ b/test/sandbox/config/boot.rb
@@ -1,5 +1,0 @@
-# frozen_string_literal: true
-
-require "rubygems"
-
-$:.unshift File.expand_path("../../../../../../lib", __FILE__)


### PR DESCRIPTION
### Summary

This is a tiny change.

The `view_component/lib` load path has already appended in [gemspec](https://github.com/github/view_component/blob/da341f82a18f48d252a0fedcd1b8310f05ad5c75/view_component.gemspec#L5), and rubygems has already called in [bundler/rubygems_integration](https://github.com/rubygems/rubygems/blob/master/bundler/lib/bundler/rubygems_integration.rb#L3).

Therefore, the sandbox app doesn't need to require boot file, and removed it.

### For maintainers

Currently, it is difficult to rewrite and test the configuration for each test case. I'm preparing to make it possible (I'm referring to [railties test](https://github.com/rails/rails/blob/main/railties/test/isolation/abstract_unit.rb), but it's a bit difficult.) In the process, I noticed this case, so I opened a pull request.

If you don't need it, please feel free to close it. Thanks :pray: