### PR TITLE
Add a missing space in a deprecation warning message

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,10 @@ title: Changelog
 
 ## main
 
+* Add blank space between "in" and "ViewComponent" in a deprecation warning.
+
+    *Vikram Dighe*
+
 * Add HappyCo to list of companies using ViewComponent.
 
     *Josh Clayton*

--- a/lib/view_component/polymorphic_slots.rb
+++ b/lib/view_component/polymorphic_slots.rb
@@ -58,7 +58,7 @@ module ViewComponent
 
           define_method(setter_name) do |*args, &block|
             ViewComponent::Deprecation.warn(
-              "polymorphic slot setters like `#{setter_name}` are deprecated and will be removed in" \
+              "polymorphic slot setters like `#{setter_name}` are deprecated and will be removed in " \
               "ViewComponent v3.0.0.\n\nUse `with_#{setter_name}` instead."
             )
 


### PR DESCRIPTION
### What are you trying to accomplish?

Add a missing space in between words.

### What approach did you choose and why?

I was able to add the space, but I didn't find a matching failing spec. Perusing the specs, this doesn't appear to be the type of requirement which has matching specs, so I have omitted them as well.

### Anything you want to highlight for special attention from reviewers?

**Before**
`DEPRECATION WARNING: polymorphic slot setters like `title_text` are deprecated and will be removed inViewComponent v3.0.0.`

**After**
`DEPRECATION WARNING: polymorphic slot setters like `title_text` are deprecated and will be removed in ViewComponent v3.0.0.`