### PR TITLE
Disable new cops by default?

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,6 +9,7 @@ AllCops:
     - gemfiles/**/*
     - test/tmp/**/*
     - vendor/bundle/**/*
+  NewCops: disable
 
 Gemspec/OrderedDependencies:
   Enabled: true


### PR DESCRIPTION
### Summary

Not sure if there's already a strategy, but each time new cops are added to rubocop we'll get a warning.

I'd be in favor of disabling by default and cherry-picking additions, or if there's an official gihtub set of cops follow that.
@Spone correctly [pointed out](https://github.com/github/view_component/pull/1277#discussion_r805672184) it might not be the best approach or necessarily be a shared perspective, so I move the commit here in order to reach a consensus.