### PR TITLE
Allow anything that responds to render_in to be rendered in the component's view context

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,10 @@ title: Changelog
 
     *Hans Lemuet*
 
+* Allow anything that responds to `#render_in` to be rendered in the parent component's view context.
+
+    *Cameron Dutro*
+
 ## 2.56.2
 
 * Restore removed `rendered_component`, marking it for deprecation in v3.0.0.

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -183,8 +183,11 @@ module ViewComponent
     #
     # @private
     def render(options = {}, args = {}, &block)
-      if options.is_a? ViewComponent::Base
-        options.__vc_original_view_context = __vc_original_view_context
+      if options.respond_to?(:render_in)
+        if options.is_a?(ViewComponent::Base)
+          options.__vc_original_view_context = __vc_original_view_context
+        end
+
         super
       else
         __vc_original_view_context.render(options, args, &block)

--- a/test/sandbox/app/components/renders_non_component.html.erb
+++ b/test/sandbox/app/components/renders_non_component.html.erb
@@ -1,0 +1,1 @@
+<%= render(@not_a_component) %>

--- a/test/sandbox/app/components/renders_non_component.rb
+++ b/test/sandbox/app/components/renders_non_component.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class RendersNonComponent < ViewComponent::Base
+  class NotAComponent
+    attr_reader :render_in_view_context
+
+    def render_in(view_context)
+      @render_in_view_context = view_context
+      "<span>I'm not a component</span>".html_safe
+    end
+  end
+
+  def initialize(not_a_component:)
+    @not_a_component = not_a_component
+  end
+end

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -1039,4 +1039,18 @@ class ViewComponentTest < ViewComponent::TestCase
       assert_selector(".base-component", count: 1)
     end
   end
+
+  def test_renders_objects_in_component_view_context
+    not_a_component = RendersNonComponent::NotAComponent.new
+    component = RendersNonComponent.new(not_a_component: not_a_component)
+
+    render_inline(component)
+
+    assert_selector "span", text: "I'm not a component"
+
+    assert(
+      not_a_component.render_in_view_context == component,
+      "Component-like object was not rendered in the parent component's view context"
+    )
+  end
 end


### PR DESCRIPTION
### What are you trying to accomplish?

I ran into an issue in [primer/rails_forms](https://github.com/primer/rails_forms) when attempting to render a form inside a component. The form should render in the component's view context instead of the original action_view context. Unfortunately the `render` method in `ViewComponent::Base` renders anything that's not explicitly a view component (i.e. inherits from `ViewComponent::Base`) in the original action_view context.

### What approach did you choose and why?

I modified `ViewComponent::Base#render` to render anything that responds to `render_in` in the component's view context. I also considered adding a flag to `render_in` to specify the desired view context, but I decided against it because it means the caller has to know an awful lot about the architecture of the view layer.

I realize I'm just trading one assumption for another, but this will unblock me for now.