### PR TITLE
Restore test coverage of `rendered_content` method in `TestHelpers`

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,9 +11,9 @@ title: Changelog
 
 ## 2.56.1
 
-* Rename private accessor `rendered_component` to `rendered_content`.
+* Rename `rendered_component` reader method to `rendered_content` in `TestHelpers`.
 
-    *Yoshiyuki Hirano*, *Simon Dawson*
+    *Yoshiyuki Hirano*, *Simon Dawson*, *Richard Macklin*
 
 ## 2.56.0
 

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -22,7 +22,7 @@ class ViewComponentTest < ViewComponent::TestCase
   def test_render_inline_sets_rendered_content
     render_inline(MyComponent.new)
 
-    assert_includes @rendered_content, "hello,world!"
+    assert_includes rendered_content, "hello,world!"
   end
 
   def test_child_component

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -19,7 +19,7 @@ class ViewComponentTest < ViewComponent::TestCase
     assert_includes render_inline(MyComponent.new).css("div").to_html, "hello,world!"
   end
 
-  def test_render_inline_sets_rendered_component
+  def test_render_inline_sets_rendered_content
     render_inline(MyComponent.new)
 
     assert_includes @rendered_content, "hello,world!"


### PR DESCRIPTION
### What are you trying to accomplish?

This PR restores test coverage of the `rendered_content` (formerly `rendered_component`) method in `TestHelpers`.

Related threads: https://github.com/github/view_component/pull/1372#discussion_r887319319, https://github.com/github/view_component/pull/1347#discussion_r886600805