### PR TITLE
Fix issue causing NoMethodErrors when calling helper methods from components rendered as part of a collection.

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,10 @@ title: Changelog
 
 ## main
 
+* Fix issue causing `NoMethodError`s when calling helper methods from components rendered as part of a collection.
+
+    *Cameron Dutro*
+
 ## 2.57.0
 
 * Add missing `require` for `Translatable` module in `Base`.

--- a/docs/api.md
+++ b/docs/api.md
@@ -77,7 +77,7 @@ Returns HTML that has been escaped by the respective template handler.
 ### #render_parent
 
 Subclass components that call `super` inside their template code will cause a
-double render if they accidentally emit the result:
+double render if they emit the result:
 
     <%= super %> # double-renders
     <% super %> # does not double-render
@@ -95,7 +95,7 @@ Components render in their own view context. Helpers and other functionality
 require a reference to the original Rails view context, an instance of
 `ActionView::Base`. Use this method to set a reference to the original
 view context. Objects that implement this method will render in the component's
-view context, while objects that do not will render in the original view context
+view context, while objects that don't will render in the original view context
 so helpers, etc work as expected.
 
 ### #with_variant(variant) → [self] (Deprecated)

--- a/docs/api.md
+++ b/docs/api.md
@@ -74,10 +74,29 @@ Entrypoint for rendering components.
 
 Returns HTML that has been escaped by the respective template handler.
 
+### #render_parent
+
+Subclass components that call `super` inside their template code will cause a
+double render if they accidentally emit the result:
+
+    <%= super %> # double-renders
+    <% super %> # does not double-render
+
+Calls `super`, returning `nil` to avoid rendering the result twice.
+
 ### #request → [ActionDispatch::Request]
 
 The current request. Use sparingly as doing so introduces coupling that
 inhibits encapsulation & reuse, often making testing difficult.
+
+### #set_original_view_context(view_context) → [void]
+
+Components render in their own view context. Helpers and other functionality
+require a reference to the original Rails view context, an instance of
+`ActionView::Base`. Use this method to set a reference to the original
+view context. Objects that implement this method will render in the component's
+view context, while objects that do not will render in the original view context
+so helpers, etc work as expected.
 
 ### #with_variant(variant) → [self] (Deprecated)
 
@@ -211,6 +230,19 @@ Defaults to `app/components`.
 
 ## ViewComponent::TestHelpers
 
+### #render_in_view_context(&block)
+
+Execute the given block in the view context. Internally sets `page` to be a
+`Capybara::Node::Simple`, allowing for Capybara assertions to be used:
+
+```ruby
+render_in_view_context do
+  render(MyComponent.new)
+end
+
+assert_text("Hello, World!")
+```
+
 ### #render_inline(component, **args, &block) → [Nokogiri::HTML]
 
 Render a component inline. Internally sets `page` to be a `Capybara::Node::Simple`,
@@ -220,6 +252,10 @@ allowing for Capybara assertions to be used:
 render_inline(MyComponent.new)
 assert_text("Hello, World!")
 ```
+
+### #rendered_component
+
+
 
 ### #with_controller_class(klass)
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -253,10 +253,6 @@ render_inline(MyComponent.new)
 assert_text("Hello, World!")
 ```
 
-### #rendered_component
-
-
-
 ### #with_controller_class(klass)
 
 Set the controller to be used while executing the given block,

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -33,6 +33,10 @@ module ViewComponent
 
     attr_accessor :__vc_original_view_context
 
+    def set_original_view_context(view_context)
+      self.__vc_original_view_context = view_context
+    end
+
     # EXPERIMENTAL: This API is experimental and may be removed at any time.
     # Hook for allowing components to do work as part of the compilation process.
     #
@@ -183,11 +187,8 @@ module ViewComponent
     #
     # @private
     def render(options = {}, args = {}, &block)
-      if options.respond_to?(:render_in)
-        if options.is_a?(ViewComponent::Base)
-          options.__vc_original_view_context = __vc_original_view_context
-        end
-
+      if options.respond_to?(:set_original_view_context)
+        options.set_original_view_context(self.__vc_original_view_context)
         super
       else
         __vc_original_view_context.render(options, args, &block)

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -37,7 +37,7 @@ module ViewComponent
     # require a reference to the original Rails view context, an instance of
     # `ActionView::Base`. Use this method to set a reference to the original
     # view context. Objects that implement this method will render in the component's
-    # view context, while objects that do not will render in the original view context
+    # view context, while objects that don't will render in the original view context
     # so helpers, etc work as expected.
     #
     # @param view_context [ActionView::Base] The original view context.
@@ -133,7 +133,7 @@ module ViewComponent
     end
 
     # Subclass components that call `super` inside their template code will cause a
-    # double render if they accidentally emit the result:
+    # double render if they emit the result:
     #
     #     <%= super %> # double-renders
     #     <% super %> # does not double-render

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -33,6 +33,15 @@ module ViewComponent
 
     attr_accessor :__vc_original_view_context
 
+    # Components render in their own view context. Helpers and other functionality
+    # require a reference to the original Rails view context, an instance of
+    # `ActionView::Base`. Use this method to set a reference to the original
+    # view context. Objects that implement this method will render in the component's
+    # view context, while objects that do not will render in the original view context
+    # so helpers, etc work as expected.
+    #
+    # @param view_context [ActionView::Base] The original view context.
+    # @return [void]
     def set_original_view_context(view_context)
       self.__vc_original_view_context = view_context
     end
@@ -118,6 +127,7 @@ module ViewComponent
       @current_template = old_current_template
     end
 
+    # @private
     def perform_render
       render_template_for(@__vc_variant).to_s + _output_postamble
     end
@@ -125,17 +135,17 @@ module ViewComponent
     # Subclass components that call `super` inside their template code will cause a
     # double render if they accidentally emit the result:
     #
-    # <%= super %> # double-renders
+    #     <%= super %> # double-renders
+    #     <% super %> # does not double-render
     #
-    # <% super %> # does not double-render
-    #
-    # Calls `super`, returning nil to avoid rendering the result twice.
+    # Calls `super`, returning `nil` to avoid rendering the result twice.
     def render_parent
       mtd = @__vc_variant ? "call_#{@__vc_variant}" : "call"
       method(mtd).super_method.call
       nil
     end
 
+    # @private
     # :nocov:
     def render_template_for(variant = nil)
       # Force compilation here so the compiler always redefines render_template_for.

--- a/lib/view_component/collection.rb
+++ b/lib/view_component/collection.rb
@@ -10,8 +10,15 @@ module ViewComponent
     delegate :format, to: :component
     delegate :size, to: :@collection
 
+    attr_accessor :__vc_original_view_context
+
+    def set_original_view_context(view_context)
+      self.__vc_original_view_context = view_context
+    end
+
     def render_in(view_context, &block)
       components.map do |component|
+        component.set_original_view_context(self.__vc_original_view_context)
         component.render_in(view_context, &block)
       end.join.html_safe # rubocop:disable Rails/OutputSafety
     end

--- a/test/sandbox/app/components/nested_collection_component.html.erb
+++ b/test/sandbox/app/components/nested_collection_component.html.erb
@@ -1,0 +1,1 @@
+<span class="nested"><%= @item %>, <%= helpers.message %></span>

--- a/test/sandbox/app/components/nested_collection_component.rb
+++ b/test/sandbox/app/components/nested_collection_component.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class NestedCollectionComponent < ViewComponent::Base
+  with_collection_parameter :item
+
+  def initialize(item:)
+    @item = item
+  end
+end

--- a/test/sandbox/app/components/nested_collection_wrapper_component.html.erb
+++ b/test/sandbox/app/components/nested_collection_wrapper_component.html.erb
@@ -1,0 +1,1 @@
+<%= render(NestedCollectionComponent.with_collection(@items)) %>

--- a/test/sandbox/app/components/nested_collection_wrapper_component.rb
+++ b/test/sandbox/app/components/nested_collection_wrapper_component.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class NestedCollectionWrapperComponent < ViewComponent::Base
+  def initialize(items:)
+    @items = items
+  end
+end

--- a/test/sandbox/app/components/renders_non_component.rb
+++ b/test/sandbox/app/components/renders_non_component.rb
@@ -2,11 +2,15 @@
 
 class RendersNonComponent < ViewComponent::Base
   class NotAComponent
-    attr_reader :render_in_view_context
+    attr_reader :render_in_view_context, :original_view_context
 
     def render_in(view_context)
       @render_in_view_context = view_context
       "<span>I'm not a component</span>".html_safe
+    end
+
+    def set_original_view_context(view_context)
+      @original_view_context = view_context
     end
   end
 

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -1053,4 +1053,16 @@ class ViewComponentTest < ViewComponent::TestCase
       "Component-like object was not rendered in the parent component's view context"
     )
   end
+
+  def test_renders_nested_collection
+    items = %w(foo bar baz boo)
+    render_inline(NestedCollectionWrapperComponent.new(items: items))
+
+    index = 0
+
+    assert_selector(".nested", count: 4) do |node|
+      assert "#{items[index]}, Hello helper method" == node.text
+      index += 1
+    end
+  end
 end


### PR DESCRIPTION
Fixes https://github.com/github/view_component/issues/1390

### What are you trying to accomplish?

A recent change introduced in https://github.com/github/view_component/pull/1385 broke helper methods when rendering collections, eg:

```erb
<%# app/components/some_parent_component.html.erb %>
<%= render(ProductComponent.with_collection(@products)) %>
```

```erb
<%# app/components/product_component.html.erb %>
<%= helpers.my_helper_method %>
```

PR #1385 changed `ViewComponent::Base#render` to render anything that responds to `#render_in` in the parent component's view context. Collections respond to `#render_in` but, unlike regular view components, don't retain a reference to the original `ActionView::Base` view context. This means that the `helpers` method returns `nil` and leads to `NoMethodErrors`.

### What approach did you choose and why?

I decided anything that should be rendered in the parent component's view context must respond to the `#set_original_view_context` method so helpers, etc work as expected. I modified `ViewComponent::Base#render` to call this new method, and also added it to the `Collection` class.