### PR TITLE
Fix syntax errors in polymorphic slots docs

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,10 @@ title: Changelog
 
 ## main
 
+* Fix syntax error in the ERB example in the polymorphic slots docs.
+
+    *Cameron Dutro*
+
 ## 2.57.0
 
 * Add missing `require` for `Translatable` module in `Base`.

--- a/docs/guide/slots.md
+++ b/docs/guide/slots.md
@@ -258,12 +258,12 @@ Filling in the `visual` slot is done by calling the appropriate slot method:
 
 ```erb
 <%= render ListItemComponent.new do |c| %>
-  <% c.with_visual_avatar(src: "http://some-site.com/my_avatar.jpg", alt: "username") %>
+  <% c.with_visual_avatar(src: "http://some-site.com/my_avatar.jpg", alt: "username") do %>
     Profile
   <% end >
 <% end %>
 <%= render ListItemComponent.new do |c| %>
-  <% c.with_visual_icon(icon: :key) %>
+  <% c.with_visual_icon(icon: :key) do %>
     Security Settings
   <% end >
 <% end %>


### PR DESCRIPTION
### What are you trying to accomplish?

I'm trying to fix a silly mistake I made a number of months ago.

### What approach did you choose and why?

I added several missing `do` keywords to the ERB example in the polymorphic slots docs.