### PR TITLE
Add ViewComponent::Deprecation

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -25,3 +25,7 @@ Layout/LineLength:
 
 Layout/SpaceBeforeBrackets:
   Enabled: true
+
+Style/FrozenStringLiteralComment:
+  Exclude:
+    - "**/*.jbuilder" # not yet supported inside jbuilder templates

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,10 @@ title: Changelog
 
 ## main
 
+* Use a dedicated deprecation instance, silence it while testing
+
+    *Max Beizer, Hans Lemuet, Elia Schito*
+
 * Fix Ruby warnings.
 
     *Hans Lemuet*

--- a/lib/view_component.rb
+++ b/lib/view_component.rb
@@ -23,7 +23,7 @@ end
 # :nocov:
 if defined?(ViewComponent::Engine)
   ViewComponent::Deprecation.warn(
-    "This manually engine loading is deprecated and will be removed in v3.0.0. " \
+    "Manually loading the engine is deprecated and will be removed in v3.0.0. " \
     "Remove `require \"view_component/engine\"`."
   )
 elsif defined?(Rails::Engine)

--- a/lib/view_component.rb
+++ b/lib/view_component.rb
@@ -10,6 +10,7 @@ module ViewComponent
   autoload :Compiler
   autoload :CompileCache
   autoload :ComponentError
+  autoload :Deprecation
   autoload :Instrumentation
   autoload :Preview
   autoload :PreviewTemplateError
@@ -21,7 +22,7 @@ end
 
 # :nocov:
 if defined?(ViewComponent::Engine)
-  ActiveSupport::Deprecation.warn(
+  ViewComponent::Deprecation.warn(
     "This manually engine loading is deprecated and will be removed in v3.0.0. " \
     "Remove `require \"view_component/engine\"`."
   )

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -235,14 +235,11 @@ module ViewComponent
     # @param variant [Symbol] The variant to be used by the component.
     # @return [self]
     def with_variant(variant)
-      ActiveSupport::Deprecation.warn(
-        "`with_variant` is deprecated and will be removed in ViewComponent v3.0.0."
-      )
-
       @__vc_variant = variant
 
       self
     end
+    deprecate :with_variant, deprecator: ViewComponent::Deprecation
 
     # The current request. Use sparingly as doing so introduces coupling that
     # inhibits encapsulation & reuse, often making testing difficult.

--- a/lib/view_component/compiler.rb
+++ b/lib/view_component/compiler.rb
@@ -49,7 +49,7 @@ module ViewComponent
         end
 
         if subclass_instance_methods.include?(:before_render_check)
-          ActiveSupport::Deprecation.warn(
+          ViewComponent::Deprecation.warn(
             "`#before_render_check` will be removed in v3.0.0.\n\n" \
             "To fix this issue, use `#before_render` instead."
           )

--- a/lib/view_component/content_areas.rb
+++ b/lib/view_component/content_areas.rb
@@ -31,7 +31,7 @@ module ViewComponent
 
     class_methods do
       def with_content_areas(*areas)
-        ActiveSupport::Deprecation.warn(
+        ViewComponent::Deprecation.warn(
           "`with_content_areas` is deprecated and will be removed in ViewComponent v3.0.0.\n\n" \
           "Use slots (https://viewcomponent.org/guide/slots.html) instead."
         )

--- a/lib/view_component/deprecation.rb
+++ b/lib/view_component/deprecation.rb
@@ -3,5 +3,6 @@
 require "active_support/deprecation"
 
 module ViewComponent
-  Deprecation = ActiveSupport::Deprecation.new("3.0", "ViewComponent")
+  DEPRECATION_HORIZON = 3
+  Deprecation = ActiveSupport::Deprecation.new(DEPRECATION_HORIZON.to_s, "ViewComponent")
 end

--- a/lib/view_component/deprecation.rb
+++ b/lib/view_component/deprecation.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require "active_support/deprecation"
+
+module ViewComponent
+  Deprecation = ActiveSupport::Deprecation.new("3.0", "ViewComponent")
+end

--- a/lib/view_component/engine.rb
+++ b/lib/view_component/engine.rb
@@ -27,7 +27,7 @@ module ViewComponent
         )
 
         if options.preview_path.present?
-          ActiveSupport::Deprecation.warn(
+          ViewComponent::Deprecation.warn(
             "`preview_path` will be removed in v3.0.0. Use `preview_paths` instead."
           )
           options.preview_paths << options.preview_path
@@ -155,7 +155,9 @@ end
 
 # :nocov:
 unless defined?(ViewComponent::Base)
-  ActiveSupport::Deprecation.warn(
+  require "view_component/deprecation"
+
+  ViewComponent::Deprecation.warn(
     "This manually engine loading is deprecated and will be removed in v3.0.0. " \
     "Remove `require \"view_component/engine\"`."
   )

--- a/lib/view_component/polymorphic_slots.rb
+++ b/lib/view_component/polymorphic_slots.rb
@@ -25,22 +25,25 @@ module ViewComponent
       end
 
       def register_polymorphic_slot(slot_name, types, collection:)
+        unless types.empty?
+          getter_name = slot_name
+
+          define_method(getter_name) do
+            get_slot(slot_name)
+          end
+        end
+
         renderable_hash = types.each_with_object({}) do |(poly_type, poly_callable), memo|
           memo[poly_type] = define_slot(
             "#{slot_name}_#{poly_type}", collection: collection, callable: poly_callable
           )
 
-          getter_name = slot_name
           setter_name =
             if collection
               "#{ActiveSupport::Inflector.singularize(slot_name)}_#{poly_type}"
             else
               "#{slot_name}_#{poly_type}"
             end
-
-          define_method(getter_name) do
-            get_slot(slot_name)
-          end
 
           define_method(setter_name) do |*args, &block|
             set_polymorphic_slot(slot_name, poly_type, *args, &block)

--- a/lib/view_component/slotable.rb
+++ b/lib/view_component/slotable.rb
@@ -23,7 +23,7 @@ module ViewComponent
       #   class_name: "Header" # class name string, used to instantiate Slot
       # )
       def with_slot(*slot_names, collection: false, class_name: nil)
-        ActiveSupport::Deprecation.warn(
+        ViewComponent::Deprecation.warn(
           "`with_slot` is deprecated and will be removed in ViewComponent v3.0.0.\n" \
           "Use the new slots API (https://viewcomponent.org/guide/slots.html) instead."
         )

--- a/script/release
+++ b/script/release
@@ -46,6 +46,12 @@ update_ruby_version() {
       -e "s/MINOR = [0-9]+/MINOR = $2/g" \
       -e "s/PATCH = [0-9]+/PATCH = $3/g" \
       lib/view_component/version.rb
+
+  # Update deprecation horizon version
+  major=$1
+  sed -E -i '' \
+      -e "s/DEPRECATION_HORIZON = [0-9]+/DEPRECATION_HORIZON = $((major + 1))/g" \
+      lib/view_component/deprecation.rb
 }
 
 update_gemfiles() {

--- a/test/sandbox/app/components/jbuilder_component.json.jbuilder
+++ b/test/sandbox/app/components/jbuilder_component.json.jbuilder
@@ -1,4 +1,2 @@
-# frozen_string_literal: true
-
 json.message @message
 json.conent content

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -19,6 +19,9 @@ require "minitest/autorun"
 # Configure Rails Environment
 ENV["RAILS_ENV"] = "test"
 
+require "view_component/deprecation"
+ViewComponent::Deprecation.behavior = :silence
+
 require File.expand_path("../sandbox/config/environment.rb", __FILE__)
 require "rails/test_help"
 


### PR DESCRIPTION
### Summary

This should allow consumers to see deprecation warnings that correctly mention the next version of VC.

Silencing is already a feature of AS::Deprecation

Closes #586 and closes #1273 (this was built starting from those PRs).
