### PR TITLE
Predicate methods for slots

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,10 @@ title: Changelog
 
 ## main
 
+* Add predicate methods `#{slot_name}?` to slots.
+
+    *Hans Lemuet*
+
 * Place all generator options under `config.generate` namespace.
 
     *Simon Fish*

--- a/docs/guide/slots.md
+++ b/docs/guide/slots.md
@@ -62,6 +62,27 @@ Returning:
 <a href="/blog/second-post">Second post</a>
 ```
 
+### Predicate methods
+
+To test whether a slot has been passed to the component, use the provided `#{slot_name}?` method.
+
+```erb
+<%# blog_component.html.erb %>
+<% if header? %>
+  <h1><%= header %></h1>
+<% end %>
+
+<% if posts? %>
+  <div class="posts">
+    <% posts.each do |post| %>
+      <%= post %>
+    <% end %>
+  </div>
+<% else %>
+  <p>No post yet.</p>
+<% end %>
+```
+
 ## Component slots
 
 Slots can also render other components. Pass the name of a component as the second argument to define a component slot.

--- a/docs/guide/slots.md
+++ b/docs/guide/slots.md
@@ -62,7 +62,7 @@ Returning:
 <a href="/blog/second-post">Second post</a>
 ```
 
-### Predicate methods
+## Predicate methods
 
 To test whether a slot has been passed to the component, use the provided `#{slot_name}?` method.
 

--- a/lib/view_component/slotable_v2.rb
+++ b/lib/view_component/slotable_v2.rb
@@ -9,7 +9,7 @@ module ViewComponent
 
     RESERVED_NAMES = {
       singular: %i[content render].freeze,
-      plural: %i[contents].freeze,
+      plural: %i[contents renders].freeze,
     }.freeze
 
     # Setup component slot state

--- a/lib/view_component/slotable_v2.rb
+++ b/lib/view_component/slotable_v2.rb
@@ -75,6 +75,10 @@ module ViewComponent
         end
         ruby2_keywords(slot_name.to_sym) if respond_to?(:ruby2_keywords, true)
 
+        define_method "#{slot_name}?" do
+          send(slot_name).present?
+        end
+
         register_slot(slot_name, collection: false, callable: callable)
       end
 
@@ -138,6 +142,10 @@ module ViewComponent
               set_slot(slot_name, nil, **args, &block)
             end
           end
+        end
+
+        define_method "#{slot_name}?" do
+          send(slot_name).present?
         end
 
         register_slot(slot_name, collection: true, callable: callable)

--- a/lib/view_component/slotable_v2.rb
+++ b/lib/view_component/slotable_v2.rb
@@ -241,7 +241,9 @@ module ViewComponent
       def raise_if_slot_ends_with_question_mark(slot_name)
         if slot_name.to_s.ends_with?("?")
           raise ArgumentError.new(
-            "#{self} declares a slot named #{slot_name}, which ends with a question mark. This is not allowed because the ViewComponent framework already provides predicate methods ending in `?`.\n\n" \
+            "#{self} declares a slot named #{slot_name}, which ends with a question mark.\n\n"\
+            "This is not allowed because the ViewComponent framework already provides predicate "\
+            "methods ending in `?`.\n\n" \
             "To fix this issue, choose a different name."
           )
         end

--- a/lib/view_component/slotable_v2.rb
+++ b/lib/view_component/slotable_v2.rb
@@ -7,6 +7,11 @@ module ViewComponent
   module SlotableV2
     extend ActiveSupport::Concern
 
+    RESERVED_NAMES = {
+      singular: %i[content render].freeze,
+      plural: %i[contents].freeze,
+    }.freeze
+
     # Setup component slot state
     included do
       # Hash of registered Slots
@@ -205,7 +210,7 @@ module ViewComponent
       end
 
       def validate_plural_slot_name(slot_name)
-        if slot_name.to_sym == :contents
+        if RESERVED_NAMES[:plural].include?(slot_name.to_sym)
           raise ArgumentError.new(
             "#{self} declares a slot named #{slot_name}, which is a reserved word in the ViewComponent framework.\n\n" \
             "To fix this issue, choose a different name."
@@ -217,7 +222,7 @@ module ViewComponent
       end
 
       def validate_singular_slot_name(slot_name)
-        if slot_name.to_sym == :content
+        if RESERVED_NAMES[:singular].include?(slot_name.to_sym)
           raise ArgumentError.new(
             "#{self} declares a slot named #{slot_name}, which is a reserved word in the ViewComponent framework.\n\n" \
             "To fix this issue, choose a different name."

--- a/lib/view_component/slotable_v2.rb
+++ b/lib/view_component/slotable_v2.rb
@@ -76,7 +76,7 @@ module ViewComponent
         ruby2_keywords(slot_name.to_sym) if respond_to?(:ruby2_keywords, true)
 
         define_method "#{slot_name}?" do
-          send(slot_name).present?
+          get_slot(slot_name).present?
         end
 
         register_slot(slot_name, collection: false, callable: callable)
@@ -145,7 +145,7 @@ module ViewComponent
         end
 
         define_method "#{slot_name}?" do
-          send(slot_name).present?
+          get_slot(slot_name).present?
         end
 
         register_slot(slot_name, collection: true, callable: callable)

--- a/lib/view_component/slotable_v2.rb
+++ b/lib/view_component/slotable_v2.rb
@@ -212,6 +212,7 @@ module ViewComponent
           )
         end
 
+        raise_if_slot_ends_with_question_mark(slot_name)
         raise_if_slot_registered(slot_name)
       end
 
@@ -223,6 +224,7 @@ module ViewComponent
           )
         end
 
+        raise_if_slot_ends_with_question_mark(slot_name)
         raise_if_slot_registered(slot_name)
       end
 
@@ -232,6 +234,15 @@ module ViewComponent
           raise ArgumentError.new(
             "#{self} declares the #{slot_name} slot multiple times.\n\n" \
             "To fix this issue, choose a different slot name."
+          )
+        end
+      end
+
+      def raise_if_slot_ends_with_question_mark(slot_name)
+        if slot_name.to_s.ends_with?("?")
+          raise ArgumentError.new(
+            "#{self} declares a slot named #{slot_name}, which ends with a question mark. This is not allowed because the ViewComponent framework already provides predicate methods ending in `?`.\n\n" \
+            "To fix this issue, choose a different name."
           )
         end
       end

--- a/test/sandbox/app/components/slots_v2_component.html.erb
+++ b/test/sandbox/app/components/slots_v2_component.html.erb
@@ -1,12 +1,16 @@
 <div class="card <%= @classes %>">
+  <% if title? %>
   <div class="title">
     <%= title %>
   </div>
+  <% end %>
+  <% if subtitle? %>
   <div class="subtitle">
     <%= subtitle %>
   </div>
+  <% end %>
   <div class="nav">
-    <% if tabs.any? %>
+    <% if tabs? %>
       <% tabs.each do |tab| %>
         <div class="tab">
           <%= tab %>
@@ -17,7 +21,7 @@
     <% end %>
   </div>
   <div class="body">
-    <% if items.any? %>
+    <% if items? %>
       <% items.each do |item| %>
         <div class="item <%= item.classes %>">
           <%= item %>
@@ -28,7 +32,7 @@
     <% end %>
   </div>
 
-  <% if extra.present? %>
+  <% if extra? %>
     <div class="extra">
       <%= extra %>
     </div>

--- a/test/view_component/slotable_v2_test.rb
+++ b/test/view_component/slotable_v2_test.rb
@@ -344,6 +344,17 @@ class SlotsV2sTest < ViewComponent::TestCase
     assert_includes exception.message, "declares a slot named content"
   end
 
+  def test_component_raises_when_given_one_slot_name_ending_with_question_mark
+    exception =
+      assert_raises ArgumentError do
+        Class.new(ViewComponent::Base) do
+          renders_one :item?
+        end
+      end
+
+    assert_includes exception.message, "declares a slot named item?, which ends with a question mark"
+  end
+
   def test_component_raises_when_given_invalid_slot_name_for_has_many
     exception = assert_raises ArgumentError do
       Class.new(ViewComponent::Base) do
@@ -352,6 +363,17 @@ class SlotsV2sTest < ViewComponent::TestCase
     end
 
     assert_includes exception.message, "declares a slot named contents"
+  end
+
+  def test_component_raises_when_given_many_slot_name_ending_with_question_mark
+    exception =
+      assert_raises ArgumentError do
+        Class.new(ViewComponent::Base) do
+          renders_many :items?
+        end
+      end
+
+    assert_includes exception.message, "declares a slot named items?, which ends with a question mark"
   end
 
   def test_renders_pass_through_slot_using_with_content


### PR DESCRIPTION
### Summary

This implements predicate methods for slots, as described in #1275.

- [x] define predicate methods on slot declaration
- [x] add validation to make sure slot names do not end with `?`
- [x] add documentation
- [x] add changelog entry

### Open questions

- Do you think it's possible / a good idea to try to warn users when they define a `#{slot_name}?` method themselves, so they notice that the library now provide this feature?

### Other Information

Close #1275