### PR TITLE
Adjust stack trace in slot name deprecation warning output

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,11 @@ title: Changelog
 
     *Thomas Hutterer*
 
+* Corrects the deprecation warning for named slots to show the file and line
+  where the slot is called
+
+    *River Bailey*
+
 ## 2.68.0
 
 * Update `gemspec` author to be ViewComponent team.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,8 +13,7 @@ title: Changelog
 
     *Thomas Hutterer*
 
-* Corrects the deprecation warning for named slots to show the file and line
-  where the slot is called
+* Corrects the deprecation warning for named slots to show the file and line where the slot is called.
 
     *River Bailey*
 

--- a/lib/view_component/slotable_v2.rb
+++ b/lib/view_component/slotable_v2.rb
@@ -92,10 +92,11 @@ module ViewComponent
             get_slot(slot_name)
           else
             if _warn_on_deprecated_slot_setter
-              ViewComponent::Deprecation.warn(
-                "Setting a slot with `##{slot_name}` is deprecated and will be removed in ViewComponent v3.0.0. " \
+              stack = caller_locations(3)
+              msg = "Setting a slot with `##{slot_name}` is deprecated and will be removed in ViewComponent v3.0.0. " \
                 "Use `#with_#{slot_name}` to set the slot instead."
-              )
+
+              ViewComponent::Deprecation.warn(msg, stack)
             end
 
             set_slot(slot_name, nil, *args, &block)

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -1091,7 +1091,7 @@ class RenderingTest < ViewComponent::TestCase
   end
 
   def test_deprecated_slot_setter_warning_stack_trace_collection
-    line_num = __LINE__ + 3 # offset because `c.item`, below, is the line that causes the deprecation warning
+    line_num = __LINE__ + 3 # offset because `c.items`, below, is the line that causes the deprecation warning
     assert_deprecated(/with_items`.*#{__FILE__}:#{line_num}/, ViewComponent::Deprecation) do
       render_inline(DeprecatedSlotsSetterComponent.new) do |c|
         c.items([{foo: "bar"}])

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -1082,7 +1082,8 @@ class RenderingTest < ViewComponent::TestCase
   end
 
   def test_deprecated_slot_setter_warning_collection_singular
-    assert_deprecated(/with_item`/, ViewComponent::Deprecation) do
+    line_num = __LINE__ + 3 # offset because `c.item`, below, is the line that causes the deprecation warning
+    assert_deprecated(/with_item`.*#{__FILE__}:#{line_num}/, ViewComponent::Deprecation) do
       render_inline(DeprecatedSlotsSetterComponent.new) do |c|
         c.item { "foo" }
       end

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -1081,9 +1081,26 @@ class RenderingTest < ViewComponent::TestCase
     end
   end
 
-  def test_deprecated_slot_setter_warning_collection_singular
+  def test_deprecated_slot_setter_warning_stack_trace_singular
     line_num = __LINE__ + 3 # offset because `c.item`, below, is the line that causes the deprecation warning
     assert_deprecated(/with_item`.*#{__FILE__}:#{line_num}/, ViewComponent::Deprecation) do
+      render_inline(DeprecatedSlotsSetterComponent.new) do |c|
+        c.item { "foo" }
+      end
+    end
+  end
+
+  def test_deprecated_slot_setter_warning_stack_trace_collection
+    line_num = __LINE__ + 3 # offset because `c.item`, below, is the line that causes the deprecation warning
+    assert_deprecated(/with_items`.*#{__FILE__}:#{line_num}/, ViewComponent::Deprecation) do
+      render_inline(DeprecatedSlotsSetterComponent.new) do |c|
+        c.items([{foo: "bar"}])
+      end
+    end
+  end
+
+  def test_deprecated_slot_setter_warning_collection_singular
+    assert_deprecated(/with_item`/, ViewComponent::Deprecation) do
       render_inline(DeprecatedSlotsSetterComponent.new) do |c|
         c.item { "foo" }
       end


### PR DESCRIPTION
### What are you trying to accomplish?

<!-- Provide a description of the changes. Link to any related issues or projects. -->

The current logging for slot name deprecation warnings displays the file in which the deprecation warning is called. To be more useful in finding and correcting deprecations, this PR adjusts the stack trace output to reflect the location of the named slot call.

### What approach did you choose and why?

<!-- Describe your thought process in making these changes. List any tradeoffs you made. Describe any alternative approaches you considered and why you discarded them. -->

The [core `ActiveSupport::Deprecation#warn` method implementation](https://github.com/rails/rails/blob/main/activesupport/lib/active_support/deprecation/reporting.rb#L18-L29) includes a call to `caller_locations(2)`. This returns the location of the deprecation call, instead of the location where the slot is used. 

To correct the issue, `caller_locations(3)` is called from within the slotable deprecation check, adding the corrected stack trace to the `Deprecation#warn` call. 

### Anything you want to highlight for special attention from reviewers?

I chose to add two new tests instead of adjusting the existing tests, to emphasize what each test is looking for. This does duplicate a small amount of the testing, but the readability and maintainability is worth the duplication. 