### PR TITLE
Improve instructions on how to run tests

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,10 @@ title: Changelog
 
 ## main
 
+* Improve Contributing docs to include how to run tests for a specific version on Rails.
+
+    *Hans Lemuet*
+
 * Add failing test for default form builder and documentation around known issue.
 
     *Simon Fish*

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -19,7 +19,7 @@ Contributions to this project are [released](https://help.github.com/articles/gi
 
 1. [Fork](https://github.com/github/view_component/fork) and clone the repository.
 1. Configure and install the dependencies: `bundle`.
-1. Make sure the tests pass on your machine: `bundle exec rake`. (Run a subset of tests by supplying a file glob to the test command: `TEST="test/components/YOUR_COMPONENT_test.rb" bundle exec rake`)
+1. Make sure the tests pass on your machine: `bundle exec rake` (see below for specific cases).
 1. Create a new branch: `git checkout -b my-branch-name`.
 1. Make your change, add tests, and make sure the tests still pass.
 1. Add an entry to the top of `docs/CHANGELOG.md` for your changes, no matter how small they're. We want to recognize your contribution!
@@ -32,6 +32,30 @@ Here are a few things you can do that will increase the likelihood of your pull 
 - Write tests.
 - Keep your change as focused as possible. If there are multiple changes you would like to make that aren't dependent upon each other, consider submitting them as separate pull requests.
 - Write a [good commit message](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
+
+### Running a subset of tests
+
+Supply a file glob to the test command:
+
+```command
+TEST="test/components/YOUR_COMPONENT_test.rb" bundle exec rake
+```
+
+### Run tests for a specific version of Rails
+
+Update the bundle:
+
+```command
+RAILS_VERSION=5.2.5 bundle update
+```
+
+Then run the test command:
+
+```command
+RAILS_VERSION=5.2.5 bundle exec rake
+```
+
+When you're done, make sure you do not commit changes to `Gemfile.lock`. Instead, discard your changes to the file: `git checkout -- Gemfile.lock`
 
 ## Documentation
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -55,7 +55,7 @@ Then run the test command:
 RAILS_VERSION=5.2.5 bundle exec rake
 ```
 
-When you're done, make sure you do not commit changes to `Gemfile.lock`. Instead, discard your changes to the file: `git checkout -- Gemfile.lock`
+When you're done, make sure you don't commit changes to `Gemfile.lock`. Instead, discard your changes to the file: `git checkout -- Gemfile.lock`
 
 ## Documentation
 


### PR DESCRIPTION
### Summary

When debugging #971, I found the `CONTRIBUTING.md` docs to be lacking instructions on how to run tests locally for a specific version of Rails. I tried to improve this.