### PR TITLE
Add frozen_string_literal statement to all generated .rb files

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,10 @@ title: Changelog
 
     *Simon Fish*
 
+* Ensure all generated `.rb` files include `# frozen_string_literal: true` statement.
+
+    *Bob Maerten*
+
 ## 2.49.0
 
 * Fix path handling for evaluated view components that broke in Ruby 3.1.

--- a/lib/rails/generators/preview/templates/component_preview.rb.tt
+++ b/lib/rails/generators/preview/templates/component_preview.rb.tt
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class <%= class_name %>ComponentPreview < ViewComponent::Preview
   def default
     render(<%= class_name %>Component.new)

--- a/lib/rails/generators/rspec/templates/component_spec.rb.tt
+++ b/lib/rails/generators/rspec/templates/component_spec.rb.tt
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe <%= class_name %>Component, type: :component do

--- a/lib/rails/generators/test_unit/templates/component_test.rb.tt
+++ b/lib/rails/generators/test_unit/templates/component_test.rb.tt
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class <%= class_name %>ComponentTest < ViewComponent::TestCase


### PR DESCRIPTION
As @boardfish evoked in https://github.com/github/view_component/pull/1194#issuecomment-1036405220:

> it's relatively safe to say that generated components will be new code in new apps, which are likely to default to `frozen_string_literal: true`

Here are the generated .rb files updated to comply with ViewComponent self coding style.