### PR TITLE
Add Lookbook to Resources docs page

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,7 +7,7 @@ title: Changelog
 
 ## main
 
-* Add Lookbook to Resources docs page
+* Add Lookbook to Resources docs page.
 
     *Mark Perkins*
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,10 @@ title: Changelog
 
 ## main
 
+* Add Lookbook to Resources docs page
+
+    *Mark Perkins*
+
 * Add blocking compiler mode for use in Rails development and testing modes, improving thread safety.
 
     *Horia Radu*

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -21,6 +21,7 @@ title: Resources
 
 - [ViewComponent::Storybook](https://github.com/jonspalmer/view_component_storybook)
 - [ViewComponent Contrib](https://github.com/palkan/view_component-contrib)
+- [Lookbook](https://github.com/allmarkedup/lookbook)
 
 ## Podcasts
 


### PR DESCRIPTION
This PR adds a link to [Lookbook](https://github.com/allmarkedup/lookbook) into the Resources page in the documentation.

People seem to be finding it useful but it would be great to get more people trying it out, so a link from here would be much appreciated :-)