### PR TITLE
Add ViewComponent::Collection to @param of #render_inline

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,10 @@ title: Changelog
 
 ## main
 
+* Update `@param` of `#render_inline` to include `ViewComponent::Collection`.
+
+    *Yutaka Kamei*
+
 ## 2.47.0
 
 * Display preview source on previews that exclusively use templates.

--- a/docs/index.md
+++ b/docs/index.md
@@ -180,6 +180,7 @@ ViewComponent is built by over a hundred members of the community, including:
 <img src="https://avatars.githubusercontent.com/wdrexler?s=64" alt="wdrexler" width="32" />
 <img src="https://avatars.githubusercontent.com/websebdev?s=64" alt="websebdev" width="32" />
 <img src="https://avatars.githubusercontent.com/edwinthinks?s=64" alt="edwinthinks" width="32" />
+<img src="https://avatars.githubusercontent.com/yykamei?s=64" alt="yykamei" width="32" />
 <img src="https://avatars.githubusercontent.com/xkraty?s=64" alt="xkraty" width="32" />
 <img src="https://avatars.githubusercontent.com/xronos-i-am?s=64" alt="xronos-i-am" width="32" />
 

--- a/lib/view_component/test_helpers.rb
+++ b/lib/view_component/test_helpers.rb
@@ -38,7 +38,7 @@ module ViewComponent
     # assert_text("Hello, World!")
     # ```
     #
-    # @param component [ViewComponent::Base] The instance of the component to be rendered.
+    # @param component [ViewComponent::Base, ViewComponent::Collection] The instance of the component to be rendered.
     # @return [Nokogiri::HTML]
     def render_inline(component, **args, &block)
       @rendered_component =


### PR DESCRIPTION
### Summary

I found out my IDE (Intellij IDEA) tells me my code is not compatible with `#render_inline` when I pass an instance of `ViewComponent::Collection`. As far as I see, `#render_inline` seems to allow us to receive an instance of `ViewComponent::Collection` because it defines `#render_in` method internally.

So, I want to add `ViewComponent::Collection` to `@param` of `#render_inline`.

### Other Information

I updated `docs/CHANGELOG.md` and `docs/index.md`, following [Submitting a pull request](https://github.com/github/view_component/blob/d7bf301fe90d169bc2ff96dff7dd4dbc5454398a/docs/CONTRIBUTING.md#submitting-a-pull-request).
