### PR TITLE
`assert_link` fails with "ArgumentError: Unused parameters passed to Capybara::Queries::SelectorQuery""

### DIFF
--- a/test/sandbox/test/capybara_dsl_test.rb
+++ b/test/sandbox/test/capybara_dsl_test.rb
@@ -92,4 +92,8 @@ class CapybaraDslTest < ViewComponent::TestCase
       assert send(method, argument)
     end
   end
+
+  test "assert_link" do
+    assert_link "My link"
+  end
 end


### PR DESCRIPTION
Hello there 👋 

We wanted to upgrade a project to the latest `view_component` (we're on 2.58.0) and started to see tests failing that use `assert_link`.

I reproduced the problem in a simple test, this is the output.

```
CapybaraDslTest#test_assert_link:
ArgumentError: Unused parameters passed to Capybara::Queries::SelectorQuery : [:link, "My link"]
```

I think that release [v2.59.0](https://github.com/github/view_component/releases/tag/v2.59.0) introduced that issue.

Is there a way to bring back `assert_link` or should we workaround it somehow?