### PR TITLE
Update the GOV.UK Components URL to new guide

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,10 @@ title: Changelog
 
 ## main
 
+* Update link to GOV.UK Components library in the resources list.
+
+    *Peter Yates*
+
 * Add Lookbook to Resources docs page.
 
     *Mark Perkins*

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -8,7 +8,7 @@ title: Resources
 ## ViewComponent libraries
 
 - [Primer ViewComponents](https://primer.style/view-components/)
-- [GOV.UK Rails Components](https://dfe-digital.github.io/govuk-components/)
+- [GOV.UK Rails Components](https://govuk-components.netlify.app/)
 - [Polaris ViewComponents](https://github.com/baoagency/polaris_view_components)
 
 ## Frameworks using ViewComponent


### PR DESCRIPTION
### Summary

The GOV.UK Components library now has a guide, the old page has been removed.