### PR TITLE
Updating preview page of docs to mention rspec

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,10 @@ title: Changelog
 
 ## main
 
+* Small update to preview docs to include rspec mention
+
+    *Leigh Halliday*
+
 * Small improvements to collection iteration docs.
 
     *Brian O'Rourke*

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,7 +7,7 @@ title: Changelog
 
 ## main
 
-* Small update to preview docs to include rspec mention
+* Small update to preview docs to include rspec mention.
 
     *Leigh Halliday*
 

--- a/docs/guide/previews.md
+++ b/docs/guide/previews.md
@@ -174,7 +174,7 @@ To render a source preview in a different place, use the view helper `preview_so
 
 ## Using with rspec
 
-When using previews with rspec, `test/components` should be replaced with `spec/components` and the `preview_paths` setting must be updated.
+When using previews with rspec,  replace `test/components` with `spec/components` and update `preview_paths`:
 
 ```ruby
 # config/application.rb

--- a/docs/guide/previews.md
+++ b/docs/guide/previews.md
@@ -171,3 +171,12 @@ config.view_component.show_previews_source = true
 ```
 
 To render a source preview in a different place, use the view helper `preview_source` from within your preview template or preview layout.
+
+## Using with rspec
+
+When using previews with rspec, `test/components` should be replaced with `spec/components` and the `preview_paths` setting must be updated.
+
+```ruby
+# config/application.rb
+config.view_component.preview_paths << "#{Rails.root}/spec/components/previews"
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -148,6 +148,7 @@ ViewComponent is built by over a hundred members of the community, including:
 <img src="https://avatars.githubusercontent.com/jules2689?s=64" alt="jules2689" width="32" />
 <img src="https://avatars.githubusercontent.com/kaspermeyer?s=64" alt="kaspermeyer" width="32" />
 <img src="https://avatars.githubusercontent.com/kylefox?s=64" alt="kylefox" width="32" />
+<img src="https://avatars.githubusercontent.com/leighhalliday?s=64" alt="leighhalliday" width="32" />
 <img src="https://avatars.githubusercontent.com/manuelpuyol?s=64" alt="manuelpuyol" width="32" />
 <img src="https://avatars.githubusercontent.com/matheusrich?s=64" alt="matheusrich" width="32" />
 <img src="https://avatars.githubusercontent.com/matt-yorkley?s=64" alt="Matt-Yorkley" width="32" />
@@ -197,6 +198,7 @@ ViewComponent is built by over a hundred members of the community, including:
 * [Cults.](https://cults3d.com/)
 * [Litmus](https://litmus.engineering/)
 * [Orbit](https://orbit.love)
+* [Wrapbook](https://wrapbook.com/)
 
 If your team starts using ViewComponent, [send a pull request](https://github.com/github/view_component/edit/main/docs/index.md) to let us know!
 You can also check out [how various projects use ViewComponent](https://github.com/github/view_component/network/dependents?package_id=UGFja2FnZS0xMDEwNjQxMzYx).


### PR DESCRIPTION
### Summary

When trying to get previews working I didn't realize that the `preview_paths` config setting had to be updated when working with rspec. I eventually found this on the `testing` page but I thought it would be better to colocate this with the preview docs because at this point I wasn't at the testing stage.
