### PR TITLE
Add `raise_on_deprecated_slot_setter` macro to raise if deprecated no…

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,10 @@ title: Changelog
 
 ## main
 
+* Add `raise_on_deprecated_slot_setter` macro to raise if deprecated non-`with_*` API for slots is used. We recommend adding this macro to your components ahead of the coming v3.0.0 release <3.
+
+    *Joel Hawksley*
+
 ## 2.62.0
 
 * Remove the experimental global output buffer feature.

--- a/docs/guide/slots.md
+++ b/docs/guide/slots.md
@@ -9,6 +9,7 @@ parent: Guide
 Since 2.12.0
 {: .label }
 
+
 In addition to the `content` accessor, ViewComponents can accept content through slots. Think of slots as a way to render multiple blocks of content, including other components.
 
 Slots are defined with `renders_one` and `renders_many`:
@@ -64,6 +65,8 @@ Returning:
 <a href="/blog/first-post">First post</a>
 <a href="/blog/second-post">Second post</a>
 ```
+
+_Note: It is also possible to set slots without the `with_` prefix. This functionality will be removed in v3.0.0. To preview this change, add `raise_on_deprecated_slot_setter`._
 
 ## Predicate methods
 

--- a/lib/view_component/slotable_v2.rb
+++ b/lib/view_component/slotable_v2.rb
@@ -17,9 +17,19 @@ module ViewComponent
       # Hash of registered Slots
       class_attribute :registered_slots
       self.registered_slots = {}
+
+      class_attribute :_raise_on_deprecated_slot_setter
+      self._raise_on_deprecated_slot_setter = false
     end
 
     class_methods do
+      ##
+      # Enables deprecations coming to the Slots API in ViewComponent v3
+      #
+      def raise_on_deprecated_slot_setter
+        self._raise_on_deprecated_slot_setter = true
+      end
+
       ##
       # Registers a sub-component
       #
@@ -81,7 +91,11 @@ module ViewComponent
             get_slot(slot_name)
           else
             # Deprecated: Will remove in 3.0
-            set_slot(slot_name, nil, *args, &block)
+            if _raise_on_deprecated_slot_setter
+              raise NoMethodError.new("#{self.class.name}##{slot_name} has been deprecated and will be removed in ViewComponent v3.0.0. Use `#with_#{slot_name}` instead <3")
+            else
+              set_slot(slot_name, nil, *args, &block)
+            end
           end
         end
         ruby2_keywords(slot_name.to_sym) if respond_to?(:ruby2_keywords, true)
@@ -141,7 +155,11 @@ module ViewComponent
         #
         # Deprecated: Will remove in 3.0
         define_method singular_name do |*args, &block|
-          set_slot(slot_name, nil, *args, &block)
+          if _raise_on_deprecated_slot_setter
+            raise NoMethodError.new("#{self.class.name}##{singular_name} has been deprecated and will be removed in ViewComponent v3.0.0. Use `#with_#{singular_name}` instead <3")
+          else
+            set_slot(slot_name, nil, *args, &block)
+          end
         end
         ruby2_keywords(singular_name.to_sym) if respond_to?(:ruby2_keywords, true)
 
@@ -162,9 +180,13 @@ module ViewComponent
           if collection_args.nil? && block.nil?
             get_slot(slot_name)
           else
-            # Deprecated: Will remove in 3.0
-            collection_args.map do |args|
-              set_slot(slot_name, nil, **args, &block)
+            if _raise_on_deprecated_slot_setter
+              raise NoMethodError.new("#{self.class.name}##{slot_name}has been deprecated and will be removed in ViewComponent v3.0.0. Use `#with_#{slot_name}` instead <3")
+            else
+              # Deprecated: Will remove in 3.0
+              collection_args.map do |args|
+                set_slot(slot_name, nil, **args, &block)
+              end
             end
           end
         end

--- a/test/sandbox/app/components/slots_v3_deprecation_component.rb
+++ b/test/sandbox/app/components/slots_v3_deprecation_component.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class SlotsV3DeprecationComponent < ViewComponent::Base
+  raise_on_deprecated_slot_setter
+
+  renders_one :label
+  renders_many :items
+
+  def call
+    content
+  end
+end

--- a/test/sandbox/test/slotable_v2_test.rb
+++ b/test/sandbox/test/slotable_v2_test.rb
@@ -579,4 +579,30 @@ class SlotsV2sTest < ViewComponent::TestCase
 
     assert_selector("h1.some-class", text: "This is a header!")
   end
+
+  def test_v3_deprection_config
+    error = assert_raises NoMethodError do
+      render_inline(SlotsV3DeprecationComponent.new) do |c|
+        c.label { "foo" }
+      end
+    end
+
+    assert_includes error.message, "Use `#with_label` instead"
+
+    error = assert_raises NoMethodError do
+      render_inline(SlotsV3DeprecationComponent.new) do |c|
+        c.item { "foo" }
+      end
+    end
+
+    assert_includes error.message, "Use `#with_item` instead"
+
+    error = assert_raises NoMethodError do
+      render_inline(SlotsV3DeprecationComponent.new) do |c|
+        c.items { "foo" }
+      end
+    end
+
+    assert_includes error.message, "Use `#with_items` instead"
+  end
 end


### PR DESCRIPTION
This PR adds a `raise_on_deprecated_slot_setter` macro to be used to preview the coming removal of the non-`with_*` methods for slots in ViewComponent v3.0.0 ❤️ 