### PR TITLE
Update slots to reference before_render

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -26,6 +26,10 @@ nav_order: 5
 
     *Marc Köhlbrugge*
 
+* Update slots documentation to include how to reference slots.
+
+    *Brittany Ellich*
+
 ## 2.69.0
 
 * Add missing `require` to fix `pvc` build.

--- a/docs/guide/slots.md
+++ b/docs/guide/slots.md
@@ -165,9 +165,7 @@ end
 <%# blog_component.html.erb %>
 <% posts.each do |post| %>
   <div class="<%= @post_container_classes %>">
-    <% if image? %>
-      <%= image %>
-    <% end %>
+    <%= image if image? %>
     <%= post %>
   </div>
 <% end %>

--- a/docs/guide/slots.md
+++ b/docs/guide/slots.md
@@ -156,7 +156,7 @@ class BlogComponent < ViewComponent::Base
   renders_many :posts
 
   def before_render
-    "PostContainer--hasImage" if image.present?
+    @post_container_classes = "PostContainer--hasImage" if image.present?
   end
 end
 ```

--- a/docs/guide/slots.md
+++ b/docs/guide/slots.md
@@ -147,7 +147,7 @@ end
 
 ## Referencing slots
 
-You can access the instance of a slot in your ruby file by using the `before_render` [lifecycle method](./lifecycle.md).
+You can access the instance of a slot in your component class by using the `before_render` [lifecycle method](./lifecycle.md).
 
 ```ruby
 # blog_component.rb

--- a/docs/guide/slots.md
+++ b/docs/guide/slots.md
@@ -147,7 +147,7 @@ end
 
 ## Referencing slots
 
-You can access the instance of a slot in your ruby file by using the `before_render` [lifecycle method](./lifecycle.md). 
+You can access the instance of a slot in your ruby file by using the `before_render` [lifecycle method](./lifecycle.md).
 
 ```ruby
 # blog_component.rb
@@ -155,16 +155,16 @@ class BlogComponent < ViewComponent::Base
   renders_one :header
   renders_one :image
   renders_many :posts
-  
+
   def initialize(**system_arguments)
     @system_arguments = system_arguments
-    
+
     @post_container_classes = class_names(
       "PostContainer",
       system_arguments[:classes]
     )
   end
-  
+
   def before_render
     @post_container_classes = class_names(
       {

--- a/docs/guide/slots.md
+++ b/docs/guide/slots.md
@@ -147,37 +147,24 @@ end
 
 ## Referencing slots
 
-You can access the instance of a slot in your component class by using the `before_render` [lifecycle method](./lifecycle.md).
+As the content passed to slots is registered after a component is initialized, it referenced in an initializer. One way to reference slots is using the `before_render` [lifecycle method](./lifecycle.md):
 
 ```ruby
 # blog_component.rb
 class BlogComponent < ViewComponent::Base
-  renders_one :header
   renders_one :image
   renders_many :posts
 
-  def initialize(classes: [])
-    @post_container_classes = class_names("post-container", classes)
-    )
-  end
-
   def before_render
-    @post_container_classes = class_names(
-      {
-        "PostContainer--hasImage": image.present?
-      },
-      @post_container_classes
-    )
+    "PostContainer--hasImage" if image.present?
   end
 end
 ```
 
 ```erb
 <%# blog_component.html.erb %>
-<h1><%= header %></h1>
-
 <% posts.each do |post| %>
-  <div class="<%= @post_container_classes =%>">
+  <div class="<%= @post_container_classes %>">
     <% if image? %>
       <%= image %>
     <% end %>

--- a/docs/guide/slots.md
+++ b/docs/guide/slots.md
@@ -147,7 +147,7 @@ end
 
 ## Referencing slots
 
-As the content passed to slots is registered after a component is initialized, it referenced in an initializer. One way to reference slots is using the `before_render` [lifecycle method](./lifecycle.md):
+As the content passed to slots is registered after a component is initialized, it cannot referenced in an initializer. One way to reference slot content is using the `before_render` [lifecycle method](./lifecycle.md):
 
 ```ruby
 # blog_component.rb

--- a/docs/guide/slots.md
+++ b/docs/guide/slots.md
@@ -156,12 +156,8 @@ class BlogComponent < ViewComponent::Base
   renders_one :image
   renders_many :posts
 
-  def initialize(**system_arguments)
-    @system_arguments = system_arguments
-
-    @post_container_classes = class_names(
-      "PostContainer",
-      system_arguments[:classes]
+  def initialize(classes: [])
+    @post_container_classes = class_names("post-container", classes)
     )
   end
 

--- a/docs/guide/slots.md
+++ b/docs/guide/slots.md
@@ -168,7 +168,7 @@ class BlogComponent < ViewComponent::Base
   def before_render
     @post_container_classes = class_names(
       {
-        "PostBody--hasImage": image.present?
+        "PostContainer--hasImage": image.present?
       },
       @post_container_classes
     )

--- a/docs/guide/slots.md
+++ b/docs/guide/slots.md
@@ -147,7 +147,7 @@ end
 
 ## Referencing slots
 
-As the content passed to slots is registered after a component is initialized, it cannot referenced in an initializer. One way to reference slot content is using the `before_render` [lifecycle method](./lifecycle.md):
+As the content passed to slots is registered after a component is initialized, it cannot referenced in an initializer. One way to reference slot content is using the `before_render` [lifecycle method](/guide/lifecycle):
 
 ```ruby
 # blog_component.rb

--- a/docs/guide/slots.md
+++ b/docs/guide/slots.md
@@ -145,6 +145,51 @@ end
 <% end %>
 ```
 
+## Referencing slots
+
+You can access the instance of a slot in your ruby file by using the `before_render` [lifecycle method](./lifecycle.md). 
+
+```ruby
+# blog_component.rb
+class BlogComponent < ViewComponent::Base
+  renders_one :header
+  renders_one :image
+  renders_many :posts
+  
+  def initialize(**system_arguments)
+    @system_arguments = system_arguments
+    
+    @post_container_classes = class_names(
+      "PostContainer",
+      system_arguments[:classes]
+    )
+  end
+  
+  def before_render
+    @post_container_classes = class_names(
+      {
+        "PostBody--hasImage": image.present?
+      },
+      @post_container_classes
+    )
+  end
+end
+```
+
+```erb
+<%# blog_component.html.erb %>
+<h1><%= header %></h1>
+
+<% posts.each do |post| %>
+  <div class="<%= @post_container_classes =%>">
+    <% if image? %>
+      <%= image %>
+    <% end %>
+    <%= post %>
+  </div>
+<% end %>
+```
+
 ## Lambda slots
 
 It's also possible to define a slot as a lambda that returns content to be rendered (either a string or a ViewComponent instance). Lambda slots are useful in cases where writing another component may be unnecessary, such as working with helpers like `content_tag` or as wrappers for another ViewComponent with specific default values:


### PR DESCRIPTION
### What are you trying to accomplish?

I recently ran into an issue using slots in view components that I think could save other people some time in the future by adding how to solve it to the documentation. Shoutout to @joelhawksley for showing me how to properly accomplish this!

### What approach did you choose and why?

I added an example that I think follows the theme of the rest of the doc to describe how to use before_render.

### Anything you want to highlight for special attention from reviewers?

Can I use class_names in the example here? And is it a good idea to reference the lifecycle.md page as well?