### PR TITLE
Add render_parent helper method to avoid double-rendering hijinks

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,8 +9,6 @@ title: Changelog
 
 ## main
 
-## 2.55.0
-
 * Add `render_parent` convenience method to avoid confusion between `<%= super %>` and `<% super %>` in template code.
 
     *Cameron Dutro*

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,12 @@ title: Changelog
 
 ## main
 
+## 2.55.0
+
+* Add `render_parent` convenience method to avoid confusion between `<%= super %>` and `<% super %>` in template code.
+
+    *Cameron Dutro*
+
 ## 2.54.0
 
 * Add `with_*` slot API for defining slots. Note: we plan to deprecate the non `with_*` API for slots in an upcoming release.

--- a/docs/guide/templates.md
+++ b/docs/guide/templates.md
@@ -92,3 +92,14 @@ Component subclasses inherit the parent component's template if they don't defin
 class MyLinkComponent < LinkComponent
 end
 ```
+
+### Rendering the Parent's Template
+
+Subclasses that wish to render the parent's template may do so by calling the `render_parent` helper method.
+
+```ruby
+<%# my_link_component.html.erb %>
+<div class="base-component-template">
+  <% render_parent %>
+</div>
+```

--- a/docs/guide/templates.md
+++ b/docs/guide/templates.md
@@ -97,7 +97,7 @@ end
 
 To render a parent component's template from a subclass, call `render_parent`:
 
-```ruby
+```erb
 <%# my_link_component.html.erb %>
 <div class="base-component-template">
   <% render_parent %>

--- a/docs/guide/templates.md
+++ b/docs/guide/templates.md
@@ -95,7 +95,7 @@ end
 
 ### Rendering parent templates
 
-Subclasses that wish to render the parent's template may do so by calling the `render_parent` helper method.
+To render a parent component's template from a subclass, call `render_parent`:
 
 ```ruby
 <%# my_link_component.html.erb %>

--- a/docs/guide/templates.md
+++ b/docs/guide/templates.md
@@ -93,7 +93,7 @@ class MyLinkComponent < LinkComponent
 end
 ```
 
-### Rendering the Parent's Template
+### Rendering parent templates
 
 Subclasses that wish to render the parent's template may do so by calling the `render_parent` helper method.
 

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -117,7 +117,7 @@ module ViewComponent
       render_template_for(@__vc_variant).to_s + _output_postamble
     end
 
-    # Superclass components that call `super` inside their template code will cause a
+    # Subclass components that call `super` inside their template code will cause a
     # double render if they accidentally emit the result. In other words, this double
     # renders:
     #

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -124,8 +124,7 @@ module ViewComponent
     #
     # <% super %> # does not double-render
     #
-    # The render_parent method simply calls `super` but makes sure to return nil to
-    # avoid rendering the result twice.
+    # Calls `super`, returning nil to avoid rendering the result twice.
     def render_parent
       mtd = @__vc_variant ? "call_#{@__vc_variant}" : "call"
       method(mtd).super_method.call

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -118,8 +118,7 @@ module ViewComponent
     end
 
     # Subclass components that call `super` inside their template code will cause a
-    # double render if they accidentally emit the result. In other words, this double
-    # renders:
+    # double render if they accidentally emit the result:
     #
     # <%= super %>
     #

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -117,6 +117,24 @@ module ViewComponent
       render_template_for(@__vc_variant).to_s + _output_postamble
     end
 
+    # Superclass components that call `super` inside their template code will cause a
+    # double render if they accidentally emit the result. In other words, this double
+    # renders:
+    #
+    # <%= super %>
+    #
+    # but this does not:
+    #
+    # <% super %>
+    #
+    # The render_parent method simply calls `super` but makes sure to return nil to
+    # avoid rendering the result twice.
+    def render_parent
+      mtd = @__vc_variant ? "call_#{@__vc_variant}" : "call"
+      method(mtd).super_method.call
+      nil
+    end
+
     # :nocov:
     def render_template_for(variant = nil)
       # Force compilation here so the compiler always redefines render_template_for.

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -120,7 +120,7 @@ module ViewComponent
     # Subclass components that call `super` inside their template code will cause a
     # double render if they accidentally emit the result:
     #
-    # <%= super %>
+    # <%= super %> # double-renders
     #
     # but this does not:
     #

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -122,9 +122,7 @@ module ViewComponent
     #
     # <%= super %> # double-renders
     #
-    # but this does not:
-    #
-    # <% super %>
+    # <% super %> # does not double-render
     #
     # The render_parent method simply calls `super` but makes sure to return nil to
     # avoid rendering the result twice.

--- a/test/sandbox/app/components/super_base_component.html.erb
+++ b/test/sandbox/app/components/super_base_component.html.erb
@@ -1,0 +1,1 @@
+<div class="base-component"></div>

--- a/test/sandbox/app/components/super_base_component.rb
+++ b/test/sandbox/app/components/super_base_component.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class SuperBaseComponent < ViewComponent::Base
+end

--- a/test/sandbox/app/components/super_component.html.erb
+++ b/test/sandbox/app/components/super_component.html.erb
@@ -1,0 +1,3 @@
+<div class="derived-component">
+  <%= render_parent %>
+</div>

--- a/test/sandbox/app/components/super_component.rb
+++ b/test/sandbox/app/components/super_component.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class SuperComponent < SuperBaseComponent
+end

--- a/test/view_component/view_component_test.rb
+++ b/test/view_component/view_component_test.rb
@@ -1014,4 +1014,13 @@ class ViewComponentTest < ViewComponent::TestCase
     render_inline(InheritedWithOwnTemplateComponent.new)
     assert_selector("div", text: "hello, my own template")
   end
+
+  def test_inherited_component_calls_super
+    render_inline(SuperComponent.new)
+
+    assert_selector(".base-component", count: 1)
+    assert_selector(".derived-component", count: 1) do
+      assert_selector(".base-component", count: 1)
+    end
+  end
 end


### PR DESCRIPTION
### Summary

Although perhaps not a common pattern, it is possible to call `super` in a derived component to render the parent's template:

```html+erb
<%# base_component.html.erb %>
<div>Content from base component</div>

<%# derived_component.html.erb %>
<div>Content from derived component</div>
<% super %>
```

```ruby
# base_component.rb
class BaseComponent < ViewComponent::Base
end

# derived_component.rb
class DerivedComponent < BaseComponent
end
```

Rendering `DerivedComponent` results in the following, as expected:

```html
<div>Content from derived component</div>
<div>Content from base component</div>
```

Unfortunately however it is very tempting to echo the result of `super` out to the page, eg. `<%= super %>` instead of `<% super %>`, which leads to double rendering both components.

This PR introduces a new `render_parent` method that simply calls `super` and returns `nil`.