### PR TITLE
Fix typo in `renders_many` documentation

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,7 +9,7 @@ title: Changelog
 
 ## main
 
-* Fixed typo in `renders_many` documentation
+* Fixed typo in `renders_many` documentation.
 
     *Graham Rogers*
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,10 @@ title: Changelog
 
 ## main
 
+* Fixed typo in `renders_many` documentation
+
+    *Graham Rogers*
+
 * Add documentation about working with `turbo-rails`.
 
     *Matheus Poli Camilo*

--- a/lib/view_component/slotable_v2.rb
+++ b/lib/view_component/slotable_v2.rb
@@ -98,11 +98,11 @@ module ViewComponent
       #
       # = Example
       #
-      #   render_many :items, -> (name:) { ItemComponent.new(name: name }
+      #   renders_many :items, -> (name:) { ItemComponent.new(name: name }
       #
       #   # OR
       #
-      #   render_many :items, ItemComponent
+      #   renders_many :items, ItemComponent
       #
       # = Rendering sub-components
       #


### PR DESCRIPTION
### What are you trying to accomplish?

`renders_many` refers to itself as `render_many` in its documentation.

### What approach did you choose and why?

Fixed the typo.

### Anything you want to highlight for special attention from reviewers?

Nope.