### PR TITLE
Fix inheritance when lazy loading

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,10 +10,14 @@ title: Changelog
 * Add ADR for separate slot getter/setter API.
 
     *Blake Williams*
-    
+
 * Add the option to use a "global" output buffer so `form_for` and friends can be used with view components.
 
     *Cameron Dutro*, *Blake Williams*
+
+* Fix template inheritance when eager loading is disabled.
+
+    *Cameron Dutro*
 
 ## 2.51.0
 

--- a/test/view_component/view_component_test.rb
+++ b/test/view_component/view_component_test.rb
@@ -996,4 +996,22 @@ class ViewComponentTest < ViewComponent::TestCase
       singleton_class.undef_method :generate_test_accessor=
     end
   end
+
+  def test_inherited_component_renders_when_lazy_loading
+    # Simulate lazy loading by manually removing the classes in question. This will completely
+    # undo the changes made by self.class.compile and friends, forcing a compile the next time
+    # #render_template_for is called. This shouldn't be necessary except in the test environment,
+    # since eager loading is turned on here.
+    Object.send(:remove_const, :MyComponent)
+    Object.send(:remove_const, :InheritedWithOwnTemplateComponent)
+
+    load "test/sandbox/app/components/my_component.rb"
+    load "test/sandbox/app/components/inherited_with_own_template_component.rb"
+
+    render_inline(MyComponent.new)
+    assert_selector("div", text: "hello,world!")
+
+    render_inline(InheritedWithOwnTemplateComponent.new)
+    assert_selector("div", text: "hello, my own template")
+  end
 end


### PR DESCRIPTION
### Summary

Fixes #1315

The performance improvement introduced in #1302 moves template compilation to the `#render_template_for` method, which runs the compiler and calls the re-defined version of `#render_template_for` the compiler creates. However, because the original implementation resides on `ViewComponent::Base`, parent classes that are rendered before their children will hide the version of `#render_template_for` that performs the compilation. Rendering any subsequent child instances actually renders the parent's template instead.

It's worth noting that this problem will only appear if Rails eager loading is disabled, i.e. when using "lazy loading." Eager loading is turned on by default in production environments, so the problem only affects the development and test environments.

This PR makes use of the `def included` hook to define a version of `#render_template_for` for each individual component. In other words, components no longer rely on calls to `#render_template_for` bubbling up to `ViewComponent::Base`.

### Other Information

Benchmarks between this branch and main:

```
Warming up --------------------------------------
           component (main)   278.000  i/100ms
Calculating -------------------------------------
           component (main)   2.815k (± 5.0%) i/s -     28.078k in  10.002372s

Pausing here -- run Ruby again to measure the next benchmark...

Warming up --------------------------------------
          component (branch)   288.000  i/100ms
Calculating -------------------------------------
          component (branch)   2.771k (± 5.1%) i/s -     27.648k in  10.002367s

Comparison:
           component (main):      2814.6 i/s
          component (branch):     2771.5 i/s - same-ish: difference falls within error