### PR TITLE
Remove broken `files` options from vale config

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,8 +12,6 @@ jobs:
         uses: errata-ai/vale-action@310a5ac41197ffb704515622b4914c72d3abc54b
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-        with:
-          files: '**/*'
   markdown:
     runs-on: ubuntu-latest
     steps:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,10 @@ title: Changelog
 
 ## main
 
+* Fix `vale` linter config options.
+
+    *Hans Lemuet*
+
 * Add failing test for default form builder and documentation around known issue.
 
     *Simon Fish*


### PR DESCRIPTION
### Summary

Vale action output contains a warning:

```
Warning: User-specified path (**/*) is invalid; falling back to 'all'.
```

Default is already `all`: https://github.com/errata-ai/vale-action#files-default-all

I removed the `files` options which is not needed.