### PR TITLE
Move changelog entry for #1162 to the right version

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -25,6 +25,10 @@ title: Changelog
 
     *Simon Fish*
 
+* Deprecate engine loading manually.
+
+    *Yoshiyuki Hirano*
+
 ## 2.45.0
 
 * Remove internal APIs from API documentation, fix link to license.
@@ -60,10 +64,6 @@ title: Changelog
     *Yoshiyuki Hirano*
 
 * Unify test code of `TestUnitGeneratorTest` with the other generators tests.
-
-    *Yoshiyuki Hirano*
-
-* Deprecate engine loading manually.
 
     *Yoshiyuki Hirano*
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -25,7 +25,14 @@ title: Changelog
 
     *Simon Fish*
 
-* Deprecate engine loading manually.
+* Deprecate loading `view_component/engine` directly.
+
+  **Upgrade notice**: You should update your `Gemfile` like this:
+
+  ```diff
+  - gem "view_component", require: "view_component/engine"`
+  + gem "view_component"
+  ```
 
     *Yoshiyuki Hirano*
 


### PR DESCRIPTION
PR #1162 was merged in d24b26ae2697685e930d863839d7f8834b9ca4a3 which was released in [v2.46.0], but its `CHANGELOG.me` entry had not been moved above the `## v2.45.0` entry in https://github.com/github/view_component/commit/a5f6463f36639e7385a9c905801e18e41b6b6538. Thus, it was incorrectly listed as being included in [v2.45.0].

Let's make sure it's listed under the correct version in `CHANGELOG.md`. And based on #1180, let's make it clear in the release notes what folks need to do to
resolve the deprecation warning after they upgrade.

[v2.45.0]: https://github.com/github/view_component/releases/tag/v2.45.0
[v2.46.0]: https://github.com/github/view_component/releases/tag/v2.46.0