### PR TITLE
Fix style in generator docs

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,10 @@ title: Changelog
 
 ## main
 
+* Correct style in generators docs.
+
+    *Hans Lemuet*
+
 * Correctly type Ruby version strings and update Rails versions used in CI configuration.
 
     *Hans Lemuet*
@@ -29,7 +33,7 @@ title: Changelog
 
     *Simon Fish*
 
-* Add WEBrick as a depenency to the docs application.
+* Add WEBrick as a depenency to the application.
 
     *Connor McQuillan*
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,7 +7,7 @@ title: Changelog
 
 ## main
 
-* Correct style in generators docs.
+* Improve style in generators docs.
 
     *Hans Lemuet*
 

--- a/docs/guide/generators.md
+++ b/docs/guide/generators.md
@@ -98,7 +98,7 @@ bin/rails generate component Example title --locale
 
 To always generate locale files, set `config.view_component.generate_locale = true`.
 
-If your prefer having your translations in distinct locale files you can set `config.view_component.generate_distinct_locale_files = true` in order to generate as many files as configured in `I18n.available_locales`.
+If your prefer having your translations in distinct locale files you can set `config.view_component.generate_distinct_locale_files = true` to generate as many files as configured in `I18n.available_locales`.
 
 ### Place the view in a sidecar directory
 


### PR DESCRIPTION
### Summary

In CI, Vale complains about the use of `in order to` and recommends replacing it with `to`.

That's it.
