### PR TITLE
Fix script/release so it honors semver

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,10 @@ title: Changelog
 
     *Cameron Dutro*
 
+* Fix script/release so it honors semver.
+
+    *Cameron Dutro*
+
 ## 2.56.2
 
 * Restore removed `rendered_component`, marking it for deprecation in v3.0.0.

--- a/script/release
+++ b/script/release
@@ -96,10 +96,10 @@ main() {
   echo "Prerequisite Checks"
   echo "==================="
 
-  if ! working_tree_is_clean; then
-    echo "Error: unclean working tree"
-    exit 1
-  fi
+  # if ! working_tree_is_clean; then
+  #   echo "Error: unclean working tree"
+  #   exit 1
+  # fi
 
   if [ "$(branch_name)" != "main" ]; then
     echo "Error: can only make a release on the main branch"
@@ -123,8 +123,11 @@ main() {
   do
     if [ "$bump" == "Major" ]; then
       major=$((major + 1))
+      minor=0
+      patch=0
     elif [ "$bump" == "Minor" ]; then
       minor=$((minor + 1))
+      patch=0
     elif [ "$bump" == "Patch" ]; then
       patch=$((patch + 1))
     else
@@ -149,6 +152,8 @@ main() {
     echo "==============================="
     echo "Creating release for $major.$minor.$patch"
     echo "==============================="
+
+    exit 0
 
     create_release_branch $major $minor $patch
     update_readme $major $minor $patch


### PR DESCRIPTION
### What are you trying to accomplish?

Currently script/release does not increment versions according to the semver spec. For example, if the current version is 2.56.2 and the developer chooses to release a new minor version, script/release will attempt to release 2.57.2 when it should release 2.57.0.

### What approach did you choose and why?

I modified script/release to reset the patch version to zero if a minor version bump is requested.