### PR TITLE
Add ADRs to docs

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,9 +10,13 @@ nav_order: 5
 
 ## main
 
+* Add architectural decisions to documentation and rename sidebar sections.
+
+    *Joel Hawksley*
+
 * Clarify documentation on testability of Rails views.
 
-    *Joel Hawksley
+    *Joel Hawksley*
 
 * Add Arrows to list of companies using ViewComponent.
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Changelog
+nav_order: 5
 ---
 
 <!-- Add unreleased changes under the "main" heading. -->

--- a/docs/CODE_OF_CONDUCT.md
+++ b/docs/CODE_OF_CONDUCT.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Code of conduct
+nav_order: 6
 ---
 
 # Contributor Covenant Code of Conduct

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Contributing
+nav_order: 7
 ---
 
 # Contributing

--- a/docs/adrs/0001-record-architecture-decisions.md
+++ b/docs/adrs/0001-record-architecture-decisions.md
@@ -1,3 +1,10 @@
+---
+layout: default
+title: 1. Record architecture decisions
+parent: Architectural decisions
+nav_order: 1
+---
+
 # 1. Record architecture decisions
 
 Date: 2021/02/19

--- a/docs/adrs/0002-naming-conventions-for-view-components.md
+++ b/docs/adrs/0002-naming-conventions-for-view-components.md
@@ -1,3 +1,10 @@
+---
+layout: default
+title: 2. Naming conventions for ViewComponents
+parent: Architectural decisions
+nav_order: 2
+---
+
 # 2. Naming conventions for ViewComponents
 
 Date: 2021/07/13

--- a/docs/adrs/0003-polymorphic-slot-definitions.md
+++ b/docs/adrs/0003-polymorphic-slot-definitions.md
@@ -1,3 +1,10 @@
+---
+layout: default
+title: 3. Polymorphic slots
+parent: Architectural decisions
+nav_order: 3
+---
+
 # 3. Polymorphic slots
 
 Date: 2021/09/29

--- a/docs/adrs/0003-polymorphic-slot-definitions.md
+++ b/docs/adrs/0003-polymorphic-slot-definitions.md
@@ -104,6 +104,7 @@ In such cases, there are several viable workarounds:
 1. Add the wrapping HTML to the template.
 1. Provide a lambda for each polymorphic type that adds the wrapping HTML. There is the potential for code duplication here, which could be mitigated by calling a class or helper method.
 1. Manually implement a polymorphic slot using a positional `type` argument and `case` statement, as shown in the example below. This effectively replicates the behavior described in this proposal.
+
     ```ruby
     renders_many :items do |type, *args, **kwargs|
       content_tag :td, class: kwargs[:table_row_classes] do

--- a/docs/adrs/0004-slots-separate-getter-setter.md
+++ b/docs/adrs/0004-slots-separate-getter-setter.md
@@ -1,4 +1,11 @@
-# Separate Slot Getters and Setters
+---
+layout: default
+title: 4. Separate Slot Getters and Setters
+parent: Architectural decisions
+nav_order: 4
+---
+
+# 4. Separate Slot Getters and Setters
 
 Date: 2022/03/22
 

--- a/docs/adrs/index.md
+++ b/docs/adrs/index.md
@@ -1,0 +1,8 @@
+---
+layout: default
+title: Architectural decisions
+nav_order: 15
+has_children: true
+---
+
+# Architectural decisions

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: API
+title: API reference
 nav_order: 3
 ---
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Compatibility
+nav_order: 6
 ---
 
 # Compatibility

--- a/docs/guide/collections.md
+++ b/docs/guide/collections.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Collections
-parent: Guide
+parent: How-to guide
 ---
 
 # Collections

--- a/docs/guide/conditional_rendering.md
+++ b/docs/guide/conditional_rendering.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Conditional rendering
-parent: Guide
+parent: How-to guide
 ---
 
 # Conditional rendering

--- a/docs/guide/generators.md
+++ b/docs/guide/generators.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Generators
-parent: Guide
+parent: How-to guide
 ---
 
 # Generators

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Getting started
-parent: Guide
+parent: How-to guide
 nav_order: 1
 ---
 

--- a/docs/guide/helpers.md
+++ b/docs/guide/helpers.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Helpers
-parent: Guide
+parent: How-to guide
 ---
 
 # Helpers

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -1,8 +1,8 @@
 ---
 layout: default
-title: Guide
+title: How-to guide
 nav_order: 2
 has_children: true
 ---
 
-# Guide
+# How-to guide

--- a/docs/guide/instrumentation.md
+++ b/docs/guide/instrumentation.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Instrumentation
-parent: Guide
+parent: How-to guide
 ---
 
 # Instrumentation

--- a/docs/guide/javascript_and_css.md
+++ b/docs/guide/javascript_and_css.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Javascript and CSS
-parent: Guide
+parent: How-to guide
 ---
 
 # Javascript and CSS

--- a/docs/guide/lifecycle.md
+++ b/docs/guide/lifecycle.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Lifecycle
-parent: Guide
+parent: How-to guide
 ---
 
 # Lifecycle

--- a/docs/guide/previews.md
+++ b/docs/guide/previews.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Previews
-parent: Guide
+parent: How-to guide
 ---
 
 # Previews

--- a/docs/guide/slots.md
+++ b/docs/guide/slots.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Slots
-parent: Guide
+parent: How-to guide
 ---
 
 # Slots

--- a/docs/guide/templates.md
+++ b/docs/guide/templates.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Templates
-parent: Guide
+parent: How-to guide
 ---
 
 # Templates

--- a/docs/guide/testing.md
+++ b/docs/guide/testing.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Testing
-parent: Guide
+parent: How-to guide
 ---
 
 # Testing

--- a/docs/guide/translations.md
+++ b/docs/guide/translations.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Translations
-parent: Guide
+parent: How-to guide
 ---
 
 # Translations

--- a/docs/history.md
+++ b/docs/history.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: History
+nav_order: 8
 ---
 
 # History

--- a/docs/known_issues.md
+++ b/docs/known_issues.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Known issues
+nav_order: 9
 ---
 
 # Known issues

--- a/docs/logo.md
+++ b/docs/logo.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Logo
+nav_order: 11
 ---
 
 # Logo

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Resources
+nav_order: 12
 ---
 
 # Resources

--- a/docs/viewcomponents-at-github.md
+++ b/docs/viewcomponents-at-github.md
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: ViewComponents in practice
+title: ViewComponents at GitHub
 nav_order: 4
 ---
 
-# ViewComponents in practice
+# ViewComponents at GitHub
 
 _GitHub's internal guide to building component-driven UI in Rails. Consider it to be more opinion than fact._
 


### PR DESCRIPTION
<img width="716" alt="Screen Shot 2022-08-23 at 2 35 25 PM" src="https://user-images.githubusercontent.com/1940294/186260471-a965298a-2748-4ada-ba5b-72b353a4985f.png">

### What are you trying to accomplish?

I'm re-attempting to land https://github.com/github/view_component/pull/1470, but in a simpler form, exposing our ADRs in the docs.

### What approach did you choose and why?

I moved them to the `docs` folder. I also renamed the sidebar items for clarity.