### PR TITLE
Add g2 to ViewComponent Users

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,10 @@ title: Changelog
 
 ## main
 
+* Add G2 to list of companies that use ViewComponent.
+
+  *Jack Shuff*
+
 * Add Within3 to list of companies that use ViewComponent.
 
     *Drew Bragg*

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,7 +11,7 @@ title: Changelog
 
 * Add G2 to list of companies that use ViewComponent.
 
-  *Jack Shuff*
+    *Jack Shuff*
 
 * Add Within3 to list of companies that use ViewComponent.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -151,6 +151,7 @@ ViewComponent is built by over a hundred members of the community, including:
 <img src="https://avatars.githubusercontent.com/jonspalmer?s=64" alt="jonspalmer" width="32" />
 <img src="https://avatars.githubusercontent.com/juanmanuelramallo?s=64" alt="juanmanuelramallo" width="32" />
 <img src="https://avatars.githubusercontent.com/jules2689?s=64" alt="jules2689" width="32" />
+<img src="https://avatars.githubusercontent.com/jwshuff?s=64" alt="jwshuff" width="32" />
 <img src="https://avatars.githubusercontent.com/kaspermeyer?s=64" alt="kaspermeyer" width="32" />
 <img src="https://avatars.githubusercontent.com/kylefox?s=64" alt="kylefox" width="32" />
 <img src="https://avatars.githubusercontent.com/leighhalliday?s=64" alt="leighhalliday" width="32" />
@@ -203,6 +204,7 @@ ViewComponent is built by over a hundred members of the community, including:
 * [Cometeer](https://cometeer.com/)
 * [Cults.](https://cults3d.com/)
 * [Framework](https://frame.work/)
+* [G2](https://www.g2.com/) (200+ components)
 * [GitHub](https://github.com/) (900+ components used 15k+ times)
 * [Litmus](https://litmus.engineering/)
 * [Mission Met Center](https://www.missionmet.com/mission-met-center)


### PR DESCRIPTION
### What are you trying to accomplish?

From conversation during RailsConf22, adding G2 to the list of ViewComponent users.

### What approach did you choose and why?

Followed previous approaches, small style/content change, but open to suggestions for better implementation (I'm assuming we are shooting for alphabetical sorts in the contribs/companies that use section).
