### PR TITLE
Test helper `#with_request_url` parses nested query parameters

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -25,6 +25,10 @@ title: Changelog
 
     *Nick Smith*
 
+* Fix `#with_request_url` test helper not parsing nested query parameters into nested hashes.
+
+    *Richard Marbach*
+
 ## 2.55.0
 
 * Add `render_parent` convenience method to avoid confusion between `<%= super %>` and `<% super %>` in template code.

--- a/docs/index.md
+++ b/docs/index.md
@@ -172,6 +172,7 @@ ViewComponent is built by over a hundred members of the community, including:
 <img src="https://avatars.githubusercontent.com/nshki?s=64" alt="nshki" width="32" />
 <img src="https://avatars.githubusercontent.com/rainerborene?s=64" alt="rainerborene" width="32" />
 <img src="https://avatars.githubusercontent.com/rdavid1099?s=64" alt="rdavid1099" width="32" />
+<img src="https://avatars.githubusercontent.com/richardmarbach?s=64" alt="richardmarbach" width="32" />
 <img src="https://avatars.githubusercontent.com/rmacklin?s=64" alt="rmacklin" width="32" />
 <img src="https://avatars.githubusercontent.com/ryogift?s=64" alt="ryogift" width="32" />
 <img src="https://avatars.githubusercontent.com/sammyhenningsson?s=64" alt="sammyhenningsson" width="32" />

--- a/lib/view_component/test_helpers.rb
+++ b/lib/view_component/test_helpers.rb
@@ -136,7 +136,7 @@ module ViewComponent
 
       request.path_info = path
       request.path_parameters = Rails.application.routes.recognize_path(path)
-      request.set_header("action_dispatch.request.query_parameters", Rack::Utils.parse_query(path.split("?")[1]))
+      request.set_header("action_dispatch.request.query_parameters", Rack::Utils.parse_nested_query(path.split("?")[1]))
       request.set_header(Rack::QUERY_STRING, path.split("?")[1])
       yield
     ensure

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -929,6 +929,10 @@ class ViewComponentTest < ViewComponent::TestCase
     with_request_url "/products?mykey=myvalue&otherkey=othervalue" do
       assert_equal "mykey=myvalue&otherkey=othervalue", request.query_string
     end
+
+    with_request_url "/products?mykey[mynestedkey]=myvalue" do
+      assert_equal({ "mynestedkey" => "myvalue" }, request.parameters["mykey"])
+    end
   end
 
   def test_components_share_helpers_state


### PR DESCRIPTION
### What are you trying to accomplish?

Hey, when using the `#with_request_url` test helper, nested parameters are currently parsed as a string key:

**Current Behaviour**
```ruby
with_request_url "/?order[id]=asc" do
 assert_equal request.parameters["order[id]"], "asc"
end
```

The common behaviour in e.g. Rails is to parse the nested URL parameters into hashes. I ran into this issue today, since it's different to how the params are parsed in the actual request.

**New behaviour**
```ruby
with_request_url "/?order[id]=asc" do
  assert_equal request.parameters["order"], {"id" => "asc"}
end
```
