### PR TITLE
Revert "Update logo code in README"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,5 @@
-<picture>
-  <source media="(prefers-color-scheme: dark)" srcset="/docs/logo/readme-dark.svg">
-  <source media="(prefers-color-scheme: light)" srcset="/docs/logo/readme-light.svg">
-  <img alt="ViewComponent logo" src="/docs/logo/readme-light.svg">
-</picture>
+![ViewComponent logo](/docs/logo/readme-light.svg#gh-light-mode-only)
+![ViewComponent logo](/docs/logo/readme-dark.svg#gh-dark-mode-only)
 
 A framework for building reusable, testable & encapsulated view components in Ruby on Rails.
 


### PR DESCRIPTION
Reverts github/view_component#1475

The logo is not showing in Github mobile app, so let's revert this until this is fixed.