### PR TITLE
Restore `rendered_component`, deprecate for v3

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,10 @@ title: Changelog
 
 ## main
 
+* Restore removed `rendered_component`, marking it for deprecation in v3.0.0.
+
+    *Tyson Gach*, *Richard Macklin*, *Joel Hawksley*
+
 ## 2.56.1
 
 * Rename private accessor `rendered_component` to `rendered_content`.

--- a/docs/guide/testing.md
+++ b/docs/guide/testing.md
@@ -66,16 +66,6 @@ def test_render_component
 end
 ```
 
-Alternatively, assert against the raw output of the component, which is exposed as `rendered_content`:
-
-```ruby
-def test_render_component
-  render_inline(ExampleComponent.new(title: "my title")) { "Hello, World!" }
-
-  assert_includes rendered_content, "Hello, World!"
-end
-```
-
 ## Slots
 
 To test components that use Slots:
@@ -202,9 +192,9 @@ RSpec.describe ExampleComponent, type: :component do
   it "renders component" do
     render_inline(described_class.new(title: "my title")) { "Hello, World!" }
 
-    expect(rendered_content).to have_css "span[title='my title']", text: "Hello, World!"
+    expect(page).to have_css "span[title='my title']", text: "Hello, World!"
     # or, to just assert against the text
-    expect(rendered_content).to have_text "Hello, World!"
+    expect(page).to have_text "Hello, World!"
   end
 end
 ```

--- a/lib/view_component/test_helpers.rb
+++ b/lib/view_component/test_helpers.rb
@@ -32,6 +32,15 @@ module ViewComponent
     # @private
     attr_reader :rendered_content
 
+    def rendered_component
+      ViewComponent::Deprecation.warn(
+        "`rendered_component` is deprecated and will be removed in v3.0.0. " \
+        "Use `page` instead."
+      )
+
+      rendered_content
+    end
+
     # Render a component inline. Internally sets `page` to be a `Capybara::Node::Simple`,
     # allowing for Capybara assertions to be used:
     #

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -19,10 +19,16 @@ class ViewComponentTest < ViewComponent::TestCase
     assert_includes render_inline(MyComponent.new).css("div").to_html, "hello,world!"
   end
 
+  def test_render_inline_sets_rendered_content
+    render_inline(MyComponent.new)
+
+    assert_includes rendered_content, "hello,world!"
+  end
+
   def test_render_inline_sets_rendered_component
     render_inline(MyComponent.new)
 
-    assert_includes @rendered_content, "hello,world!"
+    assert_includes rendered_component, "hello,world!"
   end
 
   def test_child_component


### PR DESCRIPTION
### What are you trying to accomplish?

Restore functionality I incorrectly removed ❤️ 

### What approach did you choose and why?

Restore `rendered_component`, mark it for deprecation, and update docs to avoid `rendered_content`