### PR TITLE
Update benchmarks to render more than a single time

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,10 @@ title: Changelog
 
 ## main
 
+* Update benchmark script to render multiple components/partials instead of a single instance per-run.
+
+    *Blake Williams*
+
 * Add predicate methods `#{slot_name}?` to slots.
 
     *Hans Lemuet*

--- a/performance/benchmark.rb
+++ b/performance/benchmark.rb
@@ -11,6 +11,7 @@ require File.expand_path("../test/sandbox/config/environment.rb", __dir__)
 
 module Performance
   require_relative "components/name_component.rb"
+  require_relative "components/nested_name_component.rb"
   require_relative "components/inline_component.rb"
 end
 
@@ -24,9 +25,9 @@ Benchmark.ips do |x|
   x.time = 10
   x.warmup = 2
 
-  x.report("component:") { controller_view.render(Performance::NameComponent.new(name: "Fox Mulder")) }
-  x.report("inline:") { controller_view.render(Performance::InlineComponent.new(name: "Fox Mulder")) }
-  x.report("partial:") { controller_view.render("partial", name: "Fox Mulder") }
+  x.report("component") { controller_view.render(Performance::NameComponent.new(name: "Fox Mulder")) }
+  x.report("inline") { controller_view.render(Performance::InlineComponent.new(name: "Fox Mulder")) }
+  x.report("partial") { controller_view.render("partial", name: "Fox Mulder") }
 
   x.compare!
 end

--- a/performance/components/inline_component.rb
+++ b/performance/components/inline_component.rb
@@ -1,12 +1,22 @@
 # frozen_string_literal: true
 
 class Performance::InlineComponent < ViewComponent::Base
-  def initialize(name:)
+  def initialize(name:, nested: true)
     @name = name
+    @nested = nested
   end
 
   def call
     # rubocop:disable Rails/OutputSafety
-    "<h1>hello #{@name}</h1>".html_safe
+    content = "<h1>hello #{@name}</h1>".html_safe
+
+    if @nested
+      safe_join([
+        content,
+        50.times.map { InlineComponent.new(name: @name, nested: false) }
+      ])
+    else
+      content
+    end
   end
 end

--- a/performance/components/inline_component.rb
+++ b/performance/components/inline_component.rb
@@ -1,22 +1,27 @@
 # frozen_string_literal: true
 
 class Performance::InlineComponent < ViewComponent::Base
-  def initialize(name:, nested: true)
+  class NestedComponent < ViewComponent::Base
+    def initialize(name:)
+      @name = name
+    end
+
+    def call
+      content = "<p>nested hello #{@name}</p>".html_safe
+    end
+  end
+
+  def initialize(name:)
     @name = name
-    @nested = nested
   end
 
   def call
     # rubocop:disable Rails/OutputSafety
     content = "<h1>hello #{@name}</h1>".html_safe
 
-    if @nested
-      safe_join([
-        content,
-        50.times.map { InlineComponent.new(name: @name, nested: false) }
-      ])
-    else
-      content
-    end
+    safe_join([
+      content,
+      50.times.map { render NestedComponent.new(name: @name) }
+    ], "\n\n")
   end
 end

--- a/performance/components/inline_component.rb
+++ b/performance/components/inline_component.rb
@@ -17,7 +17,6 @@ class Performance::InlineComponent < ViewComponent::Base
   end
 
   def call
-    # rubocop:disable Rails/OutputSafety
     content = "<h1>hello #{@name}</h1>".html_safe
 
     safe_join(

--- a/performance/components/inline_component.rb
+++ b/performance/components/inline_component.rb
@@ -19,9 +19,12 @@ class Performance::InlineComponent < ViewComponent::Base
     # rubocop:disable Rails/OutputSafety
     content = "<h1>hello #{@name}</h1>".html_safe
 
-    safe_join([
-      content,
-      50.times.map { render NestedComponent.new(name: @name) }
-    ], "\n\n")
+    safe_join(
+      [
+        content,
+        50.times.map { render NestedComponent.new(name: @name) }
+      ],
+      "\n\n"
+    )
   end
 end

--- a/performance/components/inline_component.rb
+++ b/performance/components/inline_component.rb
@@ -7,6 +7,7 @@ class Performance::InlineComponent < ViewComponent::Base
     end
 
     def call
+      # rubocop:disable Rails/OutputSafety
       content = "<p>nested hello #{@name}</p>".html_safe
     end
   end

--- a/performance/components/name_component.html.erb
+++ b/performance/components/name_component.html.erb
@@ -1,1 +1,7 @@
 <h1>hello <%= @name %></h1>
+
+<% if @nested %>
+  <% 50.times do %>
+    <%= render Performance::NameComponent.new(name: @name, nested: false) %>
+  <% end %>
+<% end %>

--- a/performance/components/name_component.html.erb
+++ b/performance/components/name_component.html.erb
@@ -1,7 +1,5 @@
 <h1>hello <%= @name %></h1>
 
-<% if @nested %>
-  <% 50.times do %>
-    <%= render Performance::NameComponent.new(name: @name, nested: false) %>
-  <% end %>
+<% 50.times do %>
+  <%= render Performance::NestedNameComponent.new(name: @name) %>
 <% end %>

--- a/performance/components/name_component.rb
+++ b/performance/components/name_component.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 class Performance::NameComponent < ViewComponent::Base
-  def initialize(name:)
+  def initialize(name:, nested: true)
     @name = name
+    @nested = nested
   end
 end

--- a/performance/components/nested_name_component.html.erb
+++ b/performance/components/nested_name_component.html.erb
@@ -1,0 +1,1 @@
+<p>nested hello <%= @name %></p>

--- a/performance/components/nested_name_component.rb
+++ b/performance/components/nested_name_component.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Performance::NameComponent < ViewComponent::Base
+class Performance::NestedNameComponent < ViewComponent::Base
   def initialize(name:)
     @name = name
   end

--- a/performance/views/benchmarks/_nested.html.erb
+++ b/performance/views/benchmarks/_nested.html.erb
@@ -1,0 +1,1 @@
+<p>nested hello <%= name %></p>

--- a/performance/views/benchmarks/_partial.html.erb
+++ b/performance/views/benchmarks/_partial.html.erb
@@ -1,1 +1,5 @@
 <h1>hello <%= name %></h1>
+
+<% 50.times do %>
+  <%= render 'nested', name: name, nested: false %>
+<% end %>


### PR DESCRIPTION
Previously we would render a single component or a single partial from a
controller context to benchmark performance. This is valid, but isn't as
realistic as rendering more components/partials inside the rendering
path.

This updates the benchmarks to render multiple of the renderer type
being benchmarked in an attempt to get closer to simulating a real page
load.

* Updates both components to render another component 50 times
* Updates partial to render another partial 50 times
