### PR TITLE
Use path instead of absolute_path for inside eval

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,10 @@ title: Changelog
 
 ## main
 
+* Fix path handling for evaluated view components
+
+    *Adam Hess*
+
 * Ensure i18n scope is a symbol to protect lookups.
 
     *Simon Fish*

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,7 +7,7 @@ title: Changelog
 
 ## main
 
-* Fix path handling for evaluated view components
+* Fix path handling for evaluated view components that broke in Ruby 3.1.
 
     *Adam Hess*
 

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -401,7 +401,7 @@ module ViewComponent
         # Derive the source location of the component Ruby file from the call stack.
         # We need to ignore `inherited` frames here as they indicate that `inherited`
         # has been re-defined by the consuming application, likely in ApplicationComponent.
-        child.source_location = caller_locations(1, 10).reject { |l| l.label == "inherited" }[0].absolute_path
+        child.source_location = caller_locations(1, 10).reject { |l| l.label == "inherited" }[0].path
 
         # Removes the first part of the path and the extension.
         child.virtual_path = child.source_location.gsub(

--- a/test/view_component/base_test.rb
+++ b/test/view_component/base_test.rb
@@ -104,6 +104,6 @@ class ViewComponent::Base::UnitTest < Minitest::Test
       end
     RUBY
 
-    eval(source)
+    eval(source) # rubocop:disable Security/Eval
   end
 end

--- a/test/view_component/base_test.rb
+++ b/test/view_component/base_test.rb
@@ -90,4 +90,20 @@ class ViewComponent::Base::UnitTest < Minitest::Test
   ensure
     ActionView::Template::Handlers::ERB.strip_trailing_newlines = false if Rails::VERSION::MAJOR >= 7
   end
+
+  def test_evaled_component
+    source = <<~RUBY
+      class EvaledComponent < ViewComponent::Base
+        def initialize(cta: nil, title:)
+          @cta = cta
+          @title = title
+        end
+        private
+
+        attr_reader :cta, :title
+      end
+    RUBY
+
+    eval(source)
+  end
 end


### PR DESCRIPTION
This prevents getting a nil absolute_path for code executed inside of an eval

<!-- See https://github.com/github/view_component/blob/main/docs/CONTRIBUTING.md#submitting-a-pull-request -->

### Summary

Absolute path is not always available on your callers, but path is more likely to be available. This especially fixes files that are evaluated which in ruby 3.1 never have absolute paths after this change in ruby: https://github.com/ruby/ruby/commit/64ac984129a7a4645efe5ac57c168ef880b479b2