### PR TITLE
Fix PVC CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,8 @@ jobs:
     - name: Build and test with Rake
       run: |
         cd primer_view_components
-        yarn install
+        yarn
+        cd demo && yarn && cd ..
         bundle config path vendor/bundle
         bundle install
         bundle exec rake docs:preview


### PR DESCRIPTION
### Summary

This was broken due to a change in Primer ViewComponents which now
requires running yarn in the docs directory to build the docs.
See https://github.com/primer/view_components/pull/970

[Example failed run](https://github.com/github/view_component/runs/4801553969?check_suite_focus=true)