### PR TITLE
Add Clio to the list of companies using ViewComponent

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -26,6 +26,10 @@ nav_order: 5
 
     *Marc Köhlbrugge*
 
+* Add Clio to list of companies using ViewComponent.
+
+    *Mike Buckley*
+
 ## 2.69.0
 
 * Add missing `require` to fix `pvc` build.

--- a/docs/index.md
+++ b/docs/index.md
@@ -209,6 +209,7 @@ ViewComponent is built by over a hundred members of the community, including:
 * [Bearer](https://www.bearer.com/) (70+ components)
 * [Brightline](https://hellobrightline.com)
 * [City of Paris](https://www.paris.fr/)
+* [Clio](https://www.clio.com/)
 * [Cometeer](https://cometeer.com/)
 * [Cults.](https://cults3d.com/)
 * [Framework](https://frame.work/)


### PR DESCRIPTION
### What are you trying to accomplish?

Add [Clio](https://www.clio.com/) to the list of companies using ViewComponent. 🎉 

### What approach did you choose and why?

Opening a PR to the repo is the current recommended way to add to the list of companies.

### Anything you want to highlight for special attention from reviewers?

This maintains alphabetical ordering.