### PR TITLE
Consistently evaluate passed in block content

### DIFF
--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -126,6 +126,11 @@ module ViewComponent
       before_render
 
       if render?
+        # Ensure `content` is evaluated before rendering the template, this is
+        # needed so slots and other side-effects are performed before the
+        # component template is evaluated.
+        content if self.class.use_consistent_rendering_lifecycle
+
         render_template_for(@__vc_variant).to_s + _output_postamble
       else
         ""
@@ -336,6 +341,18 @@ module ViewComponent
     # Defaults to `app/components`.
     #
     mattr_accessor :view_component_path, instance_writer: false, default: "app/components"
+
+    # Evaluate `#content` before `#call` to ensure side-effects are present
+    # during component renders. This will be the default behavior in a future
+    # release.
+    #
+    # ```ruby
+    # config.view_component.use_consistent_rendering_lifecycle = true
+    # ```
+    #
+    # Defaults to `false`
+    #
+    mattr_accessor :use_consistent_rendering_lifecycle, instance_writer: false, default: false
 
     # Parent class for generated components
     #

--- a/test/sandbox/app/components/composable_slots_component.rb
+++ b/test/sandbox/app/components/composable_slots_component.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class ComposableSlotsComponent < ViewComponent::Base
+  delegate :title, to: :@parent
+
+  def initialize
+    @parent = SlotsV2WithoutContentBlockComponent.new
+  end
+
+  def call
+    content_tag :div, class: "composable-slot-component" do
+      capture do
+        render @parent
+      end
+    end
+  end
+end

--- a/test/sandbox/test/slotable_v2_test.rb
+++ b/test/sandbox/test/slotable_v2_test.rb
@@ -588,4 +588,14 @@ class SlotsV2sTest < ViewComponent::TestCase
 
     assert_selector("h1.some-class", text: "This is a header!")
   end
+
+  def test_composable_slots_with_consistent_render
+    with_consistent_render do
+      render_inline ComposableSlotsComponent.new do |c|
+        c.title(title: "The truth is out there")
+      end
+
+      assert_selector("div h1", text: "The truth is out there")
+    end
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -111,6 +111,14 @@ ensure
   ViewComponent::CompileCache.cache = old_cache
 end
 
+def with_consistent_render
+  old_value = ViewComponent::Base.use_consistent_rendering_lifecycle
+  ViewComponent::Base.use_consistent_rendering_lifecycle = true
+  yield
+ensure
+  ViewComponent::Base.use_consistent_rendering_lifecycle = old_value
+end
+
 def without_template_annotations
   if ActionView::Base.respond_to?(:annotate_rendered_view_with_filenames)
     old_value = ActionView::Base.annotate_rendered_view_with_filenames


### PR DESCRIPTION
Currently slots aren't composable due to the lifecycle of components,
where we attempt to avoid evaluating the block passed to `render_in`

(aka `content` in the library). This creates an inconsistent experience
where delegation works only if `content` was already evaluated.

The following code looks correct, but the `c.title` code will never be
executed:

```ruby
class MyComponent
  delegate :title, to: :@sidebar

  def initialize
    @sidebar = SidebarComponent.new
  end

  def call
    content_tag :div do
      render @sidebar
    end
  end
end
```

```erb
<%= render MyComponent.new(:title) do |c| %>
  <%= c.title("My sidebar") %>
<% end %>
```

The block passed that includes the call to `c.title("My sidebar")` is
never evaluated. This is a side-effect of a performance optimization
where we attempt to lazily evaluate the block passed to `render_in`.
This optimization was introduced to avoid evaluating  the entire render
chain for components return `false` when `render?` is called since it's
unnecessary work.

If the component were slightly different and called `content` for any
reason the above code would work as expected:

```ruby
class MyComponent
  delegate :title, to: :@sidebar

  def initialize
    @sidebar = SidebarComponent.new
  end

  def call
    # this causes `content` to be evaluated, resulting in
    # <%= c.title(title: "My sidebar") %> being called. Now this
    # component will work as expected.
    modified_content = content.replace('foo', 'bar')

    content_tag :div do
      render @sidebar
    end
  end
end
```

This is an example of the optimization causing inconsistent behavior in
the library. The change above causes `content` to be called before
`#call`, so any setup/mutations/side-effects are now guaranteed to be
reflected in the component output.

Here's what the change in the component lifecycle looks like:

```
(#content can be called anywhere in the above chain, or never called)
```

Now the lifecycle looks like:

```
(#content isn't used, it's just evaluated to ensure side-effects are performed)
```

This introduces the behavior change behind a configurable value that can
be set via `view_component.config.use_consistent_rendering_lifecycle`.

To enable this before it becomes the default behavior:

`config.view_component.use_consistent_rendering_lifecycle = true`

This is largely copied from
https://github.com/github/view_component/pull/1407 but introduces it as
a opt-in behavior instead of changing the default.

### What are you trying to accomplish?

<!-- Provide a description of the changes. Link to any related issues or projects. -->

### What approach did you choose and why?

<!-- Describe your thought process in making these changes. List any tradeoffs you made. Describe any alternative approaches you considered and why you discarded them. -->

### Anything you want to highlight for special attention from reviewers?