### PR TITLE
Docs: add information about turbo-rails

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,7 +9,7 @@ title: Changelog
 
 ## main
 
-* Improve the docs: add information about working with turbo-rails.
+* Add documentation about working with `turbo-rails`.
 
     *Matheus Poli Camilo*
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,10 @@ title: Changelog
 
 ## main
 
+* Improve the docs: add information about working with turbo-rails.
+
+    *Matheus Poli Camilo*
+
 ## 2.62.0
 
 * Remove the experimental global output buffer feature.

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -99,6 +99,9 @@ end
 
 _Note: Content can't be passed to a component via a block in controllers. Instead, use `with_content`. In versions of Rails < 6.1, rendering a ViewComponent from a controller doesn't include the layout._
 
+_Note: If you are working with [turbo-rails](https://github.com/hotwired/turbo-rails), don't forget to set the
+`content_type` as `text/html`._
+
 ### Rendering ViewComponents to strings inside controller actions
 
 When rendering the same component multiple times for later reuse, use `render_in`:

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -99,7 +99,14 @@ end
 
 _Note: Content can't be passed to a component via a block in controllers. Instead, use `with_content`. In versions of Rails < 6.1, rendering a ViewComponent from a controller doesn't include the layout._
 
-_Note: When using [turbo-rails](https://github.com/hotwired/turbo-rails) be sure to set `content_type` as `text/html`._
+When using [turbo-rails](https://github.com/hotwired/turbo-rails) be sure to set `content_type` as `text/html`:
+
+```ruby
+# app/controllers/home_controller.rb
+def create
+  render(ExampleComponent.new, content_type: "text/html")
+end
+```
 
 ### Rendering ViewComponents to strings inside controller actions
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -99,7 +99,7 @@ end
 
 _Note: Content can't be passed to a component via a block in controllers. Instead, use `with_content`. In versions of Rails < 6.1, rendering a ViewComponent from a controller doesn't include the layout._
 
-When using [turbo-rails](https://github.com/hotwired/turbo-rails) be sure to set `content_type` as `text/html`:
+When using [turbo-rails](https://github.com/hotwired/turbo-rails), if you want to update a **turbo frame**, be sure to set `content_type` as `text/html`:
 
 ```ruby
 # app/controllers/home_controller.rb

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -99,7 +99,7 @@ end
 
 _Note: Content can't be passed to a component via a block in controllers. Instead, use `with_content`. In versions of Rails < 6.1, rendering a ViewComponent from a controller doesn't include the layout._
 
-When using [turbo-rails](https://github.com/hotwired/turbo-rails), if you want to update a **turbo frame**, be sure to set `content_type` as `text/html`:
+When using turbo frames with [turbo-rails](https://github.com/hotwired/turbo-rails), set `content_type` as `text/html`:
 
 ```ruby
 # app/controllers/home_controller.rb

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -99,8 +99,7 @@ end
 
 _Note: Content can't be passed to a component via a block in controllers. Instead, use `with_content`. In versions of Rails < 6.1, rendering a ViewComponent from a controller doesn't include the layout._
 
-_Note: If you are working with [turbo-rails](https://github.com/hotwired/turbo-rails), don't forget to set the
-`content_type` as `text/html`._
+_Note: When using [turbo-rails](https://github.com/hotwired/turbo-rails) be sure to set `content_type` as `text/html`._
 
 ### Rendering ViewComponents to strings inside controller actions
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -199,6 +199,7 @@ ViewComponent is built by over a hundred members of the community, including:
 <img src="https://avatars.githubusercontent.com/xkraty?s=64" alt="xkraty" width="32" />
 <img src="https://avatars.githubusercontent.com/xronos-i-am?s=64" alt="xronos-i-am" width="32" />
 <img src="https://avatars.githubusercontent.com/yykamei?s=64" alt="yykamei" width="32" />
+<img src="https://avatars.githubusercontent.com/matheuspolicamilo?s=64" alt="matheuspolicamilo" width="32" />
 
 ## Who uses ViewComponent?
 


### PR DESCRIPTION
### What are you trying to accomplish?

Added information about working with turbo-rails when rendering from controllers, on getting started guide.

Close #1440 

### What approach did you choose and why?

When using **turbo-rails** with **view_components**, and rendering a `ViewComponent` in the `Controller` on `#create`, the response has content type `text/vnd.turbo-stream.html`. This causes turbo frames to not update.

Just added information to use the `content_type: "text/html"` when working with **turbo-rails**.