### PR TITLE
[Fix] Inner Rack based methods return blank values fixed

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,10 @@ title: Changelog
 
 ## main
 
+* Return properly values for `request.path` and `request.query_string` methods.
+
+    *Vasiliy Matyushin*
+
 * Make `ViewComponent::Collection` act like a collection of view components
 
     *Sammy Henningsson*

--- a/docs/index.md
+++ b/docs/index.md
@@ -184,6 +184,7 @@ ViewComponent is built by over a hundred members of the community, including:
 <img src="https://avatars.githubusercontent.com/xkraty?s=64" alt="xkraty" width="32" />
 <img src="https://avatars.githubusercontent.com/xronos-i-am?s=64" alt="xronos-i-am" width="32" />
 <img src="https://avatars.githubusercontent.com/sammyhenningsson?s=64" alt="sammyhenningsson" width="32" />
+<img src="https://avatars.githubusercontent.com/stiig?s=64" alt="stiig" width="32" />
 
 ## Who uses ViewComponent?
 

--- a/lib/view_component/test_helpers.rb
+++ b/lib/view_component/test_helpers.rb
@@ -113,16 +113,22 @@ module ViewComponent
     #
     # @param path [String] The path to set for the current request.
     def with_request_url(path)
+      old_request_path_info = request.path_info
       old_request_path_parameters = request.path_parameters
       old_request_query_parameters = request.query_parameters
+      old_request_query_string = request.query_string
       old_controller = defined?(@controller) && @controller
 
+      request.path_info = path
       request.path_parameters = Rails.application.routes.recognize_path(path)
       request.set_header("action_dispatch.request.query_parameters", Rack::Utils.parse_query(path.split("?")[1]))
+      request.set_header(Rack::QUERY_STRING, path.split("?")[1])
       yield
     ensure
+      request.path_info = old_request_path_info
       request.path_parameters = old_request_path_parameters
       request.set_header("action_dispatch.request.query_parameters", old_request_query_parameters)
+      request.set_header(Rack::QUERY_STRING, old_request_query_string)
       @controller = old_controller
     end
 

--- a/test/view_component/view_component_test.rb
+++ b/test/view_component/view_component_test.rb
@@ -896,6 +896,10 @@ class ViewComponentTest < ViewComponent::TestCase
       render_inline UrlForComponent.new
       assert_text "/products?key=value"
     end
+
+    with_request_url "/products" do
+      assert_equal  "/products", request.path
+    end
   end
 
   def test_with_request_url_with_query_parameters
@@ -912,6 +916,10 @@ class ViewComponentTest < ViewComponent::TestCase
     with_request_url "/products?mykey=myvalue" do
       render_inline UrlForComponent.new
       assert_text "/products?key=value&mykey=myvalue"
+    end
+
+    with_request_url "/products?mykey=myvalue&otherkey=othervalue" do
+      assert_equal  "mykey=myvalue&otherkey=othervalue", request.query_string
     end
   end
 


### PR DESCRIPTION
### Summary

We check the current page for the active class in our `ApplicationHelper` like this
```rb
...
return 'active' if link_path == request.path
...
```
but it doesn't work with the test helper `with_request_url`. This PR fixes this problem and makes the `request` variable look more like a real.
