### PR TITLE
Add missing require for translatable

### DIFF
--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -9,6 +9,7 @@ require "view_component/polymorphic_slots"
 require "view_component/previewable"
 require "view_component/slotable"
 require "view_component/slotable_v2"
+require "view_component/translatable"
 require "view_component/with_content_helper"
 
 module ViewComponent


### PR DESCRIPTION
### What are you trying to accomplish?

We got a `NameError: uninitialized constant ViewComponent::Translatable` in the `pvc` test suite https://github.com/github/view_component/runs/6714662961?check_suite_focus=true in #1291 and I noticed the `require` was missing, I guess it should have been part of  #1268 but was forgotten. It's apparently happening only in gems depending on `view_component` (such as `primer/view_components`), but not when using `view_component` directly in a Rails app?

### What approach did you choose and why?

Adding the `require` fixed the test suite.

### Anything you want to highlight for special attention from reviewers?

@elia does this make sense?