### PR TITLE
Fix bug where Appraisal ran incompatible combination of Ruby and Rails

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 
-appraise "rails-5.2" do
-  gem "rails", "~> 5.2.0"
+if RUBY_VERSION < "3.0.0"
+  appraise "rails-5.2" do
+    gem "rails", "~> 5.2.0"
+  end
+else
+  puts "WARNING: Skipping Rails 5.2, as it is not compatible with Ruby >= 3.0.0"
 end
 
 appraise "rails-6.0" do

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,10 @@ title: Changelog
 
 ## main
 
+* Skip Rails 5.2 in local test environment if using incompatible Ruby version.
+
+    *Cameron Dutro*, *Blake Williams*, *Joel Hawksley*
+
 * Add articles to resources page.
 
     *Joel Hawksley*


### PR DESCRIPTION
Appraisal does not set the Ruby version, allowing developers to
run our tests with incompatible combinations of Ruby and Rails.

This change opts Rails 5.2 out of Ruby >=3.0.

Closes #1326.

Co-authored-by: Blake Williams <blakewilliams@github.com>
Co-authored-by: Cameron Dutro <camertron@github.com>

<!-- See https://github.com/github/view_component/blob/main/docs/CONTRIBUTING.md#submitting-a-pull-request -->