### PR TITLE
Allow passing component attributes to preview generator

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,11 @@ title: Changelog
 
     *Simon Fish*
 
+* Allow preview generator to use provided component attributes.
+* Add config option `config.view_component.generate.preview` to enable project-wide preview generation.
+
+  *Bob Maerten*
+
 ## 2.49.0
 
 * Fix path handling for evaluated view components that broke in Ruby 3.1.

--- a/docs/api.md
+++ b/docs/api.md
@@ -136,6 +136,14 @@ Always generate as many translations files as available locales:
 One file will be generated for each configured `I18n.available_locales`,
 falling back to `[:en]` when no `available_locales` is defined.
 
+#### #preview
+
+Always generate preview alongside the component:
+
+     config.view_component.generate.preview = true
+
+ Defaults to `false`.
+
 ### #preview_controller
 
 Set the controller used for previewing components:

--- a/lib/rails/generators/component/component_generator.rb
+++ b/lib/rails/generators/component/component_generator.rb
@@ -11,12 +11,13 @@ module Rails
 
       argument :attributes, type: :array, default: [], banner: "attribute"
       check_class_collision suffix: "Component"
+
       class_option :inline, type: :boolean, default: false
+      class_option :locale, type: :boolean, default: ViewComponent::Base.generate.locale
       class_option :parent, type: :string, desc: "The parent class for the generated component"
-      class_option :stimulus, type: :boolean, default: ViewComponent::Base.generate.stimulus_controller
       class_option :preview, type: :boolean, default: ViewComponent::Base.generate.preview
       class_option :sidecar, type: :boolean, default: false
-      class_option :locale, type: :boolean, default: ViewComponent::Base.generate.locale
+      class_option :stimulus, type: :boolean, default: ViewComponent::Base.generate.stimulus_controller
 
       def create_component_file
         template "component.rb", File.join(component_path, class_path, "#{file_name}_component.rb")

--- a/lib/rails/generators/component/component_generator.rb
+++ b/lib/rails/generators/component/component_generator.rb
@@ -14,6 +14,7 @@ module Rails
       class_option :inline, type: :boolean, default: false
       class_option :parent, type: :string, desc: "The parent class for the generated component"
       class_option :stimulus, type: :boolean, default: ViewComponent::Base.generate.stimulus_controller
+      class_option :preview, type: :boolean, default: ViewComponent::Base.generate.preview
       class_option :sidecar, type: :boolean, default: false
       class_option :locale, type: :boolean, default: ViewComponent::Base.generate.locale
 

--- a/lib/rails/generators/preview/component_generator.rb
+++ b/lib/rails/generators/preview/component_generator.rb
@@ -5,6 +5,7 @@ module Preview
     class ComponentGenerator < ::Rails::Generators::NamedBase
       source_root File.expand_path("templates", __dir__)
 
+      argument :attributes, type: :array, default: [], banner: "attribute"
       check_class_collision suffix: "ComponentPreview"
 
       def create_preview_file
@@ -19,6 +20,12 @@ module Preview
 
       def file_name
         @_file_name ||= super.sub(/_component\z/i, "")
+      end
+
+      def render_signature
+        return if attributes.blank?
+
+        attributes.map { |attr| %(#{attr.name}: "#{attr.name}") }.join(", ")
       end
     end
   end

--- a/lib/rails/generators/preview/templates/component_preview.rb.tt
+++ b/lib/rails/generators/preview/templates/component_preview.rb.tt
@@ -1,5 +1,5 @@
 class <%= class_name %>ComponentPreview < ViewComponent::Preview
   def default
-  render(<%= class_name %>Component.new<%= "(#{render_signature})" if render_signature %>)
+    render(<%= class_name %>Component.new<%= "(#{render_signature})" if render_signature %>)
   end
 end

--- a/lib/rails/generators/preview/templates/component_preview.rb.tt
+++ b/lib/rails/generators/preview/templates/component_preview.rb.tt
@@ -1,5 +1,9 @@
 class <%= class_name %>ComponentPreview < ViewComponent::Preview
   def default
+  <%- if render_signature -%>
+    render(<%= class_name %>Component.new(<%= render_signature %>))
+  <%- else -%>
     render(<%= class_name %>Component.new)
+  <%- end -%>
   end
 end

--- a/lib/rails/generators/preview/templates/component_preview.rb.tt
+++ b/lib/rails/generators/preview/templates/component_preview.rb.tt
@@ -1,9 +1,5 @@
 class <%= class_name %>ComponentPreview < ViewComponent::Preview
   def default
-  <%- if render_signature -%>
-    render(<%= class_name %>Component.new(<%= render_signature %>))
-  <%- else -%>
-    render(<%= class_name %>Component.new)
-  <%- end -%>
+  render(<%= class_name %>Component.new<%= "(#{render_signature})" if render_signature %>)
   end
 end

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -337,6 +337,13 @@ module ViewComponent
     # One file will be generated for each configured `I18n.available_locales`,
     # falling back to `[:en]` when no `available_locales` is defined.
     #
+    # #### #preview
+    #
+    # Always generate preview alongside the component:
+    #
+    #      config.view_component.generate.preview = true
+    #
+    #  Defaults to `false`.
     mattr_accessor :generate, instance_writer: false, default: ActiveSupport::OrderedOptions.new(false)
 
     class << self

--- a/test/generators/component_generator_test.rb
+++ b/test/generators/component_generator_test.rb
@@ -41,27 +41,6 @@ class ComponentGeneratorTest < Rails::Generators::TestCase
     end
   end
 
-  def test_component_preview_with_one_overridden_preview_path
-    with_preview_paths(%w[spec/components/previews]) do
-      run_generator %w[user --preview]
-
-      assert_file "spec/components/previews/user_component_preview.rb" do |component|
-        assert_match(/class UserComponentPreview < /, component)
-        assert_match(/render\(UserComponent.new\)/, component)
-      end
-    end
-  end
-
-  def test_component_preview_with_two_overridden_preview_paths
-    with_preview_paths(%w[spec/components/previews some/other/directory]) do
-      run_generator %w[user --preview]
-
-      assert_no_file "test/components/previews/user_component_preview.rb"
-      assert_no_file "spec/components/previews/user_component_preview.rb"
-      assert_no_file "some/other/directory/user_component_preview.rb"
-    end
-  end
-
   def test_component_with_arguments
     run_generator %w[user name]
 
@@ -122,17 +101,6 @@ class ComponentGeneratorTest < Rails::Generators::TestCase
     assert_file "test/components/admins/user_component_test.rb" do |component|
       assert_match(/class Admins::UserComponentTest < /, component)
       assert_match(/def test_component_renders_something_useful/, component)
-    end
-  end
-
-  def test_component_preview_with_namespace
-    with_preview_paths([]) do
-      run_generator %w[admins/user --preview]
-
-      assert_file "test/components/previews/admins/user_component_preview.rb" do |component|
-        assert_match(/class Admins::UserComponentPreview < /, component)
-        assert_match(/render\(Admins::UserComponent.new\)/, component)
-      end
     end
   end
 

--- a/test/generators/preview_generator_test.rb
+++ b/test/generators/preview_generator_test.rb
@@ -52,4 +52,26 @@ class PreviewGeneratorTest < Rails::Generators::TestCase
       end
     end
   end
+
+  def test_component_generator_with_attributes
+    with_preview_paths([]) do
+      run_generator %w[user nickname fullname]
+
+      assert_file "test/components/previews/user_component_preview.rb" do |preview|
+        assert_match(/class UserComponentPreview/, preview)
+        assert_match(/render\(UserComponent.new\(nickname: "nickname", fullname: "fullname"\)\)/, preview)
+      end
+    end
+  end
+
+  def test_component_with_namespace_and_attributes
+    with_preview_paths([]) do
+      run_generator %w[admins/user nickname fullname]
+
+      assert_file "test/components/previews/admins/user_component_preview.rb" do |preview|
+        assert_match(/class Admins::UserComponentPreview/, preview)
+        assert_match(/render\(Admins::UserComponent.new\(nickname: "nickname", fullname: "fullname"\)\)/, preview)
+      end
+    end
+  end
 end

--- a/test/generators/preview_generator_test.rb
+++ b/test/generators/preview_generator_test.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "rails/generators/preview/component_generator"
+
+Rails.application.load_generators
+
+class PreviewGeneratorTest < Rails::Generators::TestCase
+  tests Preview::Generators::ComponentGenerator
+  destination Dir.mktmpdir
+  setup :prepare_destination
+
+  def test_component_preview
+    with_preview_paths([]) do
+      run_generator %w[user --preview]
+
+      assert_file "test/components/previews/user_component_preview.rb" do |component|
+        assert_match(/class UserComponentPreview < /, component)
+        assert_match(/render\(UserComponent.new\)/, component)
+      end
+    end
+  end
+
+  def test_component_preview_with_one_overridden_preview_path
+    with_preview_paths(%w[spec/components/previews]) do
+      run_generator %w[user --preview]
+
+      assert_file "spec/components/previews/user_component_preview.rb" do |component|
+        assert_match(/class UserComponentPreview < /, component)
+        assert_match(/render\(UserComponent.new\)/, component)
+      end
+    end
+  end
+
+  def test_component_preview_with_two_overridden_preview_paths
+    with_preview_paths(%w[spec/components/previews some/other/directory]) do
+      run_generator %w[user --preview]
+
+      assert_no_file "test/components/previews/user_component_preview.rb"
+      assert_no_file "spec/components/previews/user_component_preview.rb"
+      assert_no_file "some/other/directory/user_component_preview.rb"
+    end
+  end
+
+  def test_component_preview_with_namespace
+    with_preview_paths([]) do
+      run_generator %w[admins/user --preview]
+
+      assert_file "test/components/previews/admins/user_component_preview.rb" do |component|
+        assert_match(/class Admins::UserComponentPreview < /, component)
+        assert_match(/render\(Admins::UserComponent.new\)/, component)
+      end
+    end
+  end
+end


### PR DESCRIPTION
<!-- See https://github.com/github/view_component/blob/main/docs/CONTRIBUTING.md#submitting-a-pull-request -->

### Summary

This PR allows the preview generator to get the provided component generator attributes.
Why?
Because, the default generated preview when passing attributes is not valid and fails tests, and it's not cool to generate failing tests files. ;)

### Other Information

This PR move preview generator tests to its own file as for other generators.
A config option has been added too, in order to enable project-wide preview generation.
