### PR TITLE
Raise `ArgumentError` when conflicting slots are defined.

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,19 @@ title: Changelog
 
 ## main
 
+* Raise `ArgumentError` when conflicting Slots are defined.
+
+    Before this change it was possible to define Slots with conflicting names, for example:
+
+    ```ruby
+    class MyComponent < ViewComponent::Base
+      renders_one :item
+      renders_many :items
+    end
+    ```
+
+    *Joel Hawksley*
+
 ## 2.64.0
 
 * Add `warn_on_deprecated_slot_setter` flag to opt-in to deprecation warning.

--- a/lib/view_component/slotable_v2.rb
+++ b/lib/view_component/slotable_v2.rb
@@ -80,6 +80,7 @@ module ViewComponent
       #   <% end %>
       def renders_one(slot_name, callable = nil)
         validate_singular_slot_name(slot_name)
+        validate_plural_slot_name(ActiveSupport::Inflector.pluralize(slot_name).to_sym)
 
         define_method :"with_#{slot_name}" do |*args, &block|
           set_slot(slot_name, nil, *args, &block)
@@ -148,6 +149,7 @@ module ViewComponent
       #   <% end %>
       def renders_many(slot_name, callable = nil)
         validate_plural_slot_name(slot_name)
+        validate_singular_slot_name(ActiveSupport::Inflector.singularize(slot_name).to_sym)
 
         singular_name = ActiveSupport::Inflector.singularize(slot_name)
 

--- a/lib/view_component/slotable_v2.rb
+++ b/lib/view_component/slotable_v2.rb
@@ -148,10 +148,9 @@ module ViewComponent
       #     <% end %>
       #   <% end %>
       def renders_many(slot_name, callable = nil)
+        singular_name = ActiveSupport::Inflector.singularize(slot_name)
         validate_plural_slot_name(slot_name)
         validate_singular_slot_name(ActiveSupport::Inflector.singularize(slot_name).to_sym)
-
-        singular_name = ActiveSupport::Inflector.singularize(slot_name)
 
         # Define setter for singular names
         # for example `renders_many :items` allows fetching all tabs with

--- a/test/sandbox/test/slotable_v2_test.rb
+++ b/test/sandbox/test/slotable_v2_test.rb
@@ -588,4 +588,26 @@ class SlotsV2sTest < ViewComponent::TestCase
 
     assert_selector("h1.some-class", text: "This is a header!")
   end
+
+  def test_raises_error_on_conflicting_slot_names
+    error = assert_raises ArgumentError do
+      Class.new(ViewComponent::Base) do
+        renders_one :conflicting_item
+        renders_many :conflicting_items
+      end
+    end
+
+    assert_includes error.message, "conflicting_item slot multiple times"
+  end
+
+  def test_raises_error_on_conflicting_slot_names_in_reverse_order
+    error = assert_raises ArgumentError do
+      Class.new(ViewComponent::Base) do
+        renders_many :conflicting_items
+        renders_one :conflicting_item
+      end
+    end
+
+    assert_includes error.message, "conflicting_items slot multiple times"
+  end
 end


### PR DESCRIPTION
Before this change it was possible to define Slots with conflicting names, for example:

```ruby
class MyComponent < ViewComponent::Base
  renders_one :item
  renders_many :items
end
```