### PR TITLE
Place all generator options under `generate` config option

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -44,3 +44,5 @@
 
 /.devcontainer/**/* @boardfish
 /script/replicate-bug @boardfish
+/lib/view_component/docs_builder_component.rb @boardfish
+/lib/view_component/docs_builder_component.html.erb @boardfish

--- a/Rakefile
+++ b/Rakefile
@@ -78,7 +78,6 @@ namespace :docs do
     require 'action_controller'
     require 'view_component'
     require 'view_component/docs_builder_component'
-
     docs = ActionController::Base.new.render_to_string(
       ViewComponent::DocsBuilderComponent.new(
         sections: [
@@ -88,7 +87,7 @@ namespace :docs do
           ViewComponent::DocsBuilderComponent::Section.new(heading: 'ViewComponent::TestHelpers', methods: test_helper_methods_to_document)
         ]
       )
-    )
+    ).chomp
 
     File.open("docs/api.md", "w") do |f|
       f.puts(docs)

--- a/Rakefile
+++ b/Rakefile
@@ -64,27 +64,34 @@ namespace :docs do
 
     instance_methods_to_document = meths.select { |method| method.scope != :class }
     class_methods_to_document = meths.select { |method| method.scope == :class }
-    configuration_methods_to_document = registry.get("ViewComponent::Base").meths.select { |method| method[:mattr_accessor] }
+    configuration_methods_to_document = registry.get("ViewComponent::Base").meths.select { |method|
+      method[:mattr_accessor]
+    }
     test_helper_methods_to_document = registry.
-        get("ViewComponent::TestHelpers").
-        meths.
-        sort_by { |method| method[:name] }.
-        select do |method|
-          !method.tag(:private) &&
-            method.visibility == :public
-        end
+                                      get("ViewComponent::TestHelpers").
+                                      meths.
+                                      sort_by { |method| method[:name] }.
+                                      select do |method|
+      !method.tag(:private) &&
+        method.visibility == :public
+    end
 
-    require 'rails'
-    require 'action_controller'
-    require 'view_component'
-    require 'view_component/docs_builder_component'
+    require "rails"
+    require "action_controller"
+    require "view_component"
+    require "view_component/docs_builder_component"
     docs = ActionController::Base.new.render_to_string(
       ViewComponent::DocsBuilderComponent.new(
         sections: [
-          ViewComponent::DocsBuilderComponent::Section.new(heading: 'Class methods', methods: class_methods_to_document),
-          ViewComponent::DocsBuilderComponent::Section.new(heading: 'Instance methods', methods: instance_methods_to_document),
-          ViewComponent::DocsBuilderComponent::Section.new(heading: 'Configuration', methods: configuration_methods_to_document, show_types: false),
-          ViewComponent::DocsBuilderComponent::Section.new(heading: 'ViewComponent::TestHelpers', methods: test_helper_methods_to_document)
+          ViewComponent::DocsBuilderComponent::Section.new(heading: "Class methods",
+                                                           methods: class_methods_to_document),
+          ViewComponent::DocsBuilderComponent::Section.new(heading: "Instance methods",
+                                                           methods: instance_methods_to_document),
+          ViewComponent::DocsBuilderComponent::Section.new(heading: "Configuration",
+                                                           methods: configuration_methods_to_document,
+                                                           show_types: false),
+          ViewComponent::DocsBuilderComponent::Section.new(heading: "ViewComponent::TestHelpers",
+                                                           methods: test_helper_methods_to_document)
         ]
       )
     ).chomp

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,10 @@ title: Changelog
 
 ## main
 
+* Place all generator options under `config.generate` namespace.
+
+    *Simon Fish*
+
 ## 2.49.0
 
 * Fix path handling for evaluated view components that broke in Ruby 3.1.

--- a/docs/api.md
+++ b/docs/api.md
@@ -92,17 +92,25 @@ Configuration for generators.
 All options under this namespace default to `false` unless otherwise
 stated.
 
+#### #sidecar
+
 Always generate a component with a sidecar directory:
 
     config.view_component.generate.sidecar = true
+
+#### #stimulus_controller
 
 Always generate a Stimulus controller alongside the component:
 
     config.view_component.generate.stimulus_controller = true
 
+#### #locale
+
 Always generate translations file alongside the component:
 
-    config.view_component.generate_locale = true
+    config.view_component.generate.locale = true
+
+#### #distinct_locale_files
 
 Always generate as many translations files as available locales:
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -81,7 +81,8 @@ Set a custom default layout used for preview index and individual previews:
 
 Configuration for generators.
 
-Defaults to `false` unless otherwise stated.
+All options under this namespace default to `false` unless otherwise
+stated.
 
 Always generate a component with a sidecar directory:
 
@@ -99,7 +100,8 @@ Always generate as many translations files as available locales:
 
     config.view_component.generate.distinct_locale_files = true
 
-One file will be generated for each configured `I18n.available_locales`, falling back to `[:en]` when `available_locales` is not defined.
+One file will be generated for each configured `I18n.available_locales`,
+falling back to `[:en]` when no available_locales is defined.
 
 Path for component files
 
@@ -111,7 +113,8 @@ Parent class for generated components
 
     config.view_component.generate.parent_class = "MyBaseComponent"
 
-Defaults to "ApplicationComponent" if defined, "ViewComponent::Base" otherwise.
+Defaults to "ApplicationComponent" if defined, "ViewComponent::Base"
+otherwise.
 
 ### #preview_controller
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -77,7 +77,8 @@ Parent class for generated components
 
     config.view_component.component_parent_class = "MyBaseComponent"
 
-Defaults to "ApplicationComponent" if defined, "ViewComponent::Base" otherwise.
+Defaults to nil. If this is falsy, generators will use
+"ApplicationComponent" if defined, "ViewComponent::Base" otherwise.
 
 ### #default_preview_layout
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -71,54 +71,48 @@ _Will be removed in v3.0.0._
 
 ## Configuration
 
-### #component_parent_class
-
-Parent class for generated components
-
-    config.view_component.component_parent_class = "MyBaseComponent"
-
-Defaults to "ApplicationComponent" if defined, "ViewComponent::Base" otherwise.
-
 ### #default_preview_layout
 
 Set a custom default layout used for preview index and individual previews:
 
     config.view_component.default_preview_layout = "component_preview"
 
-### #generate_distinct_locale_files
+### #generate
 
-Always generate as many translations files as available locales:
+Configuration for generators
 
-    config.view_component.generate_distinct_locale_files = true
+Defaults to `false` unless otherwise stated.
 
-Defaults to `false`.
+Always generate a component with a sidecar directory:
 
-One file will be generated for each configured `I18n.available_locales`.
-Fallback on `[:en]` when no available_locales is defined.
+    config.view_component.generate.sidecar = true
 
-### #generate_locale
+Always generate a Stimulus controller alongside the component:
+
+    config.view_component.generate.stimulus_controller = true
 
 Always generate translations file alongside the component:
 
     config.view_component.generate_locale = true
 
-Defaults to `false`.
+Always generate as many translations files as available locales:
 
-### #generate_sidecar
+    config.view_component.generate.distinct_locale_files = true
 
-Always generate a component with a sidecar directory:
+One file will be generated for each configured `I18n.available_locales`.
+Fallback on `[:en]` when no available_locales is defined.
 
-    config.view_component.generate_sidecar = true
+Path for component files
 
-Defaults to `false`.
+    config.view_component.generate.component_path = "app/my_components"
 
-### #generate_stimulus_controller
+Defaults to `app/components`.
 
-Always generate a Stimulus controller alongside the component:
+Parent class for generated components
 
-    config.view_component.generate_stimulus_controller = true
+    config.view_component.generate.parent_class = "MyBaseComponent"
 
-Defaults to `false`.
+Defaults to "ApplicationComponent" if defined, "ViewComponent::Base" otherwise.
 
 ### #preview_controller
 
@@ -176,14 +170,6 @@ Set the controller used for testing components:
 
 Defaults to ApplicationController. Can also be configured on a per-test
 basis using `with_controller_class`.
-
-### #view_component_path
-
-Path for component files
-
-    config.view_component.view_component_path = "app/my_components"
-
-Defaults to `app/components`.
 
 ## ViewComponent::TestHelpers
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -79,7 +79,7 @@ Set a custom default layout used for preview index and individual previews:
 
 ### #generate
 
-Configuration for generators
+Configuration for generators.
 
 Defaults to `false` unless otherwise stated.
 
@@ -99,8 +99,7 @@ Always generate as many translations files as available locales:
 
     config.view_component.generate.distinct_locale_files = true
 
-One file will be generated for each configured `I18n.available_locales`.
-Fallback on `[:en]` when no available_locales is defined.
+One file will be generated for each configured `I18n.available_locales`, falling back to `[:en]` when `available_locales` is not defined.
 
 Path for component files
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -71,6 +71,14 @@ _Will be removed in v3.0.0._
 
 ## Configuration
 
+### #component_parent_class
+
+Parent class for generated components
+
+    config.view_component.component_parent_class = "MyBaseComponent"
+
+Defaults to "ApplicationComponent" if defined, "ViewComponent::Base" otherwise.
+
 ### #default_preview_layout
 
 Set a custom default layout used for preview index and individual previews:
@@ -102,19 +110,6 @@ Always generate as many translations files as available locales:
 
 One file will be generated for each configured `I18n.available_locales`,
 falling back to `[:en]` when no available_locales is defined.
-
-Path for component files
-
-    config.view_component.generate.component_path = "app/my_components"
-
-Defaults to `app/components`.
-
-Parent class for generated components
-
-    config.view_component.generate.parent_class = "MyBaseComponent"
-
-Defaults to "ApplicationComponent" if defined, "ViewComponent::Base"
-otherwise.
 
 ### #preview_controller
 
@@ -172,6 +167,14 @@ Set the controller used for testing components:
 
 Defaults to ApplicationController. Can also be configured on a per-test
 basis using `with_controller_class`.
+
+### #view_component_path
+
+Path for component files
+
+    config.view_component.view_component_path = "app/my_components"
+
+Defaults to `app/components`.
 
 ## ViewComponent::TestHelpers
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -134,7 +134,7 @@ Always generate as many translations files as available locales:
     config.view_component.generate.distinct_locale_files = true
 
 One file will be generated for each configured `I18n.available_locales`,
-falling back to `[:en]` when no available_locales is defined.
+falling back to `[:en]` when no `available_locales` is defined.
 
 ### #preview_controller
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -40,6 +40,22 @@ _Use `#before_render` instead. Will be removed in v3.0.0._
 The current controller. Use sparingly as doing so introduces coupling
 that inhibits encapsulation & reuse, often making testing difficult.
 
+### #generate_distinct_locale_files (Deprecated)
+
+_Use `#generate.distinct_locale_files` instead. Will be removed in v3.0.0._
+
+### #generate_locale (Deprecated)
+
+_Use `#generate.locale` instead. Will be removed in v3.0.0._
+
+### #generate_sidecar (Deprecated)
+
+_Use `#generate.sidecar` instead. Will be removed in v3.0.0._
+
+### #generate_stimulus_controller (Deprecated)
+
+_Use `#generate.stimulus_controller` instead. Will be removed in v3.0.0._
+
 ### #helpers → [ActionView::Base]
 
 A proxy through which to access helpers. Use sparingly as doing so introduces

--- a/docs/guide/generators.md
+++ b/docs/guide/generators.md
@@ -36,6 +36,8 @@ bin/rails generate component Sections::Example title content
 
 ## Options
 
+You can specify options when running the generator. To alter the default values project-wide, define the configuration settings described in [API docs](/api.html#configuration).
+
 Generated ViewComponents are added to `app/components` by default. Set `config.view_component.view_component_path` to use a different path.
 
 ### Override template engine

--- a/lib/rails/generators/abstract_generator.rb
+++ b/lib/rails/generators/abstract_generator.rb
@@ -44,7 +44,7 @@ module ViewComponent
     end
 
     def sidecar?
-      options["sidecar"] || ViewComponent::Base.generate_sidecar
+      options["sidecar"] || ViewComponent::Base.generate.sidecar
     end
   end
 end

--- a/lib/rails/generators/component/component_generator.rb
+++ b/lib/rails/generators/component/component_generator.rb
@@ -13,7 +13,7 @@ module Rails
       check_class_collision suffix: "Component"
       class_option :inline, type: :boolean, default: false
       class_option :parent, type: :string, desc: "The parent class for the generated component"
-      class_option :stimulus, type: :boolean, default: ViewComponent::Base.generate_stimulus_controller
+      class_option :stimulus, type: :boolean, default: ViewComponent::Base.generate.stimulus_controller
       class_option :sidecar, type: :boolean, default: false
       class_option :locale, type: :boolean, default: ViewComponent::Base.generate_locale
 

--- a/lib/rails/generators/component/component_generator.rb
+++ b/lib/rails/generators/component/component_generator.rb
@@ -15,7 +15,7 @@ module Rails
       class_option :parent, type: :string, desc: "The parent class for the generated component"
       class_option :stimulus, type: :boolean, default: ViewComponent::Base.generate.stimulus_controller
       class_option :sidecar, type: :boolean, default: false
-      class_option :locale, type: :boolean, default: ViewComponent::Base.generate_locale
+      class_option :locale, type: :boolean, default: ViewComponent::Base.generate.locale
 
       def create_component_file
         template "component.rb", File.join(component_path, class_path, "#{file_name}_component.rb")

--- a/lib/rails/generators/locale/component_generator.rb
+++ b/lib/rails/generators/locale/component_generator.rb
@@ -12,7 +12,7 @@ module Locale
       class_option :sidecar, type: :boolean, default: false
 
       def create_locale_file
-        if ViewComponent::Base.generate_distinct_locale_files
+        if ViewComponent::Base.generate.distinct_locale_files
           I18n.available_locales.each do |locale|
             create_file destination(locale), translations_hash([locale]).to_yaml
           end

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -287,9 +287,10 @@ module ViewComponent
     #
     mattr_accessor :component_parent_class, instance_writer: false
 
-    # Configuration for generators
+    # Configuration for generators.
     #
-    # Defaults to `false` unless otherwise stated.
+    # All options under this namespace default to `false` unless otherwise
+    # stated.
     #
     # Always generate a component with a sidecar directory:
     #
@@ -307,8 +308,8 @@ module ViewComponent
     #
     #     config.view_component.generate.distinct_locale_files = true
     #
-    # One file will be generated for each configured `I18n.available_locales`.
-    # Fallback on `[:en]` when no available_locales is defined.
+    # One file will be generated for each configured `I18n.available_locales`,
+    # falling back to `[:en]` when no available_locales is defined.
     #
     mattr_accessor :generate, instance_writer: false, default: (ActiveSupport::OrderedOptions.new(false).tap do |c|
       c.component_path = "app/components"

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -283,7 +283,8 @@ module ViewComponent
     #
     #     config.view_component.component_parent_class = "MyBaseComponent"
     #
-    # Defaults to "ApplicationComponent" if defined, "ViewComponent::Base" otherwise.
+    # Defaults to nil. If this is falsy, generators will use
+    # "ApplicationComponent" if defined, "ViewComponent::Base" otherwise.
     #
     mattr_accessor :component_parent_class, instance_writer: false
 

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -311,7 +311,7 @@ module ViewComponent
     # Fallback on `[:en]` when no available_locales is defined.
     #
     mattr_accessor :generate, instance_writer: false, default: (ActiveSupport::OrderedOptions.new.tap do |c|
-      c.component_path = 'app/components'
+      c.component_path = "app/components"
     end)
 
     class << self

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -271,17 +271,6 @@ module ViewComponent
     #
     mattr_accessor :render_monkey_patch_enabled, instance_writer: false, default: true
 
-    # Always generate as many translations files as available locales:
-    #
-    #     config.view_component.generate_distinct_locale_files = true
-    #
-    # Defaults to `false`.
-    #
-    # One file will be generated for each configured `I18n.available_locales`.
-    # Fallback on `[:en]` when no available_locales is defined.
-    #
-    mattr_accessor :generate_distinct_locale_files, instance_writer: false, default: false
-
     # Path for component files
     #
     #     config.view_component.view_component_path = "app/my_components"
@@ -313,6 +302,13 @@ module ViewComponent
     # Always generate translations file alongside the component:
     #
     #     config.view_component.generate_locale = true
+    #
+    # Always generate as many translations files as available locales:
+    #
+    #     config.view_component.generate.distinct_locale_files = true
+    #
+    # One file will be generated for each configured `I18n.available_locales`.
+    # Fallback on `[:en]` when no available_locales is defined.
     #
     mattr_accessor :generate, instance_writer: false, default: ActiveSupport::OrderedOptions.new
 

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -310,7 +310,9 @@ module ViewComponent
     # One file will be generated for each configured `I18n.available_locales`.
     # Fallback on `[:en]` when no available_locales is defined.
     #
-    mattr_accessor :generate, instance_writer: false, default: ActiveSupport::OrderedOptions.new
+    mattr_accessor :generate, instance_writer: false, default: (ActiveSupport::OrderedOptions.new.tap do |c|
+      c.component_path = 'app/components'
+    end)
 
     class << self
       # @private

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -271,14 +271,6 @@ module ViewComponent
     #
     mattr_accessor :render_monkey_patch_enabled, instance_writer: false, default: true
 
-    # Always generate translations file alongside the component:
-    #
-    #     config.view_component.generate_locale = true
-    #
-    # Defaults to `false`.
-    #
-    mattr_accessor :generate_locale, instance_writer: false, default: false
-
     # Always generate as many translations files as available locales:
     #
     #     config.view_component.generate_distinct_locale_files = true
@@ -317,6 +309,10 @@ module ViewComponent
     # Always generate a Stimulus controller alongside the component:
     #
     #     config.view_component.generate.stimulus_controller = true
+    #
+    # Always generate translations file alongside the component:
+    #
+    #     config.view_component.generate_locale = true
     #
     mattr_accessor :generate, instance_writer: false, default: ActiveSupport::OrderedOptions.new
 

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -292,17 +292,25 @@ module ViewComponent
     # All options under this namespace default to `false` unless otherwise
     # stated.
     #
+    # #### #sidecar
+    #
     # Always generate a component with a sidecar directory:
     #
     #     config.view_component.generate.sidecar = true
+    #
+    # #### #stimulus_controller
     #
     # Always generate a Stimulus controller alongside the component:
     #
     #     config.view_component.generate.stimulus_controller = true
     #
+    # #### #locale
+    #
     # Always generate translations file alongside the component:
     #
-    #     config.view_component.generate_locale = true
+    #     config.view_component.generate.locale = true
+    #
+    # #### #distinct_locale_files
     #
     # Always generate as many translations files as available locales:
     #

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -314,13 +314,11 @@ module ViewComponent
     #
     mattr_accessor :component_parent_class, instance_writer: false
 
-    # Always generate a component with a sidecar directory:
+    # Configuration for generators
     #
-    #     config.view_component.generate_sidecar = true
+    #     config.view_component.generate.sidecar = true
     #
-    # Defaults to `false`.
-    #
-    mattr_accessor :generate_sidecar, instance_writer: false, default: false
+    mattr_accessor :generate, instance_writer: false, default: ActiveSupport::OrderedOptions.new
 
     class << self
       # @private

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -310,7 +310,7 @@ module ViewComponent
     # One file will be generated for each configured `I18n.available_locales`.
     # Fallback on `[:en]` when no available_locales is defined.
     #
-    mattr_accessor :generate, instance_writer: false, default: (ActiveSupport::OrderedOptions.new.tap do |c|
+    mattr_accessor :generate, instance_writer: false, default: (ActiveSupport::OrderedOptions.new(false).tap do |c|
       c.component_path = "app/components"
     end)
 

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -271,14 +271,6 @@ module ViewComponent
     #
     mattr_accessor :render_monkey_patch_enabled, instance_writer: false, default: true
 
-    # Always generate a Stimulus controller alongside the component:
-    #
-    #     config.view_component.generate_stimulus_controller = true
-    #
-    # Defaults to `false`.
-    #
-    mattr_accessor :generate_stimulus_controller, instance_writer: false, default: false
-
     # Always generate translations file alongside the component:
     #
     #     config.view_component.generate_locale = true
@@ -321,6 +313,10 @@ module ViewComponent
     # Always generate a component with a sidecar directory:
     #
     #     config.view_component.generate.sidecar = true
+    #
+    # Always generate a Stimulus controller alongside the component:
+    #
+    #     config.view_component.generate.stimulus_controller = true
     #
     mattr_accessor :generate, instance_writer: false, default: ActiveSupport::OrderedOptions.new
 

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -316,6 +316,10 @@ module ViewComponent
 
     # Configuration for generators
     #
+    # Defaults to `false` unless otherwise stated.
+    #
+    # Always generate a component with a sidecar directory:
+    #
     #     config.view_component.generate.sidecar = true
     #
     mattr_accessor :generate, instance_writer: false, default: ActiveSupport::OrderedOptions.new

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -335,7 +335,7 @@ module ViewComponent
     #     config.view_component.generate.distinct_locale_files = true
     #
     # One file will be generated for each configured `I18n.available_locales`,
-    # falling back to `[:en]` when no available_locales is defined.
+    # falling back to `[:en]` when no `available_locales` is defined.
     #
     mattr_accessor :generate, instance_writer: false, default: ActiveSupport::OrderedOptions.new(false)
 

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -40,6 +40,23 @@ module ViewComponent
       # noop
     end
 
+    # @!macro [attach] deprecated_generate_mattr_accessor
+    #   @method generate_$1
+    #   @deprecated Use `#generate.$1` instead. Will be removed in v3.0.0.
+    def self._deprecated_generate_mattr_accessor(name)
+      define_singleton_method("generate_#{name}".to_sym) do
+        generate.public_send(name)
+      end
+      define_singleton_method("generate_#{name}=".to_sym) do |value|
+        generate.public_send("#{name}=".to_sym, value)
+      end
+    end
+
+    _deprecated_generate_mattr_accessor :distinct_locale_files
+    _deprecated_generate_mattr_accessor :locale
+    _deprecated_generate_mattr_accessor :sidecar
+    _deprecated_generate_mattr_accessor :stimulus_controller
+
     # Entrypoint for rendering components.
     #
     # - `view_context`: ActionView context from calling view

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -337,9 +337,7 @@ module ViewComponent
     # One file will be generated for each configured `I18n.available_locales`,
     # falling back to `[:en]` when no available_locales is defined.
     #
-    mattr_accessor :generate, instance_writer: false, default: (ActiveSupport::OrderedOptions.new(false).tap do |c|
-      c.component_path = "app/components"
-    end)
+    mattr_accessor :generate, instance_writer: false, default: ActiveSupport::OrderedOptions.new(false)
 
     class << self
       # @private

--- a/lib/view_component/docs_builder_component.html.erb
+++ b/lib/view_component/docs_builder_component.html.erb
@@ -12,7 +12,7 @@ nav_order: 3
 ## <%= section.heading %>
 
 <% section.methods.each do |method| %>
-### <%= raw render ViewComponent::DocsBuilderComponent::MethodDoc.new(method) %>
+### <%== render ViewComponent::DocsBuilderComponent::MethodDoc.new(method) %>
 
 <% end %>
 <% end %>

--- a/lib/view_component/docs_builder_component.html.erb
+++ b/lib/view_component/docs_builder_component.html.erb
@@ -1,0 +1,18 @@
+---
+layout: default
+title: API
+nav_order: 3
+---
+
+<!-- Warning: AUTO-GENERATED file, don't edit. Add code comments to your Ruby instead <3 -->
+
+# API
+
+<% @sections.each do |section| %>
+## <%= section.heading %>
+
+<% section.methods.each do |method| %>
+### <%= raw render ViewComponent::DocsBuilderComponent::MethodDoc.new(method) %>
+
+<% end %>
+<% end %>

--- a/lib/view_component/docs_builder_component.rb
+++ b/lib/view_component/docs_builder_component.rb
@@ -1,0 +1,75 @@
+module ViewComponent
+  class DocsBuilderComponent < Base
+    class Section < Struct.new(:heading, :methods, :show_types, keyword_init: true)
+      def initialize(heading: nil, methods: [], show_types: true)
+        methods.sort_by! { |method| method[:name] }
+        super
+      end
+    end
+
+    class MethodDoc < ViewComponent::Base
+      def initialize(method, section: Section.new(show_types: true))
+        @method = method
+        @section = section
+      end
+
+      def show_types?
+        @section.show_types
+      end
+
+      def deprecated?
+        @method.tag(:deprecated).present?
+      end
+
+      def suffix
+        " (Deprecated)" if deprecated?
+      end
+
+      def types
+        " → [#{@method.tag(:return).types.join(',')}]" if @method.tag(:return)&.types && show_types?
+      end
+
+      def signature_or_name
+        @method.signature ? @method.signature.gsub('def ', '') : @method.name
+      end
+
+      def separator
+        @method.sep
+      end
+
+      def docstring
+        @method.docstring
+      end
+
+      def deprecation_text
+        @method.tag(:deprecated)&.text
+      end
+
+      def docstring_and_deprecation_text
+        <<~DOCS.strip
+          #{docstring}
+
+          #{"_#{deprecation_text}_" if deprecated?}
+        DOCS
+      end
+
+      def call
+        <<~DOCS.chomp
+          #{separator}#{signature_or_name}#{types}#{suffix}
+
+          #{docstring_and_deprecation_text}
+        DOCS
+      end
+    end
+
+    # { heading: String, public_only: Boolean, show_types: Boolean}
+    def initialize(sections: [])
+      @sections = sections
+    end
+
+    # deprecation
+    # return
+    # only public methods
+    # sig with types or name
+  end
+end

--- a/lib/view_component/docs_builder_component.rb
+++ b/lib/view_component/docs_builder_component.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ViewComponent
   class DocsBuilderComponent < Base
     class Section < Struct.new(:heading, :methods, :show_types, keyword_init: true)
@@ -30,7 +32,7 @@ module ViewComponent
       end
 
       def signature_or_name
-        @method.signature ? @method.signature.gsub('def ', '') : @method.name
+        @method.signature ? @method.signature.gsub("def ", "") : @method.name
       end
 
       def separator

--- a/lib/view_component/rails/tasks/view_component.rake
+++ b/lib/view_component/rails/tasks/view_component.rake
@@ -6,6 +6,6 @@ namespace :view_component do
   task statsetup: :environment do
     require "rails/code_statistics"
 
-    ::STATS_DIRECTORIES << ["ViewComponents", ViewComponent::Base.view_component_path]
+    ::STATS_DIRECTORIES << ["ViewComponents", ViewComponent::Base.generate.component_path]
   end
 end

--- a/lib/view_component/rails/tasks/view_component.rake
+++ b/lib/view_component/rails/tasks/view_component.rake
@@ -6,6 +6,6 @@ namespace :view_component do
   task statsetup: :environment do
     require "rails/code_statistics"
 
-    ::STATS_DIRECTORIES << ["ViewComponents", ViewComponent::Base.generate.component_path]
+    ::STATS_DIRECTORIES << ["ViewComponents", ViewComponent::Base.view_component_path]
   end
 end

--- a/test/generators/locale_generator_test.rb
+++ b/test/generators/locale_generator_test.rb
@@ -131,8 +131,8 @@ class LocaleGeneratorTest < Rails::Generators::TestCase
   private
 
   def with_generate_distinct_locale_files
-    ViewComponent::Base.generate_distinct_locale_files = true
+    ViewComponent::Base.generate.distinct_locale_files = true
     yield
-    ViewComponent::Base.generate_distinct_locale_files = false
+    ViewComponent::Base.generate.distinct_locale_files = false
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -76,11 +76,11 @@ ensure
 end
 
 def with_generate_sidecar(enabled)
-  old_value = ViewComponent::Base.generate_sidecar
-  ViewComponent::Base.generate_sidecar = enabled
+  old_value = ViewComponent::Base.generate.sidecar
+  ViewComponent::Base.generate.sidecar = enabled
   yield
 ensure
-  ViewComponent::Base.generate_sidecar = old_value
+  ViewComponent::Base.generate.sidecar = old_value
 end
 
 def with_new_cache

--- a/test/view_component/view_component_test.rb
+++ b/test/view_component/view_component_test.rb
@@ -973,4 +973,19 @@ class ViewComponentTest < ViewComponent::TestCase
       threads.map(&:join)
     end
   end
+
+  def test_deprecated_generate_mattr_accessor
+    ViewComponent::Base._deprecated_generate_mattr_accessor(:test_accessor)
+    assert(ViewComponent::Base.respond_to?(:generate_test_accessor))
+    assert_equal(ViewComponent::Base.generate_test_accessor, ViewComponent::Base.generate.test_accessor)
+    ViewComponent::Base.generate_test_accessor = "changed"
+    assert_equal(ViewComponent::Base.generate_test_accessor, ViewComponent::Base.generate.test_accessor)
+    ViewComponent::Base.generate.test_accessor = "changed again"
+    assert_equal(ViewComponent::Base.generate_test_accessor, ViewComponent::Base.generate.test_accessor)
+  ensure
+    ViewComponent::Base.class_eval do
+      singleton_class.undef_method :generate_test_accessor
+      singleton_class.undef_method :generate_test_accessor=
+    end
+  end
 end


### PR DESCRIPTION
<!-- See https://github.com/github/view_component/blob/main/docs/CONTRIBUTING.md#submitting-a-pull-request -->

### Summary

Closes #1229 by placing all config options linked to generators under the `generate` config option. Behind the scenes, this uses [`ActiveSupport::OrderedOptions`](https://api.rubyonrails.org/classes/ActiveSupport/OrderedOptions.html), which inherits from `Hash` to provide method accessors. Like `Hash`, this can be initialized with a default value, which has been set to `false` to reflect the existing behavior - all config options are `false` except for `component_path`.

### Other Information

TODO:

- [x] Move `generate_stimulus_controller` under namespace
- [x] Move `generate_locale` under namespace
- [x] Move `generate_distinct_locale_files` under namespace
- [x] Move `view_component_path` under namespace
- [x] Move `component_parent_class` under namespace