### PR TITLE
Use ViewComponent::Base.config as the internal endpoint for config

### DIFF
--- a/app/controllers/concerns/view_component/preview_actions.rb
+++ b/app/controllers/concerns/view_component/preview_actions.rb
@@ -43,12 +43,12 @@ module ViewComponent
 
     # :doc:
     def default_preview_layout
-      Rails.application.config.view_component.default_preview_layout
+      ViewComponent::Base.config.default_preview_layout
     end
 
     # :doc:
     def show_previews?
-      Rails.application.config.view_component.show_previews
+      ViewComponent::Base.config.show_previews
     end
 
     # :doc:

--- a/app/helpers/preview_helper.rb
+++ b/app/helpers/preview_helper.rb
@@ -22,7 +22,7 @@ module PreviewHelper
       # Fetch template source via finding it through preview paths
       # to accomodate source view when exclusively using templates
       # for previews for Rails < 6.1.
-      all_template_paths = Rails.application.config.view_component.preview_paths.map do |preview_path|
+      all_template_paths = ViewComponent::Base.config.preview_paths.map do |preview_path|
         Dir.glob("#{preview_path}/**/*")
       end.flatten
 

--- a/app/views/view_components/preview.html.erb
+++ b/app/views/view_components/preview.html.erb
@@ -1,5 +1,5 @@
 <% if @render_args[:component] %>
-  <% if Rails.application.config.view_component.render_monkey_patch_enabled || Rails.version.to_f >= 6.1 %>
+  <% if ViewComponent::Base.config.render_monkey_patch_enabled || Rails.version.to_f >= 6.1 %>
     <%= render(@render_args[:component], @render_args[:args], &@render_args[:block]) %>
   <% else %>
     <%= render_component(@render_args[:component], &@render_args[:block]) %>
@@ -8,6 +8,6 @@
   <%= render template: @render_args[:template], locals: @render_args[:locals] || {} %>
 <% end %>
 
-<% if Rails.application.config.view_component.show_previews_source %>
+<% if ViewComponent::Base.config.show_previews_source %>
   <%= preview_source %>
 <% end %>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,10 @@ title: Changelog
 
 ## main
 
+* Use ViewComponent::Base.config as the internal endpoint for config.
+
+    *Simon Fish*
+
 * Fix bug where `#with_request_url`, when used with query string, set the incorrect `request.path` and `request.fullpath`.
 
     *Franz Liedke*

--- a/lib/rails/generators/abstract_generator.rb
+++ b/lib/rails/generators/abstract_generator.rb
@@ -29,7 +29,7 @@ module ViewComponent
     end
 
     def component_path
-      Rails.application.config.view_component.view_component_path
+      ViewComponent::Base.config.view_component_path
     end
 
     def stimulus_controller
@@ -42,7 +42,7 @@ module ViewComponent
     end
 
     def sidecar?
-      options["sidecar"] || Rails.application.config.view_component.generate.sidecar
+      options["sidecar"] || ViewComponent::Base.config.generate.sidecar
     end
   end
 end

--- a/lib/rails/generators/component/component_generator.rb
+++ b/lib/rails/generators/component/component_generator.rb
@@ -13,12 +13,12 @@ module Rails
       check_class_collision suffix: "Component"
 
       class_option :inline, type: :boolean, default: false
-      class_option :locale, type: :boolean, default: Rails.application.config.view_component.generate.locale
+      class_option :locale, type: :boolean, default: ViewComponent::Base.config.generate.locale
       class_option :parent, type: :string, desc: "The parent class for the generated component"
-      class_option :preview, type: :boolean, default: Rails.application.config.view_component.generate.preview
+      class_option :preview, type: :boolean, default: ViewComponent::Base.config.generate.preview
       class_option :sidecar, type: :boolean, default: false
       class_option :stimulus, type: :boolean,
-        default: Rails.application.config.view_component.generate.stimulus_controller
+        default: ViewComponent::Base.config.generate.stimulus_controller
 
       def create_component_file
         template "component.rb", File.join(component_path, class_path, "#{file_name}_component.rb")
@@ -41,7 +41,7 @@ module Rails
       def parent_class
         return options[:parent] if options[:parent]
 
-        Rails.application.config.view_component.component_parent_class || default_parent_class
+        ViewComponent::Base.config.component_parent_class || default_parent_class
       end
 
       def initialize_signature

--- a/lib/rails/generators/locale/component_generator.rb
+++ b/lib/rails/generators/locale/component_generator.rb
@@ -12,7 +12,7 @@ module Locale
       class_option :sidecar, type: :boolean, default: false
 
       def create_locale_file
-        if Rails.application.config.view_component.generate.distinct_locale_files
+        if ViewComponent::Base.config.generate.distinct_locale_files
           I18n.available_locales.each do |locale|
             create_file destination(locale), translations_hash([locale]).to_yaml
           end

--- a/lib/rails/generators/preview/component_generator.rb
+++ b/lib/rails/generators/preview/component_generator.rb
@@ -9,7 +9,7 @@ module Preview
       check_class_collision suffix: "ComponentPreview"
 
       def create_preview_file
-        preview_paths = Rails.application.config.view_component.preview_paths
+        preview_paths = ViewComponent::Base.config.preview_paths
         return if preview_paths.count > 1
 
         path_prefix = preview_paths.one? ? preview_paths.first : "test/components/previews"

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -18,7 +18,7 @@ module ViewComponent
       delegate(*ViewComponent::Config.defaults.keys, to: :config)
 
       def config
-        Rails.application.config.view_component
+        @config ||= ViewComponent::Config.defaults
       end
     end
 
@@ -496,7 +496,7 @@ module ViewComponent
 
         # Removes the first part of the path and the extension.
         child.virtual_path = child.source_location.gsub(
-          /(.*#{Regexp.quote(Rails.application.config.view_component.view_component_path)})|(\.rb)/, ""
+          /(.*#{Regexp.quote(ViewComponent::Base.config.view_component_path)})|(\.rb)/, ""
         )
 
         # Set collection parameter to the extended component

--- a/lib/view_component/engine.rb
+++ b/lib/view_component/engine.rb
@@ -5,7 +5,7 @@ require "view_component/base"
 
 module ViewComponent
   class Engine < Rails::Engine # :nodoc:
-    config.view_component = ViewComponent::Config.default
+    config.view_component = ViewComponent::Base.config
 
     rake_tasks do
       load "view_component/rails/tasks/view_component.rake"

--- a/test/sandbox/test/integration_test.rb
+++ b/test/sandbox/test/integration_test.rb
@@ -677,7 +677,7 @@ class IntegrationTest < ActionDispatch::IntegrationTest
           preview_route: '/some/other/route',
           show_previews_source: true
         }.each do |option, value|
-          with_config_option(option, value) do
+          with_config_option(option, value, config_entrypoint: config) do
             assert_equal(config.public_send(option), config_entrypoints.second.public_send(option))
           end
         end

--- a/test/sandbox/test/integration_test.rb
+++ b/test/sandbox/test/integration_test.rb
@@ -673,8 +673,8 @@ class IntegrationTest < ActionDispatch::IntegrationTest
       config_entrypoints.first.yield_self do |config|
         {
           generate: config.generate.dup.tap { |c| c.sidecar = true },
-          preview_controller: 'SomeOtherController',
-          preview_route: '/some/other/route',
+          preview_controller: "SomeOtherController",
+          preview_route: "/some/other/route",
           show_previews_source: true
         }.each do |option, value|
           with_config_option(option, value, config_entrypoint: config) do

--- a/test/sandbox/test/integration_test.rb
+++ b/test/sandbox/test/integration_test.rb
@@ -668,17 +668,21 @@ class IntegrationTest < ActionDispatch::IntegrationTest
   end
 
   def test_config_options_shared_between_base_and_engine
-    Rails.application.config.view_component.yield_self do |config|
-      {
-        generate: config.generate.dup.tap { |c| c.sidecar = true },
-        preview_controller: "SomeOtherController",
-        preview_route: "/some/other/route",
-        show_previews_source: true
-      }.each do |option, value|
-        with_config_option(option, value) do
-          assert_equal(config.public_send(option), ViewComponent::Base.public_send(option))
+    config_entrypoints = [Rails.application.config.view_component, ViewComponent::Base.config]
+    2.times do
+      config_entrypoints.first.yield_self do |config|
+        {
+          generate: config.generate.dup.tap { |c| c.sidecar = true },
+          preview_controller: 'SomeOtherController',
+          preview_route: '/some/other/route',
+          show_previews_source: true
+        }.each do |option, value|
+          with_config_option(option, value) do
+            assert_equal(config.public_send(option), config_entrypoints.second.public_send(option))
+          end
         end
       end
+      config_entrypoints.rotate!
     end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -38,12 +38,12 @@ ViewComponent::Deprecation.behavior = :silence
 require File.expand_path("sandbox/config/environment.rb", __dir__)
 require "rails/test_help"
 
-def with_config_option(option_name, new_value)
-  old_value = Rails.application.config.view_component.public_send(option_name)
-  Rails.application.config.view_component.public_send("#{option_name}=", new_value)
+def with_config_option(option_name, new_value, config_entrypoint: Rails.application.config.view_component)
+  old_value = config_entrypoint.public_send(option_name)
+  config_entrypoint.public_send("#{option_name}=", new_value)
   yield
 ensure
-  Rails.application.config.view_component.public_send("#{option_name}=", old_value)
+  config_entrypoint.public_send("#{option_name}=", old_value)
 end
 
 # Sets custom preview paths in tests.


### PR DESCRIPTION
Tests are in place to ensure that `Rails.application.config.view_component` refers to the same thing.

### What are you trying to accomplish?

Closes #1464 

### What approach did you choose and why?

It seems that gems that use ViewComponent as a dependency might be doing things before Rails has set up an application. In that case, it makes sense to set up a config on `ViewComponent::Base` and have `Rails.application.config` reference that.

### Anything you want to highlight for special attention from reviewers?

Ideally, we want to be 100% sure that configuring ViewComponent via `Rails.application.config.view_component` and `ViewComponent::Base.config` has the same effect. Gem dependencies should use the latter, while users might want to prefer the former.