### PR TITLE
Add Arrows to list of companies using VC

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,7 +13,6 @@ title: Changelog
 
      *Matt Swanson*
 
-
 * Add WIP to list of companies using ViewComponent.
 
      *Marc Köhlbrugge*

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,11 @@ title: Changelog
 
 ## main
 
+* Add Arrows to list of companies using ViewComponent.
+
+     *Matt Swanson*
+
+
 * Add WIP to list of companies using ViewComponent.
 
      *Marc Köhlbrugge*

--- a/docs/index.md
+++ b/docs/index.md
@@ -205,6 +205,7 @@ ViewComponent is built by over a hundred members of the community, including:
 
 ## Who uses ViewComponent?
 
+* [Arrows](https://arrows.to/)
 * [Bearer](https://www.bearer.com/) (70+ components)
 * [Brightline](https://hellobrightline.com)
 * [City of Paris](https://www.paris.fr/)


### PR DESCRIPTION
We just launched a new version of the product and used VC to build out our design system components (w/ Stimulus + Tailwind)