### PR TITLE
Silence deprecation notices in CI

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,10 @@ title: Changelog
 
 ## main
 
+* Silence deprecation warnings in CI.
+
+    *Hans Lemuet*
+
 * Place all generator options under `config.generate` namespace.
 
     *Simon Fish*

--- a/lib/view_component.rb
+++ b/lib/view_component.rb
@@ -24,7 +24,7 @@ if defined?(ViewComponent::Engine)
   ActiveSupport::Deprecation.warn(
     "This manually engine loading is deprecated and will be removed in v3.0.0. " \
     "Remove `require \"view_component/engine\"`."
-  )
+  ) unless ENV["CI"]
 elsif defined?(Rails::Engine)
   require "view_component/engine"
 end

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -237,7 +237,7 @@ module ViewComponent
     def with_variant(variant)
       ActiveSupport::Deprecation.warn(
         "`with_variant` is deprecated and will be removed in ViewComponent v3.0.0."
-      )
+      ) unless ENV["CI"]
 
       @__vc_variant = variant
 

--- a/lib/view_component/compiler.rb
+++ b/lib/view_component/compiler.rb
@@ -52,7 +52,7 @@ module ViewComponent
           ActiveSupport::Deprecation.warn(
             "`#before_render_check` will be removed in v3.0.0.\n\n" \
             "To fix this issue, use `#before_render` instead."
-          )
+          ) unless ENV["CI"]
         end
 
         if raise_errors

--- a/lib/view_component/content_areas.rb
+++ b/lib/view_component/content_areas.rb
@@ -34,7 +34,7 @@ module ViewComponent
         ActiveSupport::Deprecation.warn(
           "`with_content_areas` is deprecated and will be removed in ViewComponent v3.0.0.\n\n" \
           "Use slots (https://viewcomponent.org/guide/slots.html) instead."
-        )
+        ) unless ENV["CI"]
 
         if areas.include?(:content)
           raise ArgumentError.new(

--- a/lib/view_component/engine.rb
+++ b/lib/view_component/engine.rb
@@ -29,7 +29,7 @@ module ViewComponent
         if options.preview_path.present?
           ActiveSupport::Deprecation.warn(
             "`preview_path` will be removed in v3.0.0. Use `preview_paths` instead."
-          )
+          ) unless ENV["CI"]
           options.preview_paths << options.preview_path
         end
 
@@ -158,7 +158,7 @@ unless defined?(ViewComponent::Base)
   ActiveSupport::Deprecation.warn(
     "This manually engine loading is deprecated and will be removed in v3.0.0. " \
     "Remove `require \"view_component/engine\"`."
-  )
+  ) unless ENV["CI"]
 
   require "view_component"
 end

--- a/lib/view_component/slotable.rb
+++ b/lib/view_component/slotable.rb
@@ -26,7 +26,7 @@ module ViewComponent
         ActiveSupport::Deprecation.warn(
           "`with_slot` is deprecated and will be removed in ViewComponent v3.0.0.\n" \
           "Use the new slots API (https://viewcomponent.org/guide/slots.html) instead."
-        )
+        ) unless ENV["CI"]
 
         slot_names.each do |slot_name|
           # Ensure slot_name isn't already declared


### PR DESCRIPTION
### Summary

The CI logs include a lot of deprecation warnings. In order to make them more readable, let's silence these warnings.

I took a pretty basic approach: check for `ENV["CI"]` which is [defined automatically](https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables).

### Other Information

This is an alternative to #586
