### PR TITLE
Ensure i18n_scope is a symbol to protect lookups

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,10 @@ title: Changelog
 
 ## main
 
+* Ensure i18n scope is a symbol to protect lookups.
+
+    *Simon Fish*
+
 * Small update to preview docs to include rspec mention.
 
     *Leigh Halliday*

--- a/lib/view_component/translatable.rb
+++ b/lib/view_component/translatable.rb
@@ -41,7 +41,7 @@ module ViewComponent
       EMPTY_HASH = {}.freeze
 
       def initialize(i18n_scope:, load_paths:)
-        @i18n_scope = i18n_scope.split(".")
+        @i18n_scope = i18n_scope.split(".").map(&:to_sym)
         @load_paths = load_paths
       end
 


### PR DESCRIPTION
### Summary

Closes #1264 

### Other Information

This appears to be because efforts were taken to stop `i18n` unnecessarily calling `deep_symbolize_keys`. 
