### PR TITLE
Correct path in example test command

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,10 @@ title: Changelog
 
 ## main
 
+* Correct path in example test command in Contributing document.
+
+    *Mark Wilkinson*
+
 * Update link to GOV.UK Components library in the resources list.
 
     *Peter Yates*

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,7 +7,7 @@ title: Changelog
 
 ## main
 
-* Correct path in example test command in Contributing document.
+* Correct path in example test command in Contributing docs.
 
     *Mark Wilkinson*
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -61,7 +61,7 @@ Here are a few things you can do that will increase the likelihood of your pull 
 Supply a file glob to the test command:
 
 ```command
-TEST="test/components/YOUR_COMPONENT_test.rb" bundle exec appraisal rake
+TEST="test/view_component/YOUR_COMPONENT_test.rb" bundle exec appraisal rake
 ```
 
 ### Running tests for a specific version of Rails


### PR DESCRIPTION
### Summary

The test files are in `test/view_component` now; this fixes the example to reflect that.
