### PR TITLE
Raise when ViewComponent causes a warning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,7 @@ jobs:
         bundle update
         bundle exec rake
       env:
+        RAISE_ON_WARNING: 1
         MEASURE_COVERAGE: true
         RAILS_VERSION: ${{ matrix.rails_version }}
         VIEW_COMPONENT_USE_GLOBAL_OUTPUT_BUFFER: ${{ matrix.output_buffer == 'global_buffer' && 'true' || 'false' }}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,7 +9,9 @@ title: Changelog
 
 ## main
 
-* Resolve warning in slots API, and raise in the test environment when ViewComponent code emits a warning.
+* Resolve warning in slots API.
+
+* Raise in the test environment when ViewComponent code emits a warning.
 
     *Blake Williams*
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,7 +10,6 @@ title: Changelog
 ## main
 
 * Resolve warning in slots API.
-
 * Raise in the test environment when ViewComponent code emits a warning.
 
     *Blake Williams*

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,10 @@ title: Changelog
 
 ## main
 
+* Resolve warning in slots API, and raise in the test environment when ViewComponent code emits a warning.
+
+    *Blake Williams*
+
 ## 2.54.0
 
 * Add `with_*` slot API for defining slots. Note: we plan to deprecate the non `with_*` API for slots in an upcoming release.

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -70,7 +70,7 @@ module ViewComponent
       @view_context = view_context
       self.__vc_original_view_context ||= view_context
 
-      @output_buffer = ActionView::OutputBuffer.new unless @global_buffer_in_use
+      @output_buffer = ActionView::OutputBuffer.new unless defined?(@global_buffer_in_use) && @global_buffer_in_use
 
       @lookup_context ||= view_context.lookup_context
 

--- a/lib/view_component/slotable_v2.rb
+++ b/lib/view_component/slotable_v2.rb
@@ -155,7 +155,6 @@ module ViewComponent
             set_slot(slot_name, nil, **args, &block)
           end
         end
-        ruby2_keywords(:"with_#{slot_name}") if respond_to?(:ruby2_keywords, true)
 
         # Instantiates and and adds multiple slots forwarding the first
         # argument to each slot constructor

--- a/lib/view_component/slotable_v2.rb
+++ b/lib/view_component/slotable_v2.rb
@@ -155,6 +155,7 @@ module ViewComponent
             set_slot(slot_name, nil, **args, &block)
           end
         end
+        ruby2_keywords(:"with_#{slot_name}") if respond_to?(:ruby2_keywords, true)
 
         # Instantiates and and adds multiple slots forwarding the first
         # argument to each slot constructor

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -16,6 +16,18 @@ require "pp"
 require "pathname"
 require "minitest/autorun"
 
+if ENV["RAISE_ON_WARNING"]
+  module Warning
+    def self.warn(message)
+      called_by = caller_locations(1, 1).first
+      return super if called_by.path.start_with?(Gem.paths.home)
+
+      raise "Warning: #{message}"
+    end
+  end
+end
+
+
 # Configure Rails Environment
 ENV["RAILS_ENV"] = "test"
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -22,7 +22,7 @@ if ENV["RAISE_ON_WARNING"]
 
     def self.warn(message)
       called_by = caller_locations(1, 1).first.path
-      return super unless called_by&.start_with?(PROJECT_ROOT)
+      return super unless called_by&.start_with?(PROJECT_ROOT) && !called_by.start_with?("#{PROJECT_ROOT}/vendor")
 
       raise "Warning: #{message}"
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -18,15 +18,16 @@ require "minitest/autorun"
 
 if ENV["RAISE_ON_WARNING"]
   module Warning
+    PROJECT_ROOT = File.expand_path("..", __dir__).freeze
+
     def self.warn(message)
-      called_by = caller_locations(1, 1).first
-      return super if called_by.path.start_with?(Gem.paths.home)
+      called_by = caller_locations(1, 1).first.path
+      return super unless called_by&.start_with?(PROJECT_ROOT)
 
       raise "Warning: #{message}"
     end
   end
 end
-
 
 # Configure Rails Environment
 ENV["RAILS_ENV"] = "test"


### PR DESCRIPTION
This adds support for a new env variable, `RAISE_ON_WARNING` which when
set to true causes warnings emitted in the test environment to raise
an exception.

This also enables RAISE_ON_WARNING in CI.

closes https://github.com/github/view_component/issues/1351