### PR TITLE
Fix compiler deadlock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     view_component (2.63.0)
       activesupport (>= 5.0.0, < 8.0)
+      concurrent-ruby (~> 1.0)
       method_source (~> 1.0)
 
 GEM

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,10 @@ title: Changelog
 
 ## main
 
+* Fix potential deadlock scenario in the compiler's development mode.
+
+    *Blake Williams*
+
 ## 2.63.0
 
 * Fixed typo in `renders_many` documentation.

--- a/lib/view_component/compiler.rb
+++ b/lib/view_component/compiler.rb
@@ -101,11 +101,7 @@ module ViewComponent
     end
 
     def with_read_lock(&block)
-      if development?
-        __vc_compiler_lock.with_read_lock(&block)
-      else
-        block.call
-      end
+      __vc_compiler_lock.with_read_lock(&block)
     end
 
     private

--- a/lib/view_component/compiler.rb
+++ b/lib/view_component/compiler.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'concurrent-ruby'
+require "concurrent-ruby"
 
 module ViewComponent
   class Compiler

--- a/test/sandbox/app/components/content_eval_component.rb
+++ b/test/sandbox/app/components/content_eval_component.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
-
 class ContentEvalComponent < ViewComponent::Base
-  def initialize
-  end
-
   def call
     content # evaluate content
     content_tag :h1, "content!"

--- a/test/sandbox/app/components/content_eval_component.rb
+++ b/test/sandbox/app/components/content_eval_component.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+
+class ContentEvalComponent < ViewComponent::Base
+  def initialize
+  end
+
+  def call
+    content # evaluate content
+    content_tag :h1, "content!"
+  end
+end

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -1078,4 +1078,31 @@ class RenderingTest < ViewComponent::TestCase
       index += 1
     end
   end
+
+  def test_concurrency_deadlock
+    with_compiler_mode(ViewComponent::Compiler::DEVELOPMENT_MODE) do
+      with_new_cache do
+        mutex1 = Mutex.new
+        mutex2 = Mutex.new
+
+        t1 = Thread.new do
+          mutex1.synchronize do
+            sleep 0.02
+            render_inline(ContentEvalComponent.new)
+          end
+        end
+
+        t = Thread.new do
+          render_inline(ContentEvalComponent.new) do
+            mutex1.synchronize do
+              sleep 0.01
+            end
+          end
+        end
+
+        t1.join
+        t.join
+      end
+    end
+  end
 end

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -1082,11 +1082,10 @@ class RenderingTest < ViewComponent::TestCase
   def test_concurrency_deadlock
     with_compiler_mode(ViewComponent::Compiler::DEVELOPMENT_MODE) do
       with_new_cache do
-        mutex1 = Mutex.new
-        mutex2 = Mutex.new
+        mutex = Mutex.new
 
         t1 = Thread.new do
-          mutex1.synchronize do
+          mutex.synchronize do
             sleep 0.02
             render_inline(ContentEvalComponent.new)
           end
@@ -1094,7 +1093,7 @@ class RenderingTest < ViewComponent::TestCase
 
         t = Thread.new do
           render_inline(ContentEvalComponent.new) do
-            mutex1.synchronize do
+            mutex.synchronize do
               sleep 0.01
             end
           end

--- a/view_component.gemspec
+++ b/view_component.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "activesupport", [">= 5.0.0", "< 8.0"]
   spec.add_runtime_dependency "method_source", "~> 1.0"
+  spec.add_runtime_dependency "concurrent-ruby", "~> 1.0"
   spec.add_development_dependency "appraisal", "~> 2.4"
   spec.add_development_dependency "benchmark-ips", "~> 2.8.2"
   spec.add_development_dependency "better_html", "~> 1"


### PR DESCRIPTION
Currently there's a deadlock in the compiler due to rendering locking,
which can lead to edgecases where other locks prevent the completion of
rendering and the inability to complete rendering prevents other locks
from releasing as seen in https://github.com/github/view_component/issues/1447

This resolves the issue by replacing `Monitor` with a `ReadWriteLock`.
This allows the same component to render without requiring an exclusive
lock, resulting in concurrent renders.

In summary:

- Compilation will hold a write lock, blocking `#compile` and
  `render_template_for` calls.
- `render_template_for` calls will hold a read lock, blocking `#compile`
  but allowing other calls to `render_template_for` to check out another
  read lock.

See the documentation for `ReadWriteLock` for more details: http://ruby-concurrency.github.io/concurrent-ruby/master/Concurrent/ReadWriteLock.html

closes https://github.com/github/view_component/issues/1447