### PR TITLE
Docs: add version info

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,10 @@ title: Changelog
 
 ## main
 
+* Improve the docs: add the versions various features were introduced in.
+
+    *Hans Lemuet*
+
 ## 2.57.0
 
 * Add missing `require` for `Translatable` module in `Base`.

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -17,6 +17,9 @@ ViewComponent is tested against ERB, Haml, and Slim, but it should support most 
 
 ## Disabling the render monkey patch (Rails < 6.1)
 
+Added in 2.13.0
+{: .label }
+
 To [avoid conflicts](https://github.com/github/view_component/issues/288) between ViewComponent and other gems that also monkey patch the `render` method, it's possible to configure ViewComponent to not include the render monkey patch:
 
 `config.view_component.render_monkey_patch_enabled = false # defaults to true`

--- a/docs/guide/collections.md
+++ b/docs/guide/collections.md
@@ -6,6 +6,9 @@ parent: Guide
 
 # Collections
 
+Added in 2.1.0
+{: .label }
+
 Like [Rails partials](https://guides.rubyonrails.org/layouts_and_rendering.html#rendering-collections), it's possible to render a collection with ViewComponents, using `with_collection`:
 
 ```erb
@@ -70,6 +73,9 @@ end
 
 ## Collection counter
 
+Added in 2.5.0
+{: .label }
+
 ViewComponent defines a counter variable matching the parameter name above, followed by `_counter`. To access the variable, add it to `initialize` as an argument:
 
 ```ruby
@@ -90,6 +96,9 @@ end
 ```
 
 ## Collection iteration context
+
+Added in 2.33.0
+{: .label }
 
 ViewComponent defines an iteration variable matching the parameter name above, followed by `_iteration`. This gives contextual information about the iteration to components within the collection (`#size`, `#index`, `#first?`, and `#last?`).
 

--- a/docs/guide/conditional_rendering.md
+++ b/docs/guide/conditional_rendering.md
@@ -6,6 +6,9 @@ parent: Guide
 
 # Conditional rendering
 
+Added in 1.8.0
+{: .label }
+
 Components can implement a `#render?` method to be called after initialization to determine if the component should render.
 
 Traditionally, the logic for whether to render a view could go in either the component template:

--- a/docs/guide/generators.md
+++ b/docs/guide/generators.md
@@ -70,6 +70,9 @@ bin/rails generate component Example title --test-framework rspec
 
 ### Generate a [preview](/guide/previews.html)
 
+Added in 2.25.0
+{: .label }
+
 ```console
 bin/rails generate component Example title --preview
 
@@ -83,6 +86,9 @@ bin/rails generate component Example title --preview
 ```
 
 ### Generate a [Stimulus controller](/guide/javascript_and_css.html#stimulus)
+
+Added in 2.38.0
+{: .label }
 
 ```console
 bin/rails generate component Example title --stimulus
@@ -99,6 +105,9 @@ bin/rails generate component Example title --stimulus
 To always generate a Stimulus controller, set `config.view_component.generate_stimulus_controller = true`.
 
 ### Generate [locale files](/guide/translations.html)
+
+Added in 2.47.0
+{: .label }
 
 ```console
 bin/rails generate component Example title --locale
@@ -118,6 +127,9 @@ To generate translations in distinct locale files, set `config.view_component.ge
 
 ### Place the view in a sidecar directory
 
+Added in 2.16.0
+{: .label }
+
 ```console
 bin/rails generate component Example title --sidecar
 
@@ -132,6 +144,9 @@ To always generate in the sidecar directory, set `config.view_component.generate
 
 ### Use [inline rendering](/guide/templates.html#inline) (no template file)
 
+Added in 2.24.0
+{: .label }
+
 ```console
 bin/rails generate component Example title --inline
 
@@ -142,6 +157,9 @@ bin/rails generate component Example title --inline
 ```
 
 ### Specify the parent class
+
+Added in 2.41.0
+{: .label }
 
 By default, `ApplicationComponent` is used if defined, `ViewComponent::Base` otherwise.
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -76,6 +76,9 @@ Returning:
 
 ## `#with_content`
 
+Added in 2.31.0
+{: .label }
+
 String content can also be passed to a ViewComponent by calling `#with_content`:
 
 ```erb

--- a/docs/guide/helpers.md
+++ b/docs/guide/helpers.md
@@ -24,6 +24,11 @@ class UserComponent < ViewComponent::Base
 end
 ```
 
+## Proxy
+
+Added in 1.5.0
+{: .label }
+
 Or, access helpers through the `helpers` proxy:
 
 ```ruby

--- a/docs/guide/instrumentation.md
+++ b/docs/guide/instrumentation.md
@@ -6,6 +6,9 @@ parent: Guide
 
 # Instrumentation
 
+Added in 2.34.0
+{: .label }
+
 To enable ActiveSupport notifications, use the `instrumentation_enabled` option:
 
 ```ruby

--- a/docs/guide/javascript_and_css.md
+++ b/docs/guide/javascript_and_css.md
@@ -4,7 +4,10 @@ title: Javascript and CSS
 parent: Guide
 ---
 
-# Javascript and CSS (experimental)
+# Javascript and CSS
+
+Experimental
+{: .label .label-yellow }
 
 While ViewComponent doesn't provide any built-in tooling to do so, it’s possible to include Javascript and CSS alongside components.
 

--- a/docs/guide/lifecycle.md
+++ b/docs/guide/lifecycle.md
@@ -8,6 +8,9 @@ parent: Guide
 
 ## `#before_render`
 
+Added in 2.8.0
+{: .label }
+
 Define a `before_render` method to be called before a component is rendered, when `helpers` is able to be used:
 
 ```ruby

--- a/docs/guide/previews.md
+++ b/docs/guide/previews.md
@@ -32,7 +32,13 @@ Then access the resulting previews at:
 
 _For a more interactive experience, consider using [Lookbook](https://github.com/allmarkedup/lookbook) or [ViewComponent::Storybook](https://github.com/jonspalmer/view_component_storybook)._
 
-## (Experimental) Previews as test cases
+## Previews as test cases
+
+Added in 2.56.0
+{: .label }
+
+Experimental
+{: .label .label-yellow }
 
 Use `render_preview(name)` to render previews in ViewComponent unit tests:
 

--- a/docs/guide/slots.md
+++ b/docs/guide/slots.md
@@ -6,6 +6,9 @@ parent: Guide
 
 # Slots
 
+Added in 2.12.0
+{: .label }
+
 In addition to the `content` accessor, ViewComponents can accept content through slots. Think of slots as a way to render multiple blocks of content, including other components.
 
 Slots are defined with `renders_one` and `renders_many`:
@@ -63,6 +66,9 @@ Returning:
 ```
 
 ## Predicate methods
+
+Added in 2.50.0
+{: .label }
 
 To test whether a slot has been passed to the component, use the provided `#{slot_name}?` method.
 
@@ -187,6 +193,9 @@ end
 
 ## Rendering collections
 
+Added in 2.23.0
+{: .label }
+
 `renders_many` slots can also be passed a collection, using the plural setter (`links` in this example):
 
 ```ruby
@@ -223,6 +232,9 @@ end
 
 ## `#with_content`
 
+Added in 2.31.0
+{: .label }
+
 Slot content can also be set using `#with_content`:
 
 ```erb
@@ -233,7 +245,13 @@ Slot content can also be set using `#with_content`:
 
 _To view documentation for content_areas (deprecated) and the original implementation of Slots (deprecated), see [/content_areas](/content_areas) and [/slots_v1](/slots_v1)._
 
-## Polymorphic slots (Experimental)
+## Polymorphic slots
+
+Added in 2.42.0
+{: .label }
+
+Experimental
+{: .label .label-yellow }
 
 Polymorphic slots can render one of several possible slots. To use this experimental feature, include `ViewComponent::PolymorphicSlots`.
 

--- a/docs/guide/templates.md
+++ b/docs/guide/templates.md
@@ -22,6 +22,9 @@ app/components
 
 ## Subdirectory
 
+Added in 2.7.0
+{: .label }
+
 As an alternative, views and other assets can be placed in a subdirectory with the same name as the component:
 
 ```console
@@ -44,6 +47,9 @@ bin/rails generate component Example title --sidecar
 ```
 
 ## Inline
+
+Added in 1.16.0
+{: .label }
 
 ViewComponents can render without a template file, by defining a `call` method:
 
@@ -84,6 +90,9 @@ To override the `variant` set by the request, use `with_variant`:
 
 ## Inherited
 
+Added in 2.19.0
+{: .label }
+
 Component subclasses inherit the parent component's template if they don't define their own template.
 
 ```ruby
@@ -94,6 +103,9 @@ end
 ```
 
 ### Rendering parent templates
+
+Added in 2.55.0
+{: .label }
 
 To render a parent component's template from a subclass, call `render_parent`:
 

--- a/docs/guide/testing.md
+++ b/docs/guide/testing.md
@@ -26,7 +26,13 @@ end
 
 _Note: `assert_selector` only matches on visible elements by default. To match on elements regardless of visibility, add `visible: false`. See the [Capybara documentation](https://rubydoc.info/github/jnicklas/capybara/Capybara/Node/Matchers) for more details._
 
-## (Experimental) Previews as test cases
+## Previews as test cases
+
+Added in 2.56.0
+{: .label }
+
+Experimental
+{: .label .label-yellow }
 
 Use `render_preview(name)` to render previews in ViewComponent unit tests:
 
@@ -98,6 +104,9 @@ end
 
 ## Configuring the controller used in tests
 
+Added in 2.27.0
+{: .label }
+
 Component tests assume the existence of an `ApplicationController` class, which can be configured globally using the `test_controller` option:
 
 ```ruby
@@ -128,6 +137,9 @@ end
 
 ## Setting `request.path_parameters`
 
+Added in 2.31.0
+{: .label }
+
 Some Rails helpers won't work unless `request.path_parameters` are set correctly, resulting in an `ActionController::UrlGenerationError`.
 
 To set `request.path_parameters` for a test case, use `with_request_url` from `ViewComponent::TestHelpers`:
@@ -142,6 +154,11 @@ class ExampleComponentTest < ViewComponent::TestCase
   end
 end
 ```
+
+### Query parameters
+
+Added in 2.41.0
+{: .label }
 
 It's also possible to set query parameters:
 

--- a/docs/known_issues.md
+++ b/docs/known_issues.md
@@ -9,7 +9,13 @@ title: Known issues
 
 ViewComponent [isn't compatible](https://github.com/github/view_component/issues/241) with `form_for` helpers by default.
 
-### Using a Global Output Buffer (Experimental)
+### Using a Global Output Buffer
+
+Added in 2.52.0
+{: .label }
+
+Experimental
+{: .label .label-yellow }
 
 One possible solution to the form helpers problem is to use a single, global output buffer. For details, please refer to [this pull request](https://github.com/github/view_component/pull/1307).
 


### PR DESCRIPTION
### What are you trying to accomplish?

Improve the docs: add the versions various features were introduced in.

Close #1313 

### What approach did you choose and why?

To make the info stand out, I used the [label](https://just-the-docs.github.io/just-the-docs/docs/ui-components/labels/) component provided by the Jekyll theme.

![image](https://user-images.githubusercontent.com/38524/173712181-18affefc-b629-4de4-ae3b-5a580d993b56.png)

Alternatively, we could also use a simple paragraph in italics.

### Anything you want to highlight for special attention from reviewers?

- I'm not sure which version(s) to mention on the [Translations](https://viewcomponent.org/guide/translations.html) page
- Do you think we should add versions to the [API](https://viewcomponent.org/api.html) page?
- There's a [known display bug](https://github.com/just-the-docs/just-the-docs/issues/751) when multiple labels are used. I'll try to open a PR on the theme repo to fix it.