### PR TITLE
Include polymorphic slots behavior by default

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,10 @@ title: Changelog
 
 ## main
 
+* Include polymorphic slots in `ViewComponent::Base` by default.
+
+    *Cameron Dutro*
+
 ## 2.57.1
 
 * Fix issue causing `NoMethodError`s when calling helper methods from components rendered as part of a collection.

--- a/docs/guide/slots.md
+++ b/docs/guide/slots.md
@@ -233,16 +233,14 @@ Slot content can also be set using `#with_content`:
 
 _To view documentation for content_areas (deprecated) and the original implementation of Slots (deprecated), see [/content_areas](/content_areas) and [/slots_v1](/slots_v1)._
 
-## Polymorphic slots (Experimental)
+## Polymorphic slots
 
-Polymorphic slots can render one of several possible slots. To use this experimental feature, include `ViewComponent::PolymorphicSlots`.
+Polymorphic slots can render one of several possible slots.
 
 For example, consider this list item component that can be rendered with either an icon or an avatar visual. The `visual` slot is passed a hash mapping types to slot definitions:
 
 ```ruby
 class ListItemComponent < ViewComponent::Base
-  include ViewComponent::PolymorphicSlots
-
   renders_one :visual, types: {
     icon: IconComponent,
     avatar: lambda { |**system_arguments|

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -16,6 +16,7 @@ module ViewComponent
   class Base < ActionView::Base
     include ActiveSupport::Configurable
     include ViewComponent::ContentAreas
+    include ViewComponent::PolymorphicSlots
     include ViewComponent::Previewable
     include ViewComponent::SlotableV2
     include ViewComponent::Translatable

--- a/lib/view_component/polymorphic_slots.rb
+++ b/lib/view_component/polymorphic_slots.rb
@@ -6,12 +6,14 @@ module ViewComponent
     # Module#prepend and class methods.
     def self.included(base)
       if base != ViewComponent::Base
+        # :nocov:
         location = Kernel.caller_locations(1, 1)[0]
 
         warn(
           "warning: ViewComponent::PolymorphicSlots is now included in ViewComponent::Base by default "\
           "and can be removed from #{location.path}:#{location.lineno}"
         )
+        # :nocov:
       end
 
       base.singleton_class.prepend(ClassMethods)

--- a/test/sandbox/app/components/polymorphic_slot_component.rb
+++ b/test/sandbox/app/components/polymorphic_slot_component.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class PolymorphicSlotComponent < ViewComponent::Base
-  include ViewComponent::PolymorphicSlots
-
   renders_one :header, types: {
     standard: lambda { |&block| content_tag(:div, class: "standard", &block) },
     special: lambda { |&block| content_tag(:div, class: "special", &block) }


### PR DESCRIPTION
### What are you trying to accomplish?

The polymorphic slots feature has baked for a while and appears to be stable. Pending any concerns raised in [this discussion](https://github.com/github/view_component/discussions/1398), I think it's time to include it in `ViewComponent::Base` by default.

### What approach did you choose and why?

Simply `include`ing the module in `ViewComponent` base does the trick. There's no need to wait for v3 because the changes introduced by polymorphic slots are strictly additive.