### PR TITLE
Support returning arrays from translations

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,10 @@ title: Changelog
 
 ## main
 
+* Support returning Arrays from i18n files, and support marking them as HTML-safe translations.
+
+    *foca*
+
 * Fix example in testing guide for how to setup default Rails tests.
 
     *Steven Hansen*

--- a/lib/view_component/translatable.rb
+++ b/lib/view_component/translatable.rb
@@ -82,7 +82,7 @@ module ViewComponent
         end
 
         if HTML_SAFE_TRANSLATION_KEY.match?(key)
-          translated = translated.html_safe # rubocop:disable Rails/OutputSafety
+          translated = html_safe_translation(translated)
         end
 
         translated
@@ -95,6 +95,14 @@ module ViewComponent
     # Exposes .i18n_scope as an instance method
     def i18n_scope
       self.class.i18n_scope
+    end
+
+    def html_safe_translation(translation)
+      if translation.respond_to?(:map)
+        translation.map { |element| element.respond_to?(:html_safe) ? element.html_safe : element } # rubocop:disable Rails/OutputSafety
+      else
+        translation.respond_to?(:html_safe) ? translation.html_safe : translation # rubocop:disable Rails/OutputSafety
+      end
     end
   end
 end

--- a/lib/view_component/translatable.rb
+++ b/lib/view_component/translatable.rb
@@ -100,8 +100,10 @@ module ViewComponent
     def html_safe_translation(translation)
       if translation.respond_to?(:map)
         translation.map { |element| html_safe_translation(element) }
+      elsif translation.respond_to?(:html_safe)
+        translation.html_safe # rubocop:disable Rails/OutputSafety
       else
-        translation.respond_to?(:html_safe) ? translation.html_safe : translation # rubocop:disable Rails/OutputSafety
+        translation
       end
     end
   end

--- a/lib/view_component/translatable.rb
+++ b/lib/view_component/translatable.rb
@@ -100,10 +100,8 @@ module ViewComponent
     def html_safe_translation(translation)
       if translation.respond_to?(:map)
         translation.map { |element| html_safe_translation(element) }
-      elsif translation.respond_to?(:html_safe)
-        translation.html_safe # rubocop:disable Rails/OutputSafety
       else
-        translation
+        translation.html_safe # rubocop:disable Rails/OutputSafety
       end
     end
   end

--- a/lib/view_component/translatable.rb
+++ b/lib/view_component/translatable.rb
@@ -101,6 +101,9 @@ module ViewComponent
       if translation.respond_to?(:map)
         translation.map { |element| html_safe_translation(element) }
       else
+        # It's assumed here that objects loaded by the i18n backend will respond to `#html_safe?`.
+        # It's reasonable that if we're in Rails, `active_support/core_ext/string/output_safety.rb`
+        # will provide this to `Object`.
         translation.html_safe # rubocop:disable Rails/OutputSafety
       end
     end

--- a/lib/view_component/translatable.rb
+++ b/lib/view_component/translatable.rb
@@ -99,7 +99,7 @@ module ViewComponent
 
     def html_safe_translation(translation)
       if translation.respond_to?(:map)
-        translation.map { |element| element.respond_to?(:html_safe) ? element.html_safe : element } # rubocop:disable Rails/OutputSafety
+        translation.map { |element| html_safe_translation(element) }
       else
         translation.respond_to?(:html_safe) ? translation.html_safe : translation # rubocop:disable Rails/OutputSafety
       end

--- a/test/sandbox/app/components/translatable_component.yml
+++ b/test/sandbox/app/components/translatable_component.yml
@@ -7,3 +7,13 @@ en:
 
   from:
     sidecar: This is coming from the sidecar
+
+  list:
+    - This
+    - returns
+    - a list
+
+  list_html:
+    - <em>This</em>
+    - returns
+    - a list with <strong>embedded</strong> HTML

--- a/test/view_component/translatable_test.rb
+++ b/test/view_component/translatable_test.rb
@@ -84,6 +84,27 @@ class TranslatableTest < ViewComponent::TestCase
     assert_equal "Hello from sidecar translations!", translate(".hello", default: default_value)
   end
 
+  def test_translate_returns_lists
+    assert_equal ["This", "returns", "a list"], translate(".list")
+  end
+
+  def test_translate_returns_html_safe_lists
+    translated_list = translate(".list_html")
+
+    assert_equal(
+      [
+        "<em>This</em>",
+        "returns",
+        "a list with <strong>embedded</strong> HTML"
+      ],
+      translated_list
+    )
+
+    translated_list.each do |item|
+      assert_predicate item, :html_safe?
+    end
+  end
+
   private
 
   def translate(key, **options)


### PR DESCRIPTION
When i18n finds a YAML array as a value, it returns the Array as is. ActionView allows this, and the `#translate` helper in AV will correctly handle "HTML-safe" keys when the value is an Array, by calling `#html_safe` on each element.

However, ViewComponent assumes translations can only be strings, and raises an error when this is not the case.

This PR lifts the code from ActionView to handle HTML-safe translations so we can correctly escape both strings and arrays, to avoid surprising anyone that is extracting components from existing views that depend on this AV behavior.