### PR TITLE
Add Orbit to the list of teams using ViewComponent

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,10 @@ title: Changelog
 
 ## main
 
+* Add Orbit to users list.
+
+    *Nicolas Goutay*
+
 ## 2.45.0
 
 * Remove internal APIs from API documentation, fix link to license.

--- a/docs/index.md
+++ b/docs/index.md
@@ -186,6 +186,7 @@ ViewComponent is built by over a hundred members of the community, including:
 * [City of Paris](https://www.paris.fr/)
 * [Cults.](https://cults3d.com/)
 * [Litmus](https://litmus.engineering/)
+* [Orbit](https://orbit.love)
 
 If your team starts using ViewComponent, [send a pull request](https://github.com/github/view_component/edit/main/docs/index.md) to let us know!
 You can also check out [how various projects use ViewComponent](https://github.com/github/view_component/network/dependents?package_id=UGFja2FnZS0xMDEwNjQxMzYx).


### PR DESCRIPTION
### Summary

Adding [Orbit](https://orbit.love) to the list of teams using ViewComponent

### Other Information

Hey! We’re very happy users of ViewComponent at Orbit.

We’ve been using them for about a year and wrote about our [ViewComponent/Storybook setup](https://orbit.love/blog/building-a-component-library-in-rails-with-storybook) as well as a [primer on Storybook for Rails developers](https://orbit.love/blog/im-a-rails-developer-what-the-heck-is-storybook-and-should-i-care). We’re now in the process of building a design system with it, and the Primer repository as well as [this Rails Conf talk](https://youtu.be/QoetqsBCsbE) by Joel have been an invaluable help!
