### PR TITLE
Return @rendered_content from rendered_component test helper

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,10 @@ title: Changelog
 
 ## main
 
+* Return `@rendered_content` from `rendered_component` test helper.
+
+    *Simon Dawson*
+
 ## 2.56.0
 
 * Introduce experimental `render_preview` test helper. Note: `@rendered_component` in `TestHelpers` has been renamed to `@rendered_content`.

--- a/lib/view_component/test_helpers.rb
+++ b/lib/view_component/test_helpers.rb
@@ -30,9 +30,11 @@ module ViewComponent
     end
 
     # @private
+    # :nocov:
     def rendered_component
       @rendered_content
     end
+    # :nocov:
 
     # Render a component inline. Internally sets `page` to be a `Capybara::Node::Simple`,
     # allowing for Capybara assertions to be used:

--- a/lib/view_component/test_helpers.rb
+++ b/lib/view_component/test_helpers.rb
@@ -30,7 +30,9 @@ module ViewComponent
     end
 
     # @private
-    attr_reader :rendered_component
+    def rendered_component
+      @rendered_content
+    end
 
     # Render a component inline. Internally sets `page` to be a `Capybara::Node::Simple`,
     # allowing for Capybara assertions to be used:


### PR DESCRIPTION
Broken in https://github.com/github/view_component/pull/1347, released in v2.56.0.

The `@rendered_component` variable was renamed to `@rendered_content`, but the corresponding `attr_accessor` was not updated/renamed. Consequently, `rendered_component` now always returns `nil.

See also the related PR https://github.com/github/view_component/pull/1372
