### PR TITLE
Update logo code in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
-![ViewComponent logo](/docs/logo/readme-light.svg#gh-light-mode-only)
-![ViewComponent logo](/docs/logo/readme-dark.svg#gh-dark-mode-only)
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="/docs/logo/readme-dark.svg">
+  <source media="(prefers-color-scheme: light)" srcset="/docs/logo/readme-light.svg">
+  <img alt="ViewComponent logo" src="/docs/logo/readme-light.svg">
+</picture>
 
 A framework for building reusable, testable & encapsulated view components in Ruby on Rails.
 


### PR DESCRIPTION
### What are you trying to accomplish?

Make the README logo light mode / dark mode friendly (it has initially been done in #1169 but this approach is now deprecated)

### What approach did you choose and why?

The new recommended approach: https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#specifying-the-theme-an-image-is-shown-to