### PR TITLE
Fix request.path inside with_request_url helper

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,7 +9,7 @@ title: Changelog
 
 ## main
 
-* Fix `#with_request_url` (when used with query string) resulting in incorrect `request.path` and `request.fullpath`.
+* Fix bug where `#with_request_url`, when used with query string, set the incorrect `request.path` and `request.fullpath`.
 
     *Franz Liedke*
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,10 @@ title: Changelog
 
 ## main
 
+* Fix `#with_request_url` (when used with query string) resulting in incorrect `request.path` and `request.fullpath`.
+
+    *Franz Liedke*
+
 * Add link to [ViewComponentAttributes](https://github.com/amba-Health/view_component_attributes) in Resources section of docs.
 
     *Romaric Pascal*

--- a/docs/index.md
+++ b/docs/index.md
@@ -137,6 +137,7 @@ ViewComponent is built by over a hundred members of the community, including:
 <img src="https://avatars.githubusercontent.com/elia?s=64" alt="elia" width="32" />
 <img src="https://avatars.githubusercontent.com/franco?s=64" alt="franco" width="32" />
 <img src="https://avatars.githubusercontent.com/franks921?s=64" alt="franks921" width="32" />
+<img src="https://avatars.githubusercontent.com/franzliedke?s=64" alt="franzliedke" width="32" />
 <img src="https://avatars.githubusercontent.com/fsateler?s=64" alt="fsateler" width="32" />
 <img src="https://avatars.githubusercontent.com/fugufish?s=64" alt="fugufish" width="32" />
 <img src="https://avatars.githubusercontent.com/g13ydson?s=64" alt="g13ydson" width="32" />

--- a/lib/view_component/test_helpers.rb
+++ b/lib/view_component/test_helpers.rb
@@ -190,10 +190,14 @@ module ViewComponent
       old_request_query_string = request.query_string
       old_controller = defined?(@controller) && @controller
 
+      # Started in https://github.com/github/view_component/pull/1058
+      # Broken in https://github.com/github/view_component/pull/1221
+
+      path, query = path.split("?", 2)
       request.path_info = path
       request.path_parameters = Rails.application.routes.recognize_path(path)
-      request.set_header("action_dispatch.request.query_parameters", Rack::Utils.parse_nested_query(path.split("?")[1]))
-      request.set_header(Rack::QUERY_STRING, path.split("?")[1])
+      request.set_header("action_dispatch.request.query_parameters", Rack::Utils.parse_nested_query(query))
+      request.set_header(Rack::QUERY_STRING, query)
       yield
     ensure
       request.path_info = old_request_path_info

--- a/lib/view_component/test_helpers.rb
+++ b/lib/view_component/test_helpers.rb
@@ -190,9 +190,6 @@ module ViewComponent
       old_request_query_string = request.query_string
       old_controller = defined?(@controller) && @controller
 
-      # Started in https://github.com/github/view_component/pull/1058
-      # Broken in https://github.com/github/view_component/pull/1221
-
       path, query = path.split("?", 2)
       request.path_info = path
       request.path_parameters = Rails.application.routes.recognize_path(path)

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -935,7 +935,9 @@ class RenderingTest < ViewComponent::TestCase
     end
 
     with_request_url "/products?mykey=myvalue&otherkey=othervalue" do
+      assert_equal "/products", request.path
       assert_equal "mykey=myvalue&otherkey=othervalue", request.query_string
+      assert_equal "/products?mykey=myvalue&otherkey=othervalue", request.fullpath
     end
 
     with_request_url "/products?mykey[mynestedkey]=myvalue" do


### PR DESCRIPTION
### What are you trying to accomplish?

`#with_request_url` is great. It was started in #1058, but later #1221
introduced a tiny regression in the parsing of segments.

When using `#with_request_url` including a query string, the `#path`
helper would now contain the query string segment, when it should not.
This led to `#fullpath` having the query string twice.

### What approach did you choose and why?

I added regression tests to the existing scenarios and then fixed the parsing to make them pass. :)

### Anything you want to highlight for special attention from reviewers?

I love this library. 😍 