### PR TITLE
Fix shadowing outer local variable and other warnings

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -22,3 +22,6 @@ Layout/DotPosition:
 Layout/LineLength:
   Max: 120
   Enabled: true
+
+Layout/SpaceBeforeBrackets:
+  Enabled: true

--- a/app/helpers/preview_helper.rb
+++ b/app/helpers/preview_helper.rb
@@ -27,8 +27,8 @@ module PreviewHelper
       end.flatten
 
       # Search for templates the contain `html`.
-      matching_templates = all_template_paths.find_all do |template|
-        template =~ /#{template_identifier}*.(html)/
+      matching_templates = all_template_paths.find_all do |path|
+        path =~ /#{template_identifier}*.(html)/
       end
 
       # In-case of a conflict due to multiple template files with

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,10 @@ title: Changelog
 
 ## main
 
+* Fix Ruby warnings.
+
+    *Hans Lemuet*
+
 * Place all generator options under `config.generate` namespace.
 
     *Simon Fish*

--- a/lib/view_component/preview.rb
+++ b/lib/view_component/preview.rb
@@ -73,8 +73,8 @@ module ViewComponent # :nodoc:
       # Returns the relative path (from preview_path) to the preview example template if the template exists
       def preview_example_template_path(example)
         preview_path =
-          Array(preview_paths).detect do |preview_path|
-            Dir["#{preview_path}/#{preview_name}_preview/#{example}.html.*"].first
+          Array(preview_paths).detect do |path|
+            Dir["#{path}/#{preview_name}_preview/#{example}.html.*"].first
           end
 
         if preview_path.nil?

--- a/lib/view_component/slotable_v2.rb
+++ b/lib/view_component/slotable_v2.rb
@@ -276,8 +276,8 @@ module ViewComponent
         renderable_function = slot_definition[:renderable_function].bind(self)
         renderable_value =
           if block_given?
-            renderable_function.call(*args) do |*args|
-              view_context.capture(*args, &block)
+            renderable_function.call(*args) do |*rargs|
+              view_context.capture(*rargs, &block)
             end
           else
             renderable_function.call(*args)

--- a/test/sandbox/app/components/jbuilder_component.json.jbuilder
+++ b/test/sandbox/app/components/jbuilder_component.json.jbuilder
@@ -1,4 +1,2 @@
-# frozen_string_literal: true
-
 json.message @message
 json.conent content

--- a/test/sandbox/app/components/jbuilder_component.json.jbuilder
+++ b/test/sandbox/app/components/jbuilder_component.json.jbuilder
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 json.message @message
 json.conent content

--- a/test/view_component/slotable_v2_test.rb
+++ b/test/view_component/slotable_v2_test.rb
@@ -477,8 +477,8 @@ class SlotsV2sTest < ViewComponent::TestCase
     PartialHelper::State.reset
 
     assert_nothing_raised do
-      render_inline WrapperComponent.new do |c|
-        c.render(PartialSlotHelperComponent.new) do |c|
+      render_inline WrapperComponent.new do |w|
+        w.render(PartialSlotHelperComponent.new) do |c|
           c.header {}
         end
       end

--- a/test/view_component/tasks_test.rb
+++ b/test/view_component/tasks_test.rb
@@ -13,7 +13,7 @@ class TasksTest < ActiveSupport::TestCase
 
   test "adds components to rails stats" do
     Dir.chdir(Rails.root) do
-      assert_output /ViewComponents/ do
+      assert_output(/ViewComponents/) do
         Rake::Task["stats"].invoke
       end
     end


### PR DESCRIPTION
### Summary

This fixes the following warnings that are output when running the tests:

```
/home/runner/work/view_component/view_component/lib/view_component/slotable_v2.rb:279: warning: shadowing outer local variable - args
/home/runner/work/view_component/view_component/app/helpers/preview_helper.rb:30: warning: shadowing outer local variable - template
/home/runner/work/view_component/view_component/test/sandbox/app/components/jbuilder_component.json.jbuilder:1: warning: `frozen_string_literal' is ignored after any tokens
/home/runner/work/view_component/view_component/test/view_component/slotable_v2_test.rb:481: warning: shadowing outer local variable - c
/home/runner/work/view_component/view_component/test/view_component/tasks_test.rb:16: warning: ambiguous first argument; put parentheses or a space even after `/' operator
Run options: --seed 12208

# Running:

/home/runner/work/view_component/view_component/lib/view_component/preview.rb:76: warning: shadowing outer local variable - preview_path
```

### Other Information

I did not find how to fix those:

```
/home/runner/work/view_component/view_component/lib/view_component/polymorphic_slots.rb:41: warning: method redefined; discarding old header
/home/runner/work/view_component/view_component/lib/view_component/polymorphic_slots.rb:41: warning: previous definition of header was here
/home/runner/work/view_component/view_component/lib/view_component/polymorphic_slots.rb:41: warning: method redefined; discarding old items
/home/runner/work/view_component/view_component/lib/view_component/polymorphic_slots.rb:41: warning: previous definition of items was here
```

I also took care of this:

```
The following cops were added to RuboCop, but are not configured. Please set Enabled to either `true` or `false` in your `.rubocop.yml` file.

Please also note that can also opt-in to new cops by default by adding this to your config:
  AllCops:
    NewCops: enable
Layout/SpaceBeforeBrackets: # (new in 1.7)
  Enabled: true
For more information: https://docs.rubocop.org/rubocop/versioning.html
```